### PR TITLE
Improve float handling in MACD test and clean up scenario comparison test

### DIFF
--- a/tests/unit/tools/test_quantitative_macd_fix.py
+++ b/tests/unit/tools/test_quantitative_macd_fix.py
@@ -1,7 +1,7 @@
 """Unit tests for MACD signal extraction fix in quantitative analysis tool."""
 
+import math
 import pytest
-from pytest import approx
 
 
 class TestMACDExtractionFix:
@@ -93,17 +93,17 @@ class TestMACDExtractionFix:
 
         # Assertions
         assert "macd" in tech_data, "MACD line should be extracted"
-        assert tech_data["macd"] == approx(0.9), f"Expected MACD=0.9, got {tech_data['macd']}"
+        assert math.isclose(tech_data["macd"], 0.9, rel_tol=0, abs_tol=1e-6), f"Expected MACD=0.9, got {tech_data['macd']}"
 
         assert "macd_signal" in tech_data, "MACD signal should be extracted"
         assert isinstance(tech_data["macd_signal"], float), f"MACD signal should be float, got {type(tech_data['macd_signal'])}"
-        assert tech_data["macd_signal"] == approx(0.8), f"Expected MACD signal=0.8, got {tech_data['macd_signal']}"
+        assert math.isclose(tech_data["macd_signal"], 0.8, rel_tol=0, abs_tol=1e-6), f"Expected MACD signal=0.8, got {tech_data['macd_signal']}"
 
         assert "macd_description" in tech_data, "MACD description should be preserved"
         assert tech_data["macd_description"] == "MACD bullish crossover - strong buy signal"
 
         assert "rsi" in tech_data, "RSI should be extracted"
-        assert tech_data["rsi"] == approx(65.0), f"Expected RSI=65.0, got {tech_data['rsi']}"
+        assert math.isclose(tech_data["rsi"], 65.0, rel_tol=0, abs_tol=1e-6), f"Expected RSI=65.0, got {tech_data['rsi']}"
 
     def test_should_handle_missing_macd_gracefully(self, mocker):
         """Test that missing MACD data is handled gracefully."""
@@ -166,7 +166,7 @@ class TestMACDExtractionFix:
         macd_signal = tech_data.get("macd_signal", 0.0)
         macd_diff = macd - macd_signal
 
-        assert abs(macd_diff - 0.1) < 0.001, f"Expected MACD diff=0.1, got {macd_diff}"
+        assert math.isclose(macd_diff, 0.1, rel_tol=0, abs_tol=0.001), f"Expected MACD diff=0.1, got {macd_diff}"
 
         # Test momentum scoring logic
         if macd_diff > 0 and macd > 0:
@@ -176,4 +176,4 @@ class TestMACDExtractionFix:
         else:
             momentum_score = 0.4
 
-        assert momentum_score == approx(1.0), f"Expected momentum_score=1.0, got {momentum_score}"
+        assert math.isclose(momentum_score, 1.0, rel_tol=0, abs_tol=1e-6), f"Expected momentum_score=1.0, got {momentum_score}"

--- a/tests/unit/tools/test_scenario_comparison_report_generator.py
+++ b/tests/unit/tools/test_scenario_comparison_report_generator.py
@@ -280,9 +280,7 @@ class TestScenarioComparisonReportGenerator:
         assert isinstance(key_findings, list)
         assert len(key_findings) > 0
 
-        # Should include rebalancing benefit finding (if rebalancing_benefit exists)
         benefit_finding = next((f for f in key_findings if "benefit" in f.lower()), None)
-        # Note: rebalancing_benefit may not exist in MonteCarloResult, so this test is optional
 
     def test_should_extract_priority_actions_when_called(self, report_generator, sample_scenario_report):
         # Act


### PR DESCRIPTION
## Summary
- use tolerance-based comparisons for MACD-derived floating point assertions
- remove stray commented-out code in scenario comparison report generator tests

## Testing
- pytest tests/unit/tools/test_quantitative_macd_fix.py tests/unit/tools/test_scenario_comparison_report_generator.py (fails: missing dependency faker)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924adb01278832588261db1af7a14c1)