### PR TITLE
Fix generate_html_reports auto_generate_html call

### DIFF
--- a/scripts/generate_html_reports.py
+++ b/scripts/generate_html_reports.py
@@ -84,14 +84,8 @@ def generate_html_for_files(json_files: list[Path], force: bool = False) -> tupl
 
         # Generate HTML (reads JSON file internally)
         try:
-            # Load JSON data
-            import json
-
-            with open(json_path) as f:
-                output_data = json.load(f)
-
             # Generate HTML
-            result_path = auto_generate_html(json_path, output_data, crew_name)
+            result_path = auto_generate_html(json_path)
 
             if result_path:
                 logger.info(f"  ✅ Generated: {result_path.relative_to(json_path.parents[1])}")


### PR DESCRIPTION
## Summary
- update generate_html_reports to invoke auto_generate_html with the correct signature
- remove unnecessary JSON loading now that conversion uses only the file path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924af4162ec83259e12198592e914c1)