### PR TITLE
fix: mock quiet hours in notification tests to prevent CI time-zone failures

### DIFF
--- a/tests/unit/tools/test_notification_service.py
+++ b/tests/unit/tools/test_notification_service.py
@@ -363,6 +363,9 @@ class TestNotificationService:
         user_id = "test_user"
         notification_service.set_user_preferences(user_id, sample_preferences)
 
+        # Ensure test is not blocked by quiet hours (CI runs at 06:xx UTC which is within 22-7)
+        mocker.patch.object(notification_service, "_is_quiet_hours", return_value=False)
+
         # Mock email provider
         mock_email_provider = mocker.AsyncMock()
         mock_record = NotificationRecord(
@@ -401,6 +404,9 @@ class TestNotificationService:
             title="Critical Portfolio Alert",
             message="Critical portfolio deviation detected",
         )
+
+        # Ensure test is not blocked by quiet hours (CI runs at 06:xx UTC which is within 22-7)
+        mocker.patch.object(notification_service, "_is_quiet_hours", return_value=False)
 
         # Mock providers
         mock_email_provider = mocker.AsyncMock()


### PR DESCRIPTION
## Summary
- Tests `test_should_send_email_notification_when_preferences_allow` and `test_should_send_both_notifications_when_alert_severity_high` were failing on CI
- CI runs at ~06:xx UTC, which falls within the default quiet hours window (22–7), causing `_is_quiet_hours()` to return `True` and skip all notifications
- Fixed by mocking `_is_quiet_hours` to return `False` in both tests, making them time-zone independent

## Test plan
- [x] Both previously failing tests now pass locally
- [x] No changes to production code — test-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)