### PR TITLE
ci: remove broken PR-comment step from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -115,15 +115,3 @@ jobs:
           else
             echo "markdownlint not installed, skipping link check"
           fi
-
-      - name: Comment PR with build status
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '✅ Documentation build succeeded! Preview will be available after merge.'
-            })


### PR DESCRIPTION
## Summary

- The `validate` job in `.github/workflows/docs.yml` had a `github-script@v7` step that tried to post a "✅ Documentation build succeeded!" comment to every PR.
- It was failing on every run with HTTP 403 (`Resource not accessible by integration`) because the workflow's `permissions:` block grants only `contents: write / pages: write / id-token: write` — not `issues: write / pull-requests: write`.
- Worse, the step ran under `if: always()` with a hardcoded success message — so even on a genuine docs-build failure it would have posted a green checkmark. Negative signal value.
- Removed the step rather than granting extra permissions. The underlying docs build + strict mkdocs validation remain as the real check.

This unblocks PRs that touch `docs/` or `mkdocs.yml` from showing a red × for a cosmetic comment step.

## Test plan

- [x] `mkdocs build --strict` still runs in the `validate` job
- [x] No other step in this workflow depends on the removed comment step
- [ ] CI on this PR: both `Build Documentation` and `Validate Documentation` jobs green