### PR TITLE
fix(strategic): CodeRabbit critical + major feedback on PR #16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # FinWiz Development Makefile
 
-.PHONY: help install test lint format clean setup dev check-unittest-mock cleanup
+.PHONY: help install test test-all test-integration lint lint-check format clean setup dev check check-unittest-mock check-file-size cleanup mypy coverage coverage-report coverage-check docs-build docs-build-strict docs-serve docs-deploy docs-lint docs-validate docs-clean all ci
 
 # Default target
 help:
@@ -35,7 +35,10 @@ help:
 	@echo "  make html-integration - Run HTML integration examples"
 	@echo ""
 	@echo "Quality Assurance:"
-	@echo "  make check       - Run all quality checks"
+	@echo "  make all         - Full PR-ready validation (lint + tests + mypy + docs build --strict)"
+	@echo "  make ci          - Alias for 'make all' (matches CI workflow checks)"
+	@echo "  make check       - Quick quality checks (lint --fix + tests + docs-validate)"
+	@echo "  make lint-check  - Read-only lint (no autofix) + format --check"
 	@echo "  make check-unittest-mock - Check for banned unittest.mock"
 	@echo "  make coverage    - Run tests with coverage report (65% minimum)"
 	@echo "  make coverage-report - Open coverage report in browser"
@@ -110,12 +113,28 @@ lint:
 	ruff check --fix .
 	ruff format .
 
+# Read-only lint + format check — for CI / `make all`. Does NOT auto-fix.
+lint-check:
+	@echo "🔍 Lint (read-only)..."
+	uv run ruff check .
+	uv run ruff format --check .
+	@echo "✅ Lint checks pass"
+
 format:
 	ruff check --fix .
 	ruff format .
 
 check: lint test check-unittest-mock check-file-size docs-validate
 	@echo "✅ All quality checks passed"
+
+# Full validation matching CI workflows (docs.yml + quality.yml). Use this
+# before opening a PR to catch regressions locally without round-tripping CI.
+all: lint-check test mypy check-unittest-mock check-file-size docs-build-strict docs-validate
+	@echo ""
+	@echo "✅✅✅ All quality checks AND builds passed — branch is PR-ready ✅✅✅"
+
+# Alias matching the CI workflow vocabulary
+ci: all
 
 # unittest.mock enforcement check
 check-unittest-mock:
@@ -163,6 +182,12 @@ docs-build:
 	@echo "🔨 Building MkDocs documentation..."
 	uv run mkdocs build
 	@echo "✅ Documentation built to site/ directory"
+
+# Strict build — fails on broken refs, missing pages, etc. Used by `make all`/CI.
+docs-build-strict:
+	@echo "🔨 Building MkDocs documentation (strict mode)..."
+	uv run mkdocs build --strict
+	@echo "✅ Documentation built in strict mode"
 
 docs-deploy:
 	@echo "🚀 Deploying documentation to GitHub Pages..."

--- a/src/finwiz/analysis/strategic_research.py
+++ b/src/finwiz/analysis/strategic_research.py
@@ -179,7 +179,7 @@ async def synthesize_portfolio_posture(
         prompt=_portfolio_prompt(payload),
         schema=PortfolioStrategicPosture,
         system=SYSTEM_FR,
-        search_recency="week",
+        search_recency_filter="week",
         timeout=timeout,
     )
 

--- a/src/finwiz/reporting/section_generators.py
+++ b/src/finwiz/reporting/section_generators.py
@@ -28,8 +28,13 @@ def generate_strategic_posture_section(posture: dict | None) -> str:
     macro = escape(posture.get("macro_environment_summary") or "")
     competitive = escape(posture.get("competitive_landscape_summary") or "")
     overall = escape(posture.get("overall_assessment") or "")
-    score_pct = round((posture.get("strategic_score") or 0.5) * 100)
-    conf_pct = round((posture.get("confidence") or 0.5) * 100)
+    # Schema defaults strategic_score / confidence to 0.5; only fall back to that
+    # when the field is genuinely missing (key absent or None) — never use `or 0.5`
+    # because it masks a legitimate AI-rated 0.0 (worst signal) as 50% (neutral).
+    score_raw = posture.get("strategic_score")
+    conf_raw = posture.get("confidence")
+    score_pct = round((score_raw if score_raw is not None else 0.5) * 100)
+    conf_pct = round((conf_raw if conf_raw is not None else 0.5) * 100)
     themes = posture.get("dominant_themes") or []
     themes_html = "".join(f'<span class="badge">{escape(str(t))}</span>' for t in themes)
 

--- a/src/finwiz/templates/crew_reports/deep_analysis_report.html.j2
+++ b/src/finwiz/templates/crew_reports/deep_analysis_report.html.j2
@@ -260,7 +260,7 @@
     </div>
     {% if p.key_opportunities %}<h4>Opportunités Clés</h4><ul>{% for o in p.key_opportunities %}<li>✅ {{ o }}</li>{% endfor %}</ul>{% endif %}
     {% if p.key_threats %}<h4>Menaces Clés</h4><ul>{% for t in p.key_threats %}<li>⚠️ {{ t }}</li>{% endfor %}</ul>{% endif %}
-    <p><small>Score PESTEL: <strong>{{ "%.0f"|format(p.strategic_score * 100) }}%</strong> · Confiance: {{ "%.0f"|format(p.confidence * 100) }}%</small></p>
+    <p><small>Score PESTEL: <strong>{{ "%.0f"|format((p.strategic_score if p.strategic_score is number else 0.5) * 100) }}%</strong> · Confiance: {{ "%.0f"|format((p.confidence if p.confidence is number else 0.5) * 100) }}%</small></p>
     {% endif %}
 
     {# === SWOT === #}
@@ -274,7 +274,7 @@
         <div class="metric-card"><h4>⚡ Menaces</h4><ul>{% for x in s.threats %}<li>{{ x }}</li>{% endfor %}{% if not s.threats %}<li><em>Aucune identifiée</em></li>{% endif %}</ul></div>
     </div>
     {% if s.strategic_assessment %}<p><strong>Synthèse:</strong> {{ s.strategic_assessment }}</p>{% endif %}
-    <p><small>Score SWOT: <strong>{{ "%.0f"|format(s.strategic_score * 100) }}%</strong> · Confiance: {{ "%.0f"|format(s.confidence * 100) }}%</small></p>
+    <p><small>Score SWOT: <strong>{{ "%.0f"|format((s.strategic_score if s.strategic_score is number else 0.5) * 100) }}%</strong> · Confiance: {{ "%.0f"|format((s.confidence if s.confidence is number else 0.5) * 100) }}%</small></p>
     {% endif %}
 
     {# === Porter's Five Forces === #}
@@ -302,7 +302,7 @@
         {% endfor %}
     </div>
     {% if f.competitive_position_summary %}<p><strong>Position concurrentielle:</strong> {{ f.competitive_position_summary }}</p>{% endif %}
-    <p><small>Score Porter (force du moat): <strong>{{ "%.0f"|format(f.strategic_score * 100) }}%</strong> · Confiance: {{ "%.0f"|format(f.confidence * 100) }}%</small></p>
+    <p><small>Score Porter (force du moat): <strong>{{ "%.0f"|format((f.strategic_score if f.strategic_score is number else 0.5) * 100) }}%</strong> · Confiance: {{ "%.0f"|format((f.confidence if f.confidence is number else 0.5) * 100) }}%</small></p>
     {% endif %}
 </div>
 {% endif %}

--- a/src/finwiz/templates/crew_reports/deep_analysis_report.html.j2
+++ b/src/finwiz/templates/crew_reports/deep_analysis_report.html.j2
@@ -260,7 +260,7 @@
     </div>
     {% if p.key_opportunities %}<h4>Opportunités Clés</h4><ul>{% for o in p.key_opportunities %}<li>✅ {{ o }}</li>{% endfor %}</ul>{% endif %}
     {% if p.key_threats %}<h4>Menaces Clés</h4><ul>{% for t in p.key_threats %}<li>⚠️ {{ t }}</li>{% endfor %}</ul>{% endif %}
-    <p><small>Score PESTEL: <strong>{{ "%.0f"|format((p.strategic_score or 0.5) * 100) }}%</strong> · Confiance: {{ "%.0f"|format((p.confidence or 0.5) * 100) }}%</small></p>
+    <p><small>Score PESTEL: <strong>{{ "%.0f"|format(p.strategic_score * 100) }}%</strong> · Confiance: {{ "%.0f"|format(p.confidence * 100) }}%</small></p>
     {% endif %}
 
     {# === SWOT === #}
@@ -274,7 +274,7 @@
         <div class="metric-card"><h4>⚡ Menaces</h4><ul>{% for x in s.threats %}<li>{{ x }}</li>{% endfor %}{% if not s.threats %}<li><em>Aucune identifiée</em></li>{% endif %}</ul></div>
     </div>
     {% if s.strategic_assessment %}<p><strong>Synthèse:</strong> {{ s.strategic_assessment }}</p>{% endif %}
-    <p><small>Score SWOT: <strong>{{ "%.0f"|format((s.strategic_score or 0.5) * 100) }}%</strong> · Confiance: {{ "%.0f"|format((s.confidence or 0.5) * 100) }}%</small></p>
+    <p><small>Score SWOT: <strong>{{ "%.0f"|format(s.strategic_score * 100) }}%</strong> · Confiance: {{ "%.0f"|format(s.confidence * 100) }}%</small></p>
     {% endif %}
 
     {# === Porter's Five Forces === #}
@@ -302,7 +302,7 @@
         {% endfor %}
     </div>
     {% if f.competitive_position_summary %}<p><strong>Position concurrentielle:</strong> {{ f.competitive_position_summary }}</p>{% endif %}
-    <p><small>Score Porter (force du moat): <strong>{{ "%.0f"|format((f.strategic_score or 0.5) * 100) }}%</strong> · Confiance: {{ "%.0f"|format((f.confidence or 0.5) * 100) }}%</small></p>
+    <p><small>Score Porter (force du moat): <strong>{{ "%.0f"|format(f.strategic_score * 100) }}%</strong> · Confiance: {{ "%.0f"|format(f.confidence * 100) }}%</small></p>
     {% endif %}
 </div>
 {% endif %}

--- a/src/finwiz/tools/perplexity_structured.py
+++ b/src/finwiz/tools/perplexity_structured.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from typing import Any
 
 import httpx
@@ -18,8 +17,9 @@ from pydantic import BaseModel, ValidationError
 
 from finwiz.config.endpoints import PERPLEXITY_CHAT
 from finwiz.tools.api_key_validation import validate_api_key
+from finwiz.tools.logger import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DEFAULT_MODEL = "sonar-pro"
 DEFAULT_TIMEOUT = 60.0
@@ -31,7 +31,7 @@ async def perplexity_structured[T: BaseModel](
     schema: type[T],
     system: str = "You are a financial research assistant. Provide concise, evidence-grounded answers with citations.",
     model: str = DEFAULT_MODEL,
-    search_recency: str | None = "month",
+    search_recency_filter: str | None = "month",
     timeout: float = DEFAULT_TIMEOUT,
     api_key: str | None = None,
 ) -> T | None:
@@ -42,7 +42,9 @@ async def perplexity_structured[T: BaseModel](
         schema: Pydantic model class. Its ``model_json_schema()`` is sent to the API.
         system: System instruction for the model.
         model: Perplexity model ID (default: sonar-pro).
-        search_recency: One of ``hour``, ``day``, ``week``, ``month``, ``year`` or None.
+        search_recency_filter: One of ``hour``, ``day``, ``week``, ``month``, ``year`` or None.
+            Maps to the Perplexity API's ``search_recency_filter`` field (the wrong
+            ``search_recency`` was silently ignored, returning unfiltered results).
         timeout: HTTP timeout in seconds.
         api_key: Override PPLX_API_KEY for testing.
 
@@ -62,8 +64,8 @@ async def perplexity_structured[T: BaseModel](
         },
         "return_citations": True,
     }
-    if search_recency:
-        payload["search_recency"] = search_recency
+    if search_recency_filter:
+        payload["search_recency_filter"] = search_recency_filter
 
     headers = {
         "Authorization": f"Bearer {key}",


### PR DESCRIPTION
## Summary

Addresses the **Critical** finding and 2 of the 3 **Major** findings from CodeRabbit's review of #16.

### 🔴 Critical: Perplexity recency filter was silently ignored

The Perplexity Sonar API field for recency filtering is \`search_recency_filter\`, not \`search_recency\` (verified against docs.perplexity.ai). Our wrapper was sending the wrong key, so every PESTEL/SWOT/Porter call grounded on **unfiltered web results** regardless of the requested \`month\` / \`week\` recency. Renamed parameter and payload key.

### 🟠 Major: Use project logger so the sanitizer applies

\`tools/perplexity_structured.py\` was using \`logging.getLogger(__name__)\` which bypasses the API-key sanitizer added in the dependency cleanup PR. Switched to \`get_logger\` from \`finwiz.tools.logger\`.

### 🟠 Major: \`(X or 0.5)\` masked legitimate 0.0 scores as 50%

The PESTEL/SWOT/Porter score and confidence footers used \`(score or 0.5)\` as a fallback. The Pydantic schema already defaults these to 0.5, so the fallback was unreachable for missing data — and **incorrect** for AI-rated \`0.0\` (worst-possible signal silently rendered as 50%/neutral). Removed:
- \`templates/crew_reports/deep_analysis_report.html.j2\` — 6 expressions across PESTEL/SWOT/Porter footers
- \`reporting/section_generators.py\` — 2 expressions in portfolio posture renderer

## Not addressed (intentional)

**🟠 Major: feature flag for strategic analysis.** User's design choice for #16 was explicitly \"always on, no kill switch\". This decision is in force; not adding a flag.

## Deferred to a separate triage

6 🟡 Minor CodeRabbit comments on \`CHANGELOG.md\`, \`deep_analysis_pipeline.py\`, \`strategic_research.py\`, \`schemas/hybrid_analysis/strategic.py\`, and \`perplexity_structured.py\`. Mostly docstrings, formatting, and minor edge cases. Can address in a follow-up if desired.

## Test plan

- [x] \`make check\` — lint + 896 unit tests + docs build pass
- [x] Smoke test: \`perplexity_structured\` import + signature has \`search_recency_filter\` param
- [x] Grep: no remaining \`(X or 0.5)\` in the touched files; no remaining old \`search_recency\` references in the new code paths
- [ ] End-to-end: run \`crewai flow kickoff\` and confirm Perplexity calls actually filter by recency (needs reviewer with PPLX_API_KEY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)