### PR TITLE
fix(llm): retry OpenRouter mid-stream drops via litellm.num_retries=3

### DIFF
--- a/src/finwiz/config/llm/llm_config.py
+++ b/src/finwiz/config/llm/llm_config.py
@@ -42,7 +42,30 @@ logger = get_logger(__name__)
 # instance. Catches OpenRouter mid-stream drops (RemoteProtocolError /
 # "incomplete chunked read") and APIError 502/503/504 with built-in
 # exponential backoff. Tunable via LLM_NUM_RETRIES (default: 3).
-litellm.num_retries = int(os.getenv("LLM_NUM_RETRIES", "3"))
+#
+# Note: tools/crewai_retry_patch.py (initialize_retry_mechanism) is a no-op
+# in current CrewAI — its `Agent._get_llm` patch target no longer exists,
+# and the langchain BaseLLM isinstance gate would fail on crewai.LLM (litellm
+# wrapper) anyway. So this module-level setting is the only active retry layer.
+_DEFAULT_LLM_NUM_RETRIES = 3
+
+
+def _parse_num_retries() -> int:
+    """Safely parse LLM_NUM_RETRIES. Empty/invalid -> default; never raises."""
+    raw = os.getenv("LLM_NUM_RETRIES", "").strip()
+    if not raw:
+        return _DEFAULT_LLM_NUM_RETRIES
+    try:
+        value = int(raw)
+    except ValueError:
+        # Don't crash module import on a typo'd env value (e.g. LLM_NUM_RETRIES=foo).
+        # Logger isn't initialized yet at this point, so use a print warning.
+        print(f"[llm_config] Invalid LLM_NUM_RETRIES={raw!r}, falling back to {_DEFAULT_LLM_NUM_RETRIES}")
+        return _DEFAULT_LLM_NUM_RETRIES
+    return max(0, value)  # Clamp negatives to 0 (litellm treats <=0 as "no retries")
+
+
+litellm.num_retries = _parse_num_retries()
 
 
 # =============================================================================

--- a/src/finwiz/config/llm/llm_config.py
+++ b/src/finwiz/config/llm/llm_config.py
@@ -25,6 +25,7 @@ Environment Variables:
 import os
 from typing import Any
 
+import litellm
 from crewai import LLM
 from dotenv import load_dotenv
 
@@ -34,6 +35,14 @@ from finwiz.tools.logger import get_logger
 load_dotenv()
 
 logger = get_logger(__name__)
+
+# Module-level litellm retry policy for transient errors. CrewAI's LLM class
+# doesn't expose num_retries on its constructor, so we set it on the litellm
+# module — it applies to every litellm.completion call made by any CrewAI LLM
+# instance. Catches OpenRouter mid-stream drops (RemoteProtocolError /
+# "incomplete chunked read") and APIError 502/503/504 with built-in
+# exponential backoff. Tunable via LLM_NUM_RETRIES (default: 3).
+litellm.num_retries = int(os.getenv("LLM_NUM_RETRIES", "3"))
 
 
 # =============================================================================
@@ -316,7 +325,9 @@ def get_configured_llm(model_override: str | None = None, model_type: str = "sta
                 extra_body["tool_choice"] = "auto"
             logger.info("OpenRouter middle-out transform enabled for automatic context compression")
 
-        # Create LLM with proper configuration
+        # Create LLM with proper configuration.
+        # Note: retry on transient errors is handled at the litellm module level
+        # (litellm.num_retries set at import time in this file).
         llm = LLM(
             model=model,
             timeout=timeout,


### PR DESCRIPTION
## Summary

Fixes the wave of \`httpcore.RemoteProtocolError: peer closed connection without sending complete message body (incomplete chunked read)\` failures coming from CrewAI's \`deep_qualitative_analysis_task\`.

## Root cause

OpenRouter sometimes drops the HTTP/1.1 chunked response mid-stream when the upstream provider (grok / deepseek / etc.) is overloaded or flakes out partway through generation. The error surfaces as \`RemoteProtocolError\` → \`litellm.APIError\` and bubbles up to the CrewAI thread, killing the qualitative task.

CrewAI's \`LLM(...)\` constructor doesn't expose a \`num_retries\` parameter (verified via \`inspect.signature\` — only \`timeout\` is the closest retry-related field), so the previous code was running with **zero litellm-level retries**. Every transient stream drop was a hard failure.

## Fix

Set \`litellm.num_retries = 3\` at module import time in \`llm_config.py\`. This is a global litellm setting that applies to every \`litellm.completion\` call made by any CrewAI LLM instance, with built-in exponential backoff. It catches:
- \`httpcore.RemoteProtocolError\` / incomplete chunked reads
- \`litellm.APIError\` (502/503/504)
- Other transient provider hiccups

Tunable via \`LLM_NUM_RETRIES\` env var if you want to crank it up (e.g., \`LLM_NUM_RETRIES=5\`).

## Test plan

- [x] \`make check\` passes (lint + 4967 tests + docs build)
- [x] Smoke: \`litellm.num_retries\` reads \`3\` by default and picks up env override on reload
- [ ] End-to-end: rerun the failing portfolio kickoff (\`crewai flow kickoff\`) and confirm the qualitative crew now succeeds despite occasional OpenRouter drops

## Why not a CrewAI \`LLM(...)\` kwarg?

I tried first — Pyright/runtime confirmed CrewAI's \`LLM\` doesn't accept \`num_retries\` (only 25 init params, none retry-related). The litellm module-level global is the canonical way to configure this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic retry handling for LLM operations to recover from transient errors (configurable retry attempts, default 3).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->