### PR TITLE
fix(crew): make PerplexitySearchTool conditional on PPLX_API_KEY

### DIFF
--- a/src/finwiz/crews/deep_analysis/deep_analysis.py
+++ b/src/finwiz/crews/deep_analysis/deep_analysis.py
@@ -90,6 +90,25 @@ load_dotenv()
 apply_json_repair_patch()
 
 
+def _build_asset_analyst_tools() -> list[Any]:
+    """Return PerplexitySearchTool when PPLX_API_KEY is set, else empty list.
+
+    Falls back gracefully when the env var is missing (CI without secrets,
+    local dev without a Perplexity key) instead of crashing crew construction
+    with a Pydantic ValidationError. The prompt's anti-hallucination rules
+    still apply in zero-tool mode — fact verification is just unavailable.
+    """
+    import os
+
+    if not os.getenv("PPLX_API_KEY"):
+        logger.warning("PPLX_API_KEY not set — asset_analyst falling back to zero-tool mode. Fact verification disabled; relying solely on prompt anti-hallucination rules.")
+        return []
+
+    from finwiz.tools.perplexity_search_tool import PerplexitySearchTool
+
+    return [PerplexitySearchTool()]
+
+
 @CrewBase
 class DeepAnalysisCrew:
     """
@@ -220,14 +239,16 @@ class DeepAnalysisCrew:
         before mentioning them in the narrative, since the model's training data
         is often outdated for corporate facts. The tasks.yaml prompt caps usage
         to 2-3 calls per holding to keep token cost bounded.
-        """
-        from finwiz.tools.perplexity_search_tool import PerplexitySearchTool
 
+        When PPLX_API_KEY is not set (CI, local dev without Perplexity key),
+        the agent falls back to zero-tool mode and the prompt's anti-hallucination
+        rules become the only safeguard.
+        """
         return Agent(
             config=self.agents_config["asset_analyst"],
             verbose=True,
             reasoning=False,  # Plan tool calls via the prompt, not via reasoning loop (cheaper)
-            tools=[PerplexitySearchTool()],
+            tools=_build_asset_analyst_tools(),
             llm=self._get_configured_llm(),
         )
 


### PR DESCRIPTION
## Summary

Fixes the CI failure on \`Code Quality\` introduced by PR #19.

## Root cause

PR #19 unconditionally added \`PerplexitySearchTool()\` to \`asset_analyst\`. \`PerplexitySearchTool.model_post_init\` calls \`validate_api_key(\"PPLX_API_KEY\")\` which raises a Pydantic \`ValidationError\` when the env var is missing. CI doesn't have \`PPLX_API_KEY\` (and shouldn't — it's a paid live API), so two crew tests crashed at agent construction:

\`\`\`
FAILED tests/unit/crews/test_deep_analysis_crew.py::TestDeepAnalysisCrew::test_should_instantiate_crew_without_keyerror
FAILED tests/unit/crews/test_deep_analysis_crew.py::TestDeepAnalysisCrew::test_should_have_exactly_one_agent
  pydantic_core.ValidationError: PerplexitySearchTool requires PPLX_API_KEY
\`\`\`

## Fix

Extract \`_build_asset_analyst_tools()\` helper:

\`\`\`python
def _build_asset_analyst_tools() -> list[Any]:
    if not os.getenv(\"PPLX_API_KEY\"):
        logger.warning(\"PPLX_API_KEY not set — asset_analyst falling back to zero-tool mode...\")
        return []
    from finwiz.tools.perplexity_search_tool import PerplexitySearchTool
    return [PerplexitySearchTool()]
\`\`\`

When the key is missing, the agent reverts to the same zero-tool posture it had before PR #19. The prompt's anti-hallucination block from PR #19 remains as the only safeguard. With the key set (production), full Perplexity fact-verification is preserved.

## Test plan

- [x] \`env -u PPLX_API_KEY uv run pytest tests/unit/crews/test_deep_analysis_crew.py\` — 12/12 pass
- [x] \`make check\` passes locally
- [ ] CI passes on this PR (the one that was failing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)