### PR TITLE
fix: remove Phase 3 global timeout (the lock that discarded completed work)

### DIFF
--- a/src/finwiz/flows/orchestrator.py
+++ b/src/finwiz/flows/orchestrator.py
@@ -213,31 +213,18 @@ class FinwizFlow(Flow[FinwizState]):
         await self.validation_orch.check_portfolio()
 
         # Phase 3: Deep Analysis (analyzes the loaded holdings)
-        # Always runs — no env-var gate. See deep_analysis_orchestrator.py.
-        # Wrapped in try/finally so post-flow cost/cache summaries fire even
-        # on the hard-fail path (Phase 3 is the largest LLM spend; operators
-        # need cost attribution exactly when something went wrong).
+        # Always runs — no env-var gate. The orchestrator raises RuntimeError
+        # directly when 0 analyses are produced (single source of truth for
+        # the fail-loud signal). The try/except here ensures the post-flow
+        # cost/cache summaries still fire on the failure path — Phase 3 is
+        # the largest LLM spend, and operators need cost attribution exactly
+        # when something went wrong.
         try:
             logger.info("=" * 80)
             logger.info("PHASE 3: Deep Analysis")
             logger.info("=" * 80)
             await self.deep_analysis_orch.analyze_and_update_portfolio()
-
-            # FAIL LOUDLY: when we have holdings but produced 0 analyses, the report
-            # would otherwise show every holding as "pending" with placeholder
-            # grades. That's the silent-success antipattern that lost user trust.
-            # Better to abort with a clear error than ship a misleading report.
-            portfolio_holdings = (self.state.portfolio_review or {}).get("holdings") or []
-            analyzed_count = len(self.state.deep_analysis_results or {})
-            if portfolio_holdings and analyzed_count == 0:
-                raise RuntimeError(
-                    f"Phase 3 produced 0 deep analyses for {len(portfolio_holdings)} holdings. "
-                    "Refusing to generate a report based on placeholder data. "
-                    "Check upstream data fetch / crew failures in the log."
-                )
         except Exception:
-            # Run cost/cache summary BEFORE re-raising so operators get token
-            # spend visibility on the failure mode they care about most.
             self._log_post_flow_summaries()
             raise
 

--- a/src/finwiz/orchestrators/deep_analysis_orchestrator.py
+++ b/src/finwiz/orchestrators/deep_analysis_orchestrator.py
@@ -92,15 +92,21 @@ class DeepAnalysisOrchestrator:
 
         run_batch_prefetch(self.state, holdings, self.logger)
 
-        # Step 1: Run deep analysis on all holdings CONCURRENTLY
+        # Step 1: Run deep analysis on all holdings CONCURRENTLY.
+        # If the runner itself raises (executor init, asyncio loop, config
+        # error — NOT per-holding errors which are isolated by the gather's
+        # return_exceptions=True), re-raise so the flow can't continue and
+        # report success on a Phase 3 crash. State is updated first so the
+        # post-flow cost summary (in flows/orchestrator.py try/except) can
+        # still see the failure context.
         try:
             deep_results = await self.run_deep_analysis_concurrent(holdings)
         except Exception as e:
-            self.logger.error(f"Deep analysis failed: {e}", exc_info=True)
+            self.logger.critical(f"❌ Deep analysis runner crashed: {e}", exc_info=True)
             self.state.deep_analysis_success = False
             self.state.deep_analysis_error = str(e)
             self.state.deep_analysis_coverage = (0, len(holdings))
-            return {"deep_analysis_results": {}, "error": str(e)}
+            raise
 
         # Honest success accounting — success only if we actually produced analyses.
         # Coverage tuple (analyzed, total) is read by the reporting layer to

--- a/src/finwiz/orchestrators/deep_analysis_orchestrator.py
+++ b/src/finwiz/orchestrators/deep_analysis_orchestrator.py
@@ -112,10 +112,17 @@ class DeepAnalysisOrchestrator:
         self.state.deep_analysis_success = analyzed > 0
 
         if analyzed == 0:
-            self.logger.critical(
-                f"❌ Deep analysis produced 0 results for {total} holdings. Failed tickers: {self._failed_holdings[:10]}{'...' if len(self._failed_holdings) > 10 else ''}"
-            )
-        elif analyzed < total:
+            # FAIL LOUDLY from the orchestrator. This is the single source of
+            # truth for "Phase 3 produced nothing" — fires regardless of which
+            # flow path called us (sequential body vs @listen callback). The
+            # flow-level wrapper (try/except: _log_post_flow_summaries; raise)
+            # ensures cost summary still fires before this propagates.
+            failed_preview = self._failed_holdings[:10]
+            ellipsis = "..." if len(self._failed_holdings) > 10 else ""
+            msg = f"Deep analysis produced 0 results for {total} holdings. Failed tickers: {failed_preview}{ellipsis}"
+            self.logger.critical(f"❌ {msg}")
+            raise RuntimeError(msg)
+        if analyzed < total:
             missing = total - analyzed
             self.logger.warning(
                 f"⚠️ Partial coverage: {analyzed}/{total} holdings analyzed, "
@@ -300,10 +307,6 @@ class DeepAnalysisOrchestrator:
         # Per-holding timeout - prevents one stuck ticker blocking all
         PER_HOLDING_TIMEOUT = int(os.getenv("FINWIZ_HOLDING_TIMEOUT", "600"))
 
-        # Global timeout for entire analysis phase (default: 30 minutes)
-        # Prevents the entire concurrent phase from hanging indefinitely
-        GLOBAL_PHASE_TIMEOUT = int(os.getenv("FINWIZ_PHASE_TIMEOUT", "1800"))
-
         async def analyze_with_timeout(holding: dict[str, Any], executor: Any) -> tuple[str, DeepAnalysisResult | None, Any | None]:
             """Wrap analysis with per-holding timeout that starts when work begins."""
             ticker = holding.get("ticker", "unknown")
@@ -325,38 +328,32 @@ class DeepAnalysisOrchestrator:
                     self._failed_holdings.append(ticker)
                     return (ticker, None, None)
 
-        # Use ThreadPoolExecutor with explicit cleanup to prevent deadlocks
-        # NOTE: When asyncio.wait_for times out, the underlying thread keeps running
-        # We must shutdown with wait=False to prevent hanging on stuck threads
+        # NO AGGREGATE TIMEOUT. Each holding has its own PER_HOLDING_TIMEOUT
+        # (analyze_with_timeout above). An aggregate cap would discard already
+        # completed work when one slow ticker pushes total runtime over —
+        # which is exactly what discarded XRP-USD's grade=D verdict on
+        # 2026-04-27 (XRP finished at 09:00:12, the 1800s aggregate timeout
+        # fired at 09:04:55 and threw the result away). With 60+ holdings,
+        # an outer cap is the wrong abstraction — let total runtime scale
+        # with N at the per-holding budget.
+        # See memory/feedback_no_aggregate_timeouts.md for the principle.
         executor = ThreadPoolExecutor(max_workers=max_workers * 2)
         try:
-            # Submit all holdings - semaphore ensures only max_workers run at a time
-            # and timeout starts when semaphore is acquired (work begins)
+            # Submit all holdings - semaphore ensures only max_workers run at a
+            # time and per-holding timeout starts when semaphore is acquired.
             futures = [analyze_with_timeout(holding, executor) for holding in holdings]
-            try:
-                # Global timeout prevents entire phase from hanging
-                completed = await asyncio.wait_for(
-                    asyncio.gather(*futures, return_exceptions=False),
-                    timeout=GLOBAL_PHASE_TIMEOUT,
-                )
-            except TimeoutError:
-                self.logger.critical(f"❌ Global phase timeout after {GLOBAL_PHASE_TIMEOUT}s - aborting remaining analyses. {len(holdings)} holdings will be marked as pending.")
-                # Mark every holding that hasn't been individually tracked as failed
-                # (they were in flight when the global timeout fired).
-                for h in holdings:
-                    t = h.get("ticker")
-                    if t and t not in self._failed_holdings:
-                        self._failed_holdings.append(t)
-                completed = []
-            except Exception as e:
-                self.logger.critical(f"❌ Deep analysis gather failed: {e}", exc_info=True)
-                for h in holdings:
-                    t = h.get("ticker")
-                    if t and t not in self._failed_holdings:
-                        self._failed_holdings.append(t)
-                completed = []
+            # return_exceptions=True so one holding's escaped exception doesn't
+            # cancel siblings. Per-holding handlers (analyze_with_timeout +
+            # analyze_single_sync) already log + track failures via
+            # _failed_holdings — this is defense-in-depth.
+            results_or_excs = await asyncio.gather(*futures, return_exceptions=True)
+            for item in results_or_excs:
+                if isinstance(item, BaseException):
+                    self.logger.error(f"Unhandled exception in gather: {item!r}", exc_info=item)
+                    continue
+                completed.append(item)
         finally:
-            # CRITICAL: Don't wait for stuck threads - they may be deadlocked
+            # CRITICAL: Don't wait for stuck threads - they may be deadlocked.
             # cancel_futures=True attempts to cancel pending futures (Python 3.9+)
             self.logger.info("Shutting down executor (not waiting for stuck threads)")
             executor.shutdown(wait=False, cancel_futures=True)

--- a/tests/unit/orchestrators/test_orchestrator_state_integration.py
+++ b/tests/unit/orchestrators/test_orchestrator_state_integration.py
@@ -163,9 +163,16 @@ class TestOrchestratorStateIntegration:
 
     @pytest.mark.asyncio
     async def test_deep_analysis_sets_error_state_on_failure(self, state, mocker):
-        """Deep analysis failure sets deep_analysis_success=False and deep_analysis_error."""
-        mocker.patch("os.getenv", side_effect=lambda k, d="": "true" if k == "DEEP_PORTFOLIO_ANALYSIS" else d)
+        """Runner failure sets state AND re-raises so the flow can't report success.
 
+        Trust requirement: a Phase 3 runner crash (executor init error,
+        asyncio loop error, etc.) must propagate. Previously the
+        orchestrator swallowed the exception and returned an error dict,
+        which let the flow continue and report 'completed successfully'
+        despite zero analyses. Now the orchestrator updates state and
+        re-raises — flows/orchestrator.py's try/except still ensures
+        cost summaries fire on the failure path.
+        """
         orch = DeepAnalysisOrchestrator(
             state,
             crew_factory=mocker.Mock(),
@@ -180,11 +187,13 @@ class TestOrchestratorStateIntegration:
             side_effect=RuntimeError("Analysis timeout"),
         )
 
-        result = await orch.analyze_and_update_portfolio()
+        with pytest.raises(RuntimeError, match="Analysis timeout"):
+            await orch.analyze_and_update_portfolio()
 
+        # State was updated BEFORE the re-raise so observers see the failure
         assert state.deep_analysis_success is False
         assert "Analysis timeout" in state.deep_analysis_error
-        assert "error" in result
+        assert state.deep_analysis_coverage == (0, len(state.portfolio_review["holdings"]))
 
     # ---- Discovery consolidation ----
 

--- a/uv.lock
+++ b/uv.lock
@@ -894,7 +894,7 @@ wheels = [
 
 [[package]]
 name = "finwiz"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
## Summary

Removes the 1800s aggregate timeout that was discarding successfully-completed deep-analysis work. With 60+ holdings, an outer cap is the wrong abstraction — per-holding timeouts are the correct safety mechanism.

## Evidence (latest run before this fix)

\`\`\`
09:00:12  Synthesis complete: XRP-USD grade=D rec=SELL    ← REAL VERDICT
09:00:12  Pipeline complete for XRP-USD: 92.3s
09:04:55  ❌ Global phase timeout after 1800s
09:04:55  asyncio.gather completed with 0 results          ← XRP DISCARDED
09:04:55  ❌ Deep analysis produced 0 results for 63
[10 minutes later, after the orchestrator gave up:]
09:05:58  Synthesis complete: XAIX grade=C rec=HOLD (604.8s)
09:06:16  ✅ FinWiz analysis workflow completed successfully
\`\`\`

XRP-USD finished cleanly **4½ minutes BEFORE** the timeout, but \`asyncio.wait_for\` cancelled the whole gather and threw its result away.

## Three changes

1. **Delete \`GLOBAL_PHASE_TIMEOUT\`** + the \`asyncio.wait_for\` wrapping the gather. \`PER_HOLDING_TIMEOUT\` (600s default, \`FINWIZ_HOLDING_TIMEOUT\` env var) remains the only cap. Total runtime now scales naturally with N.
2. **\`return_exceptions=True\`** so one holding's exception doesn't poison the batch.
3. **Raise \`RuntimeError\` from the orchestrator** on 0 results — single source of truth, independent of flow call path. Removed the duplicate flow-level check.

## User principle captured

> *\"we have 60 ticker, why do we have a global timeout? this is a stupid lock no?\"*

Saved as \`memory/feedback_no_aggregate_timeouts.md\` so future plans don't propose aggregate-timeout patterns again.

## Test plan

- [x] Synthetic asyncio test: one slow item doesn't block siblings (11/11 completed despite a 2s outlier)
- [x] Synthetic asyncio test: one failure doesn't poison siblings (5/6 completed when one item raises)
- [x] \`make check\` passes (lint + tests + docs build + mypy clean: 491 files)
- [ ] End-to-end on a real portfolio: confirm fast holdings produce enriched JSONs even when slow outliers exist; confirm RuntimeError fires + flow does NOT report success on total failure

## Out of scope

- Per-holding pipeline optimization (XAIX 604s — separate work).
- Reducing the dual-path @start vs @listen ambiguity in \`flows/orchestrator.py\`.
- Strategic Perplexity per-call timeout tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deep analysis now produces explicit failure errors when no analyses complete and surfaces detailed failure messages.
  * Concurrent analysis is more resilient: one task's failure no longer cancels others; individual exceptions are logged and skipped.
  * Removed the aggregate/global phase timeout to allow longer-running analyses to finish.

* **Tests**
  * Adjusted tests to expect exception propagation and verify state updates on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->