### PR TITLE
fix(discovery): remove INVESTMENT_DISCOVERY_ENABLED kill switch — Phase 4 always runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,7 +124,6 @@ FINWIZ_STATE_CLEANUP_MAX_AGE_DAYS=7               # Max age for state cleanup
 # =============================================================================
 
 DEEP_PORTFOLIO_ANALYSIS=false                     # Enable deep portfolio analysis with AI crews
-INVESTMENT_DISCOVERY_ENABLED=true                 # Enable investment discovery features
 PORTFOLIO_ENABLE_ALTERNATIVES=true                # Enable alternative investment suggestions
 PORTFOLIO_ENABLE_REBALANCING=false                # Enable portfolio rebalancing (experimental)
 

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -107,7 +107,7 @@
    - Store DeepAnalysisResult in flow state
    - Merge with previous analysis if available
 
-5. **Phase 4: Discovery** (DiscoveryOrchestrator - optional)
+5. **Phase 4: Discovery** (DiscoveryOrchestrator)
    - Parallel execution: check_crypto(), check_stock(), check_etf()
    - Consolidate A+ investment opportunities
    - Store in flow state

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -298,7 +298,7 @@ synthesize_enriched_analysis(ctx, quant, qual)
 
 - Approach: Environment-based toggles with circuit breakers
 - Implementation: `src/finwiz/config/features/flags.py`
-- Flags: DEEP_ANALYSIS_ENABLED, PERPLEXITY_RESEARCH_ENABLED, INVESTMENT_DISCOVERY_ENABLED, PORTFOLIO_REBALANCING_ENABLED
+- Flags: DEEP_ANALYSIS_ENABLED, PERPLEXITY_RESEARCH_ENABLED, PORTFOLIO_REBALANCING_ENABLED
 - Usage: is_feature_enabled(feature_name) returns bool
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,8 +122,8 @@ OPENAI_API_KEY=...              # Required
 SERPER_API_KEY=...              # Required
 # Optional: ANTHROPIC_API_KEY, PERPLEXITY_API_KEY, ALPHA_VANTAGE_API_KEY, etc.
 # Feature flags: DEEP_ANALYSIS_ENABLED, PERPLEXITY_RESEARCH_ENABLED
-# Discovery toggle (opt-in, ~$0.50-1 extra LLM cost):
-#   INVESTMENT_DISCOVERY_ENABLED=true crewai flow kickoff
+# Investment Discovery (Phase 4) runs unconditionally; the
+# INVESTMENT_DISCOVERY_ENABLED kill switch was removed.
 # Validation: VALIDATION_STRICTNESS=off|warn|error
 # Scenario probabilities: RISK_FREE_RATE=0.045  (Black-Scholes risk-free rate for options-implied probabilities)
 ```
@@ -133,12 +133,10 @@ SERPER_API_KEY=...              # Required
 `crewai flow kickoff` is the sole production entry point. Flow parameters are
 passed via CrewAI-native mechanisms — not via argparse.
 
-- **Runtime (recommended):** export an env var before the command.
-  `app_initializer.kickoff()` reads `INVESTMENT_DISCOVERY_ENABLED` and forwards
-  it to the flow as an input.
-- **Programmatic:** call `FinwizFlow(state=FinwizState()).kickoff(inputs={"discovery_enabled": True})`.
+- **Programmatic:** call `FinwizFlow(state=FinwizState()).kickoff(inputs={...})`.
   Inputs populate the structured `FinwizState` Pydantic fields before any
-  `@start()` method runs.
+  `@start()` method runs. The `discovery_enabled` field is preserved for API
+  stability but Phase 4 runs unconditionally regardless of its value.
 
 
 ## grepai - Semantic Code Search

--- a/docs/superpowers/plans/2026-04-27-v5.1-trust-spine.md
+++ b/docs/superpowers/plans/2026-04-27-v5.1-trust-spine.md
@@ -1,0 +1,3389 @@
+# v5.1 Trust Spine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote the four already-existing deep-analysis pipeline stages from functions in a 1209-line module into typed, contracted modules with explicit invariants, per-stage resilience, and a persistent run ledger — so silent failure becomes a Pydantic validation error, not a discovered-in-prod bug.
+
+**Architecture:** Extract the existing stage functions into `src/finwiz/analysis/stages/` modules. Each stage returns a typed `StageResult[T]` envelope with explicit `OK | DEGRADED | FAILED` outcome and provenance. A `@stage` decorator enforces per-unit timeout, retry policy, and ledger recording. A `RunLedger` persists outcomes to JSONL and derives the `TrustBanner` the report consumes literally. The qualitative stage's existing Python fallback is *labeled* as `DEGRADED` instead of impersonating real AI output. AST static check fails CI on aggregate-timeout / improper-gather patterns.
+
+**Tech Stack:** Python 3.12, Pydantic v2 (strict, `extra="forbid"`), CrewAI, asyncio, pytest + pytest-mock, Hypothesis (property tests), ruff, mypy strict. JSONL output via stdlib `json.dumps(default=str)`.
+
+**Spec:** [`docs/superpowers/specs/2026-04-27-v5.1-trust-spine-design.md`](../specs/2026-04-27-v5.1-trust-spine-design.md)
+
+**Existing references:**
+- `src/finwiz/analysis/deep_analysis_pipeline.py` (1209 lines — source of extracted stages)
+- `src/finwiz/orchestrators/deep_analysis_orchestrator.py:45,80,108,117,241,246,304,330,334` (`_failed_holdings`, `deep_analysis_coverage`, `PER_HOLDING_TIMEOUT`)
+- `src/finwiz/reporting/section_generators.py:75,269` (current banner / "Analyse en attente")
+- `src/finwiz/schemas/hybrid_analysis/` (existing payload models — re-used as `StageResult[T]` parameter)
+- `src/finwiz/config/resilience_config.py:101,132` (current `FINWIZ_HOLDING_TIMEOUT`)
+
+---
+
+## File Structure
+
+### New schema files (`src/finwiz/schemas/`)
+
+| File | Responsibility |
+|------|----------------|
+| `schemas/stage_contract.py` | `StageOutcome` enum, `StageProvenance`, `StageResult[T]` |
+| `schemas/run_ledger.py` | `RunLedgerEntry`, `CoverageSummary`, `TrustBanner` |
+
+### New stage modules (`src/finwiz/analysis/stages/`)
+
+| File | Responsibility |
+|------|----------------|
+| `stages/__init__.py` | Public exports: `run_pipeline` |
+| `stages/_resilience.py` | `@stage` decorator: timeout, retry, outcome-capture, ledger-record |
+| `stages/_ledger.py` | `RunLedger` class (JSONL writer, banner derivation) |
+| `stages/collect.py` | `collect_raw_data` stage |
+| `stages/quantify.py` | `calculate_quantitative` stage |
+| `stages/qualify.py` | `generate_qualitative` stage (only stage allowed `DEGRADED`) |
+| `stages/synthesize.py` | `synthesize_enriched_analysis` stage |
+| `stages/emit.py` | `build_verdict` stage (returns `DeepAnalysisResult` or `AnalysePending`) |
+
+### Other new files
+
+| File | Responsibility |
+|------|----------------|
+| `src/finwiz/analysis/_helpers.py` | Private utilities moved from `deep_analysis_pipeline.py`: `_today_french`, `_summarize_metrics`, `_truncate_text`, `_filter_numeric_values`, `_build_sentiment_summary`, `_get_analysis_crew`, `_build_crew_inputs` |
+| `scripts/check_stage_contract.py` | AST static check; fails on aggregate-timeout / improper `asyncio.gather` patterns under `analysis/stages/` |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/finwiz/analysis/deep_analysis_pipeline.py` | Shrinks to ~80-line facade — re-exports `analyze_holding` calling `run_pipeline` |
+| `src/finwiz/orchestrators/deep_analysis_orchestrator.py` | `_failed_holdings` becomes a thin view over `RunLedger.failed_tickers()`. State updates go through ledger |
+| `src/finwiz/flow_state.py` | `deep_analysis_coverage` becomes a property derived from the ledger |
+| `src/finwiz/reporting/section_generators.py` | Reads `TrustBanner` literally; adds amber-badge branch reading `provenance.outcome == DEGRADED` |
+| `src/finwiz/reporting/python_report_generator.py` | Reads `TrustBanner` instead of `deep_analysis_coverage` tuple |
+| `Makefile` | Add `check-stage-contract` target wired into `check` |
+
+### New test files
+
+| File | Responsibility |
+|------|----------------|
+| `tests/unit/schemas/test_stage_contract.py` | Validators for `StageProvenance`, `StageResult` invariants I1–I3 |
+| `tests/unit/schemas/test_run_ledger.py` | `RunLedgerEntry`, `TrustBanner` state-rule table |
+| `tests/unit/analysis/stages/__init__.py` | (empty package marker) |
+| `tests/unit/analysis/stages/test_ledger.py` | `RunLedger` JSONL persistence + coverage |
+| `tests/unit/analysis/stages/test_resilience.py` | `@stage` decorator: timeout, retry, error-capture, allow_degrade enforcement |
+| `tests/unit/analysis/stages/test_collect.py` | `collect` stage outcomes |
+| `tests/unit/analysis/stages/test_quantify.py` | `quantify` stage outcomes |
+| `tests/unit/analysis/stages/test_qualify.py` | `qualify` stage including `DEGRADED` branch |
+| `tests/unit/analysis/stages/test_synthesize.py` | `synthesize` reads provenance and emits low-confidence verdict on `DEGRADED` |
+| `tests/unit/analysis/stages/test_emit.py` | `emit` returns `AnalysePending` on FAILED upstream |
+| `tests/unit/analysis/stages/test_pipeline.py` | Three-holding integration: OK, DEGRADED, FAILED |
+| `tests/unit/analysis/stages/test_property_invariants.py` | Hypothesis property tests for ledger invariants |
+| `tests/unit/scripts/test_check_stage_contract.py` | AST check on synthetic offending code |
+| `tests/regression/test_trust_crisis_v030.py` | v0.3.0 silent-success regression |
+
+---
+
+## Phase A — Schemas Foundation
+
+No behavior change. Pure type definitions with validators. Each task is small and TDD-friendly.
+
+### Task A1: `StageOutcome` Enum
+
+**Files:**
+- Create: `src/finwiz/schemas/stage_contract.py`
+- Test: `tests/unit/schemas/test_stage_contract.py`
+
+- [ ] **Step 1: Write failing test for enum values**
+
+```python
+# tests/unit/schemas/test_stage_contract.py
+from finwiz.schemas.stage_contract import StageOutcome
+
+
+def test_stage_outcome_has_three_values() -> None:
+    assert {o.value for o in StageOutcome} == {"ok", "degraded", "failed"}
+
+
+def test_stage_outcome_is_str_enum() -> None:
+    assert StageOutcome.OK == "ok"
+    assert StageOutcome.DEGRADED == "degraded"
+    assert StageOutcome.FAILED == "failed"
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `uv run pytest tests/unit/schemas/test_stage_contract.py -v`
+Expected: FAIL — `ModuleNotFoundError: finwiz.schemas.stage_contract`.
+
+- [ ] **Step 3: Create the enum**
+
+```python
+# src/finwiz/schemas/stage_contract.py
+"""Stage contract types: outcome enum, provenance, and result envelope."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class StageOutcome(StrEnum):
+    """Result of executing a single pipeline stage.
+
+    OK       - stage produced its expected payload
+    DEGRADED - stage produced a fallback payload (qualify stage only)
+    FAILED   - stage did not produce any payload
+    """
+
+    OK = "ok"
+    DEGRADED = "degraded"
+    FAILED = "failed"
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `uv run pytest tests/unit/schemas/test_stage_contract.py -v`
+Expected: PASS — both tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/schemas/stage_contract.py tests/unit/schemas/test_stage_contract.py
+rtk git commit -m "feat(schemas): add StageOutcome enum for v5.1 trust spine"
+```
+
+---
+
+### Task A2: `StageProvenance` Model with Invariants I1 + I3
+
+**Files:**
+- Modify: `src/finwiz/schemas/stage_contract.py`
+- Test: `tests/unit/schemas/test_stage_contract.py`
+
+- [ ] **Step 1: Write failing tests for I1 (only qualify may DEGRADE) and I3 (fallback_used ⇒ DEGRADED)**
+
+```python
+# Append to tests/unit/schemas/test_stage_contract.py
+import pytest
+from pydantic import ValidationError
+
+from finwiz.schemas.stage_contract import StageOutcome, StageProvenance
+
+
+def test_provenance_ok_for_collect_is_valid() -> None:
+    p = StageProvenance(stage="collect", outcome=StageOutcome.OK, duration_ms=12)
+    assert p.outcome == StageOutcome.OK
+
+
+def test_provenance_failed_with_reason_is_valid() -> None:
+    p = StageProvenance(
+        stage="quantify",
+        outcome=StageOutcome.FAILED,
+        reason="scorer raised",
+        duration_ms=5,
+    )
+    assert p.outcome == StageOutcome.FAILED
+
+
+def test_provenance_degraded_outside_qualify_raises() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        StageProvenance(stage="collect", outcome=StageOutcome.DEGRADED, duration_ms=1)
+    assert "DEGRADED" in str(excinfo.value)
+
+
+def test_provenance_degraded_in_qualify_is_valid() -> None:
+    p = StageProvenance(
+        stage="qualify",
+        outcome=StageOutcome.DEGRADED,
+        fallback_used="python_proxy_qualitative",
+        reason="AI null",
+        duration_ms=3000,
+    )
+    assert p.outcome == StageOutcome.DEGRADED
+
+
+def test_provenance_fallback_without_degraded_raises() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        StageProvenance(
+            stage="qualify",
+            outcome=StageOutcome.OK,
+            fallback_used="python_proxy_qualitative",
+            duration_ms=1,
+        )
+    assert "fallback_used" in str(excinfo.value)
+
+
+def test_provenance_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        StageProvenance(
+            stage="collect",
+            outcome=StageOutcome.OK,
+            duration_ms=1,
+            unknown_field="boom",
+        )
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+Run: `uv run pytest tests/unit/schemas/test_stage_contract.py -v`
+Expected: 6 tests collected, 5 fail with `ImportError` on `StageProvenance`.
+
+- [ ] **Step 3: Add `StageProvenance` model with validators**
+
+```python
+# Append to src/finwiz/schemas/stage_contract.py
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+StageName = Literal["collect", "quantify", "qualify", "synthesize", "emit"]
+
+
+class StageProvenance(BaseModel):
+    """Diagnostic record produced by every stage execution."""
+
+    stage: StageName
+    outcome: StageOutcome
+    reason: str | None = None
+    duration_ms: int
+    retries_used: int = 0
+    fallback_used: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_degraded_only_in_qualify(self) -> "StageProvenance":
+        """Invariant I1: only the `qualify` stage may emit DEGRADED."""
+        if self.outcome == StageOutcome.DEGRADED and self.stage != "qualify":
+            raise ValueError(
+                f"DEGRADED outcome forbidden for stage '{self.stage}'; "
+                "only 'qualify' may degrade"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _check_fallback_implies_degraded(self) -> "StageProvenance":
+        """Invariant I3: fallback_used populated ⇒ outcome == DEGRADED."""
+        if self.fallback_used is not None and self.outcome != StageOutcome.DEGRADED:
+            raise ValueError(
+                f"fallback_used='{self.fallback_used}' requires outcome=DEGRADED, "
+                f"got {self.outcome}"
+            )
+        return self
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+Run: `uv run pytest tests/unit/schemas/test_stage_contract.py -v`
+Expected: 8 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/schemas/stage_contract.py tests/unit/schemas/test_stage_contract.py
+rtk git commit -m "feat(schemas): add StageProvenance with invariants I1+I3"
+```
+
+---
+
+### Task A3: `StageResult[T]` Generic with Invariant I2
+
+**Files:**
+- Modify: `src/finwiz/schemas/stage_contract.py`
+- Test: `tests/unit/schemas/test_stage_contract.py`
+
+- [ ] **Step 1: Write failing tests for I2 (`payload is None` ⇔ FAILED)**
+
+```python
+# Append to tests/unit/schemas/test_stage_contract.py
+from pydantic import BaseModel as _PBM
+
+from finwiz.schemas.stage_contract import StageResult
+
+
+class _Payload(_PBM):
+    value: int
+
+
+def test_result_ok_with_payload_is_valid() -> None:
+    r = StageResult[_Payload](
+        payload=_Payload(value=42),
+        provenance=StageProvenance(stage="collect", outcome=StageOutcome.OK, duration_ms=1),
+    )
+    assert r.payload is not None and r.payload.value == 42
+
+
+def test_result_failed_with_payload_raises() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        StageResult[_Payload](
+            payload=_Payload(value=1),
+            provenance=StageProvenance(
+                stage="collect", outcome=StageOutcome.FAILED, duration_ms=1, reason="boom"
+            ),
+        )
+    assert "FAILED" in str(excinfo.value)
+
+
+def test_result_ok_without_payload_raises() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        StageResult[_Payload](
+            payload=None,
+            provenance=StageProvenance(stage="collect", outcome=StageOutcome.OK, duration_ms=1),
+        )
+    assert "payload" in str(excinfo.value)
+
+
+def test_result_failed_without_payload_is_valid() -> None:
+    r = StageResult[_Payload](
+        payload=None,
+        provenance=StageProvenance(
+            stage="collect", outcome=StageOutcome.FAILED, duration_ms=1, reason="boom"
+        ),
+    )
+    assert r.payload is None
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+Run: `uv run pytest tests/unit/schemas/test_stage_contract.py -v -k result_`
+Expected: 4 tests fail with `ImportError`.
+
+- [ ] **Step 3: Add `StageResult[T]` generic**
+
+```python
+# Append to src/finwiz/schemas/stage_contract.py
+from typing import Generic, TypeVar
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class StageResult(BaseModel, Generic[T]):
+    """Envelope returned by every pipeline stage."""
+
+    payload: T | None
+    provenance: StageProvenance
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_payload_iff_not_failed(self) -> "StageResult[T]":
+        """Invariant I2: payload is None iff outcome == FAILED."""
+        if self.provenance.outcome == StageOutcome.FAILED and self.payload is not None:
+            raise ValueError("FAILED outcome requires payload=None")
+        if self.provenance.outcome != StageOutcome.FAILED and self.payload is None:
+            raise ValueError(
+                f"outcome={self.provenance.outcome} requires payload!=None"
+            )
+        return self
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+Run: `uv run pytest tests/unit/schemas/test_stage_contract.py -v`
+Expected: 12 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/schemas/stage_contract.py tests/unit/schemas/test_stage_contract.py
+rtk git commit -m "feat(schemas): add StageResult[T] with invariant I2"
+```
+
+---
+
+### Task A4: `RunLedgerEntry`, `CoverageSummary`, `TrustBanner` Schemas
+
+**Files:**
+- Create: `src/finwiz/schemas/run_ledger.py`
+- Test: `tests/unit/schemas/test_run_ledger.py`
+
+- [ ] **Step 1: Write failing tests for `RunLedgerEntry`**
+
+```python
+# tests/unit/schemas/test_run_ledger.py
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from finwiz.schemas.run_ledger import (
+    CoverageSummary,
+    RunLedgerEntry,
+    TrustBanner,
+)
+from finwiz.schemas.stage_contract import StageOutcome
+
+
+def test_ledger_entry_minimum_fields() -> None:
+    entry = RunLedgerEntry(
+        run_id="01HZ...",
+        ticker="DELL",
+        started_at=datetime(2026, 4, 27, 9, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 4, 27, 9, 0, 1, tzinfo=timezone.utc),
+        stage="collect",
+        outcome=StageOutcome.OK,
+    )
+    assert entry.cost_usd == 0.0
+    assert entry.retries_used == 0
+
+
+def test_ledger_entry_extra_field_rejected() -> None:
+    with pytest.raises(ValidationError):
+        RunLedgerEntry(
+            run_id="x",
+            ticker="X",
+            started_at=datetime.now(timezone.utc),
+            finished_at=datetime.now(timezone.utc),
+            stage="collect",
+            outcome=StageOutcome.OK,
+            unknown_field=1,
+        )
+```
+
+- [ ] **Step 2: Write failing tests for `TrustBanner` state rules (table-driven)**
+
+```python
+# Append to tests/unit/schemas/test_run_ledger.py
+@pytest.mark.parametrize(
+    ("analyzed", "degraded", "failed", "total", "expected_state", "expected_block"),
+    [
+        # blocked
+        (0, 0, 0, 0, "blocked", True),
+        (0, 0, 0, 5, "blocked", True),
+        (0, 0, 5, 5, "blocked", True),  # zero analyzed even with attempts
+        # red — strictly more than half failed (2 * failed > total)
+        (1, 0, 4, 5, "red", True),  # 2*4=8 > 5
+        (10, 0, 11, 21, "red", True),  # 2*11=22 > 21
+        # amber — degraded > 0 OR 0 < failed and 2*failed <= total
+        (4, 1, 0, 5, "amber", False),
+        (4, 0, 1, 5, "amber", False),  # 2*1=2 <= 5
+        (10, 0, 10, 21, "amber", False),  # 2*10=20 <= 21, not blocked
+        # green — all OK
+        (5, 0, 0, 5, "green", False),
+    ],
+)
+def test_banner_state_rules(
+    analyzed: int,
+    degraded: int,
+    failed: int,
+    total: int,
+    expected_state: str,
+    expected_block: bool,
+) -> None:
+    summary = CoverageSummary(
+        analyzed=analyzed, degraded=degraded, failed=failed, total=total
+    )
+    banner = TrustBanner.from_coverage(summary)
+    assert banner.state == expected_state
+    assert banner.block_decisions is expected_block
+    assert banner.message  # non-empty
+
+
+def test_banner_message_red_includes_warning() -> None:
+    banner = TrustBanner.from_coverage(
+        CoverageSummary(analyzed=1, degraded=0, failed=4, total=5)
+    )
+    assert "NE PAS" in banner.message
+```
+
+- [ ] **Step 3: Run tests, expect failure**
+
+Run: `uv run pytest tests/unit/schemas/test_run_ledger.py -v`
+Expected: All fail with `ImportError`.
+
+- [ ] **Step 4: Create the schemas**
+
+```python
+# src/finwiz/schemas/run_ledger.py
+"""Run ledger entry, coverage summary, and trust banner schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, computed_field, model_validator
+
+from finwiz.schemas.stage_contract import StageName, StageOutcome
+
+
+class RunLedgerEntry(BaseModel):
+    """One row of the persistent run ledger.
+
+    Written as JSONL to ``output/run_ledger/<run_id>.jsonl``.
+    """
+
+    run_id: str
+    ticker: str
+    started_at: datetime
+    finished_at: datetime
+    stage: StageName
+    outcome: StageOutcome
+    reason: str | None = None
+    fallback_used: str | None = None
+    retries_used: int = 0
+    cost_usd: float = 0.0
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class CoverageSummary(BaseModel):
+    """Aggregate counts derived from the ledger."""
+
+    analyzed: int  # holdings whose final stage emitted OK
+    degraded: int  # holdings whose final stage emitted DEGRADED
+    failed: int  # holdings whose pipeline did not produce a verdict
+    total: int  # holdings attempted
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_counts(self) -> "CoverageSummary":
+        if any(v < 0 for v in (self.analyzed, self.degraded, self.failed, self.total)):
+            raise ValueError("counts must be non-negative")
+        if self.analyzed + self.degraded + self.failed > self.total:
+            raise ValueError("analyzed + degraded + failed cannot exceed total")
+        return self
+
+
+class TrustBanner(BaseModel):
+    """User-visible trust banner derived deterministically from coverage."""
+
+    state: Literal["green", "amber", "red", "blocked"]
+    analyzed: int
+    degraded: int
+    failed: int
+    total: int
+    message: str
+    block_decisions: bool
+
+    model_config = ConfigDict(extra="forbid")
+
+    @classmethod
+    def from_coverage(cls, summary: CoverageSummary) -> "TrustBanner":
+        """Apply the deterministic state-rule ladder (top-to-bottom, first match)."""
+        analyzed = summary.analyzed
+        degraded = summary.degraded
+        failed = summary.failed
+        total = summary.total
+
+        if total == 0 or analyzed == 0:
+            state = "blocked"
+            message = (
+                "Aucune analyse complète n'a été produite. "
+                "NE PAS prendre de décisions sur ce rapport."
+            )
+            block = True
+        elif 2 * failed > total:
+            state = "red"
+            message = (
+                f"{failed}/{total} holdings ont échoué. "
+                "NE PAS prendre de décisions sur ce rapport."
+            )
+            block = True
+        elif degraded > 0 or failed > 0:
+            state = "amber"
+            parts = []
+            if degraded:
+                parts.append(f"{degraded} en mode dégradé (proxy quantitatif)")
+            if failed:
+                parts.append(f"{failed} en attente d'analyse")
+            message = "Confiance partielle: " + ", ".join(parts) + "."
+            block = False
+        else:
+            state = "green"
+            message = f"Analyse complète: {analyzed}/{total} holdings."
+            block = False
+
+        return cls(
+            state=state,
+            analyzed=analyzed,
+            degraded=degraded,
+            failed=failed,
+            total=total,
+            message=message,
+            block_decisions=block,
+        )
+```
+
+- [ ] **Step 5: Run tests, expect pass**
+
+Run: `uv run pytest tests/unit/schemas/test_run_ledger.py -v`
+Expected: 12 tests passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add src/finwiz/schemas/run_ledger.py tests/unit/schemas/test_run_ledger.py
+rtk git commit -m "feat(schemas): add RunLedgerEntry, CoverageSummary, TrustBanner"
+```
+
+---
+
+## Phase B — Stage Infrastructure
+
+The `RunLedger`, `@stage` decorator, and AST check. Each is testable in isolation, no behavior change to the pipeline yet.
+
+### Task B1: `RunLedger` Class with JSONL Persistence
+
+**Files:**
+- Create: `src/finwiz/analysis/stages/__init__.py` (empty placeholder)
+- Create: `src/finwiz/analysis/stages/_ledger.py`
+- Test: `tests/unit/analysis/stages/__init__.py` (empty)
+- Test: `tests/unit/analysis/stages/test_ledger.py`
+
+- [ ] **Step 1: Create empty package markers**
+
+```bash
+mkdir -p src/finwiz/analysis/stages tests/unit/analysis/stages
+echo '"""Stage modules for the deep-analysis pipeline."""' > src/finwiz/analysis/stages/__init__.py
+touch tests/unit/analysis/stages/__init__.py
+```
+
+- [ ] **Step 2: Write failing test for record + coverage**
+
+```python
+# tests/unit/analysis/stages/test_ledger.py
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.schemas.run_ledger import RunLedgerEntry
+from finwiz.schemas.stage_contract import StageOutcome
+
+
+def _entry(ticker: str, stage: str, outcome: StageOutcome) -> RunLedgerEntry:
+    now = datetime(2026, 4, 27, 9, 0, tzinfo=timezone.utc)
+    return RunLedgerEntry(
+        run_id="r1",
+        ticker=ticker,
+        started_at=now,
+        finished_at=now,
+        stage=stage,
+        outcome=outcome,
+    )
+
+
+def test_ledger_records_entries_in_memory(tmp_path: Path) -> None:
+    ledger = RunLedger(run_id="r1", artifact_dir=tmp_path)
+    ledger.record(_entry("AAPL", "collect", StageOutcome.OK))
+    ledger.record(_entry("AAPL", "emit", StageOutcome.OK))
+    assert len(ledger.entries) == 2
+
+
+def test_ledger_writes_jsonl(tmp_path: Path) -> None:
+    ledger = RunLedger(run_id="r1", artifact_dir=tmp_path)
+    ledger.record(_entry("AAPL", "collect", StageOutcome.OK))
+    artifact = tmp_path / "r1.jsonl"
+    assert artifact.exists()
+    lines = artifact.read_text().splitlines()
+    assert len(lines) == 1
+    assert "AAPL" in lines[0]
+
+
+def test_ledger_coverage_counts_terminal_stage_only(tmp_path: Path) -> None:
+    ledger = RunLedger(run_id="r1", artifact_dir=tmp_path, total=2)
+    # AAPL succeeds end-to-end
+    for s in ("collect", "quantify", "qualify", "synthesize", "emit"):
+        ledger.record(_entry("AAPL", s, StageOutcome.OK))
+    # MSFT degrades at qualify
+    ledger.record(_entry("MSFT", "collect", StageOutcome.OK))
+    ledger.record(_entry("MSFT", "quantify", StageOutcome.OK))
+    ledger.record(_entry("MSFT", "qualify", StageOutcome.DEGRADED))
+    ledger.record(_entry("MSFT", "synthesize", StageOutcome.OK))
+    ledger.record(_entry("MSFT", "emit", StageOutcome.OK))
+    summary = ledger.coverage()
+    assert summary.analyzed == 1
+    assert summary.degraded == 1
+    assert summary.failed == 0
+    assert summary.total == 2
+
+
+def test_ledger_failed_tickers_lists_unanalyzed(tmp_path: Path) -> None:
+    ledger = RunLedger(run_id="r1", artifact_dir=tmp_path, total=2)
+    ledger.record(_entry("AAPL", "collect", StageOutcome.OK))
+    ledger.record(_entry("AAPL", "emit", StageOutcome.OK))
+    ledger.record(_entry("MSFT", "collect", StageOutcome.FAILED))
+    assert ledger.failed_tickers() == ["MSFT"]
+```
+
+- [ ] **Step 3: Run test, expect failure**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_ledger.py -v`
+Expected: `ImportError: cannot import name 'RunLedger'`.
+
+- [ ] **Step 4: Implement `RunLedger`**
+
+```python
+# src/finwiz/analysis/stages/_ledger.py
+"""Persistent run ledger: append-only JSONL + in-memory accessors."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from threading import Lock
+from typing import Iterable
+
+from finwiz.schemas.run_ledger import (
+    CoverageSummary,
+    RunLedgerEntry,
+    TrustBanner,
+)
+from finwiz.schemas.stage_contract import StageOutcome
+
+_TERMINAL_STAGE = "emit"
+
+
+class RunLedger:
+    """Append-only ledger of stage outcomes for one pipeline kickoff."""
+
+    def __init__(self, run_id: str, artifact_dir: Path, total: int = 0) -> None:
+        self.run_id = run_id
+        self.entries: list[RunLedgerEntry] = []
+        self._total = total
+        self._lock = Lock()
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        self._artifact = artifact_dir / f"{run_id}.jsonl"
+
+    def set_total(self, total: int) -> None:
+        with self._lock:
+            self._total = total
+
+    def record(self, entry: RunLedgerEntry) -> None:
+        with self._lock:
+            self.entries.append(entry)
+            with self._artifact.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry.model_dump(mode="json"), default=str))
+                f.write("\n")
+
+    def _by_ticker_terminal_outcome(self) -> dict[str, StageOutcome]:
+        """Outcome of the terminal `emit` stage per ticker.
+
+        A ticker without a terminal-stage record is treated as FAILED
+        (pipeline did not reach `emit`).
+        """
+        seen: dict[str, StageOutcome] = {}
+        for entry in self.entries:
+            if entry.stage == _TERMINAL_STAGE:
+                seen[entry.ticker] = entry.outcome
+        return seen
+
+    def _all_tickers_attempted(self) -> set[str]:
+        return {e.ticker for e in self.entries}
+
+    def coverage(self) -> CoverageSummary:
+        terminal = self._by_ticker_terminal_outcome()
+        analyzed = sum(1 for o in terminal.values() if o == StageOutcome.OK)
+        # Degraded propagates: emit emits OK but a *prior* qualify was DEGRADED.
+        # Count tickers whose qualify was DEGRADED but whose emit was OK.
+        degraded_qualifies = {
+            e.ticker
+            for e in self.entries
+            if e.stage == "qualify" and e.outcome == StageOutcome.DEGRADED
+        }
+        degraded = sum(
+            1
+            for ticker, terminal_outcome in terminal.items()
+            if ticker in degraded_qualifies and terminal_outcome == StageOutcome.OK
+        )
+        analyzed_clean = analyzed - degraded
+        attempted = self._all_tickers_attempted()
+        failed = len(attempted) - analyzed
+        total = max(self._total, len(attempted))
+        return CoverageSummary(
+            analyzed=analyzed_clean + degraded,
+            degraded=degraded,
+            failed=failed,
+            total=total,
+        )
+
+    def failed_tickers(self) -> list[str]:
+        terminal = self._by_ticker_terminal_outcome()
+        attempted = sorted(self._all_tickers_attempted())
+        return [t for t in attempted if terminal.get(t) != StageOutcome.OK]
+
+    def to_banner(self) -> TrustBanner:
+        return TrustBanner.from_coverage(self.coverage())
+
+    def entries_for(self, ticker: str) -> list[RunLedgerEntry]:
+        return [e for e in self.entries if e.ticker == ticker]
+
+    def append_many(self, entries: Iterable[RunLedgerEntry]) -> None:
+        for e in entries:
+            self.record(e)
+```
+
+- [ ] **Step 5: Run tests, expect pass**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_ledger.py -v`
+Expected: 4 tests passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/__init__.py src/finwiz/analysis/stages/_ledger.py tests/unit/analysis/stages/
+rtk git commit -m "feat(stages): add RunLedger with JSONL persistence and coverage view"
+```
+
+---
+
+### Task B2: `@stage` Decorator — Synchronous Path
+
+**Files:**
+- Create: `src/finwiz/analysis/stages/_resilience.py`
+- Test: `tests/unit/analysis/stages/test_resilience.py`
+
+- [ ] **Step 1: Write failing tests for OK path, exception capture, and allow_degrade enforcement**
+
+```python
+# tests/unit/analysis/stages/test_resilience.py
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.analysis.stages._resilience import StageContext, stage
+from finwiz.schemas.stage_contract import (
+    StageOutcome,
+    StageProvenance,
+    StageResult,
+)
+
+
+class _Payload(BaseModel):
+    value: int
+
+
+def _ctx(tmp_path: Path) -> StageContext:
+    return StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+
+
+@stage(name="collect", timeout_s=5, retries=0)
+def _collect_ok(ctx: StageContext) -> _Payload:
+    return _Payload(value=42)
+
+
+@stage(name="quantify", timeout_s=5, retries=0)
+def _quantify_raises(ctx: StageContext, prev: _Payload) -> _Payload:
+    raise RuntimeError("boom")
+
+
+def test_stage_wraps_return_in_stage_result_ok(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    result = _collect_ok(ctx)
+    assert isinstance(result, StageResult)
+    assert result.provenance.stage == "collect"
+    assert result.provenance.outcome == StageOutcome.OK
+    assert result.payload is not None and result.payload.value == 42
+
+
+def test_stage_records_ledger_entry_on_ok(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    _collect_ok(ctx)
+    assert len(ctx.ledger.entries) == 1
+    assert ctx.ledger.entries[0].outcome == StageOutcome.OK
+
+
+def test_stage_captures_exception_as_failed(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    result = _quantify_raises(ctx, _Payload(value=1))
+    assert result.payload is None
+    assert result.provenance.outcome == StageOutcome.FAILED
+    assert "boom" in (result.provenance.reason or "")
+
+
+def test_stage_records_ledger_entry_on_failure(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    _quantify_raises(ctx, _Payload(value=1))
+    assert ctx.ledger.entries[-1].outcome == StageOutcome.FAILED
+
+
+def test_stage_allow_degrade_outside_qualify_raises_at_decoration() -> None:
+    with pytest.raises(ValueError) as excinfo:
+
+        @stage(name="collect", timeout_s=5, retries=0, allow_degrade=True)
+        def _bad(ctx: StageContext) -> _Payload:
+            return _Payload(value=1)
+
+    assert "allow_degrade" in str(excinfo.value)
+    assert "qualify" in str(excinfo.value)
+
+
+def test_stage_validation_error_not_retried(tmp_path: Path, mocker: Any) -> None:
+    from pydantic import ValidationError
+
+    calls = {"n": 0}
+
+    @stage(name="quantify", timeout_s=5, retries=3)
+    def _validate(ctx: StageContext) -> _Payload:
+        calls["n"] += 1
+        # Force a validation error from pydantic
+        _Payload(value="not-an-int")  # type: ignore[arg-type]
+        return _Payload(value=1)
+
+    ctx = _ctx(tmp_path)
+    _validate(ctx)
+    assert calls["n"] == 1  # no retry on ValidationError
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_resilience.py -v`
+Expected: All fail with `ImportError`.
+
+- [ ] **Step 3: Implement `StageContext` and `@stage` decorator**
+
+```python
+# src/finwiz/analysis/stages/_resilience.py
+"""@stage decorator: timeout, retry, exception capture, ledger record."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from functools import wraps
+from typing import Any, Callable, ParamSpec, TypeVar
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.schemas.run_ledger import RunLedgerEntry
+from finwiz.schemas.stage_contract import (
+    StageName,
+    StageOutcome,
+    StageProvenance,
+    StageResult,
+)
+
+# httpcore is an httpx transitive — guard import to keep optional surface small.
+try:  # pragma: no cover - import guard
+    import httpcore  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover
+    httpcore = None  # type: ignore[assignment]
+
+
+@dataclass
+class StageContext:
+    """Per-holding context threaded through every stage call."""
+
+    ticker: str
+    run_id: str
+    ledger: RunLedger
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+P = ParamSpec("P")
+T = TypeVar("T", bound=BaseModel)
+
+_TRANSIENT_EXC: tuple[type[BaseException], ...]
+_TRANSIENT_EXC = (OSError, asyncio.TimeoutError)
+_TRANSIENT_HTTP_TYPES: tuple[type[BaseException], ...] = (httpx.HTTPStatusError,)
+if httpcore is not None:  # pragma: no branch
+    _TRANSIENT_HTTP_TYPES = (*_TRANSIENT_HTTP_TYPES, httpcore.RemoteProtocolError)
+
+
+def _is_transient(exc: BaseException) -> bool:
+    if isinstance(exc, (ValidationError, AssertionError)):
+        return False
+    if isinstance(exc, _TRANSIENT_EXC):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code >= 500
+    if any(isinstance(exc, t) for t in _TRANSIENT_HTTP_TYPES):
+        return True
+    return False
+
+
+def stage(
+    *,
+    name: StageName,
+    timeout_s: float,
+    retries: int,
+    allow_degrade: bool = False,
+) -> Callable[[Callable[P, T | StageResult[T]]], Callable[P, StageResult[T]]]:
+    """Decorate a stage function with timeout, retry, capture, and ledger record.
+
+    Stage bodies must be idempotent: retries re-execute the full body.
+
+    Raises:
+        ValueError at decoration time if allow_degrade=True for a non-qualify stage.
+    """
+    if allow_degrade and name != "qualify":
+        raise ValueError(
+            f"allow_degrade=True is only valid for stage 'qualify', got '{name}'"
+        )
+
+    def deco(fn: Callable[P, T | StageResult[T]]) -> Callable[P, StageResult[T]]:
+        @wraps(fn)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> StageResult[T]:
+            ctx = _extract_context(args)
+            started = datetime.now(timezone.utc)
+            t0 = time.perf_counter()
+            attempt = 0
+            last_exc: BaseException | None = None
+
+            while attempt <= retries:
+                try:
+                    raw = fn(*args, **kwargs)
+                    result = _coerce_to_stage_result(raw, name=name, t0=t0, attempt=attempt)
+                    if not allow_degrade and result.provenance.outcome == StageOutcome.DEGRADED:
+                        raise ValueError(
+                            f"stage '{name}' returned DEGRADED but allow_degrade=False"
+                        )
+                    _record(ctx, result, started, name)
+                    return result
+                except (ValidationError, AssertionError):
+                    raise
+                except BaseException as exc:  # noqa: BLE001 — intentional capture
+                    last_exc = exc
+                    if not _is_transient(exc) or attempt == retries:
+                        result = _failed_result(name, t0, attempt, exc)
+                        _record(ctx, result, started, name)
+                        return result
+                    attempt += 1
+
+            # unreachable: loop always returns
+            assert last_exc is not None
+            raise last_exc  # pragma: no cover
+
+        return wrapper
+
+    return deco
+
+
+def _extract_context(args: tuple[Any, ...]) -> StageContext:
+    for a in args:
+        if isinstance(a, StageContext):
+            return a
+    raise TypeError("stage function must receive a StageContext as positional arg")
+
+
+def _coerce_to_stage_result(
+    raw: Any, *, name: StageName, t0: float, attempt: int
+) -> StageResult[Any]:
+    if isinstance(raw, StageResult):
+        # Patch retries_used and duration_ms if not set by the body.
+        prov = raw.provenance.model_copy(
+            update={
+                "retries_used": max(raw.provenance.retries_used, attempt),
+                "duration_ms": raw.provenance.duration_ms or _ms_since(t0),
+            }
+        )
+        return StageResult(payload=raw.payload, provenance=prov)
+    return StageResult(
+        payload=raw,
+        provenance=StageProvenance(
+            stage=name,
+            outcome=StageOutcome.OK,
+            duration_ms=_ms_since(t0),
+            retries_used=attempt,
+        ),
+    )
+
+
+def _failed_result(name: StageName, t0: float, attempt: int, exc: BaseException) -> StageResult[Any]:
+    return StageResult(
+        payload=None,
+        provenance=StageProvenance(
+            stage=name,
+            outcome=StageOutcome.FAILED,
+            reason=f"{type(exc).__name__}: {exc}",
+            duration_ms=_ms_since(t0),
+            retries_used=attempt,
+        ),
+    )
+
+
+def _record(
+    ctx: StageContext,
+    result: StageResult[Any],
+    started: datetime,
+    name: StageName,
+) -> None:
+    ctx.ledger.record(
+        RunLedgerEntry(
+            run_id=ctx.run_id,
+            ticker=ctx.ticker,
+            started_at=started,
+            finished_at=datetime.now(timezone.utc),
+            stage=name,
+            outcome=result.provenance.outcome,
+            reason=result.provenance.reason,
+            fallback_used=result.provenance.fallback_used,
+            retries_used=result.provenance.retries_used,
+        )
+    )
+
+
+def _ms_since(t0: float) -> int:
+    return int((time.perf_counter() - t0) * 1000)
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_resilience.py -v`
+Expected: 6 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/_resilience.py tests/unit/analysis/stages/test_resilience.py
+rtk git commit -m "feat(stages): add @stage decorator (sync) with retry/capture/ledger"
+```
+
+---
+
+### Task B3: `@stage` Decorator — Async Path with Timeout
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/_resilience.py`
+- Modify: `tests/unit/analysis/stages/test_resilience.py`
+
+- [ ] **Step 1: Write failing tests for async timeout and async retry**
+
+```python
+# Append to tests/unit/analysis/stages/test_resilience.py
+import asyncio
+
+
+@pytest.mark.asyncio
+async def test_stage_async_ok(tmp_path: Path) -> None:
+    @stage(name="collect", timeout_s=1, retries=0)
+    async def _ac(ctx: StageContext) -> _Payload:
+        await asyncio.sleep(0)
+        return _Payload(value=99)
+
+    ctx = _ctx(tmp_path)
+    result = await _ac(ctx)
+    assert result.provenance.outcome == StageOutcome.OK
+    assert result.payload is not None and result.payload.value == 99
+
+
+@pytest.mark.asyncio
+async def test_stage_async_timeout_becomes_failed(tmp_path: Path) -> None:
+    @stage(name="collect", timeout_s=0.05, retries=0)
+    async def _slow(ctx: StageContext) -> _Payload:
+        await asyncio.sleep(1.0)
+        return _Payload(value=1)
+
+    ctx = _ctx(tmp_path)
+    result = await _slow(ctx)
+    assert result.provenance.outcome == StageOutcome.FAILED
+    assert "TimeoutError" in (result.provenance.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_stage_async_retries_transient(tmp_path: Path) -> None:
+    calls = {"n": 0}
+
+    @stage(name="qualify", timeout_s=1, retries=2, allow_degrade=False)
+    async def _flaky(ctx: StageContext) -> _Payload:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise OSError("transient")
+        return _Payload(value=7)
+
+    ctx = _ctx(tmp_path)
+    result = await _flaky(ctx)
+    assert calls["n"] == 3
+    assert result.provenance.outcome == StageOutcome.OK
+    assert result.provenance.retries_used == 2
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_resilience.py -v -k async`
+Expected: tests fail because the wrapper isn't async-aware (returns coroutine, not StageResult).
+
+- [ ] **Step 3: Add async branch to the decorator**
+
+Replace the `wrapper` portion of `stage(...)` so it dispatches on `inspect.iscoroutinefunction(fn)`:
+
+```python
+# Edit src/finwiz/analysis/stages/_resilience.py
+# Add at top:
+import inspect
+
+# Replace the deco() function with:
+def deco(fn: Callable[P, T | StageResult[T]]) -> Callable[P, StageResult[T]]:
+    if inspect.iscoroutinefunction(fn):
+        @wraps(fn)
+        async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> StageResult[T]:
+            ctx = _extract_context(args)
+            started = datetime.now(timezone.utc)
+            t0 = time.perf_counter()
+            attempt = 0
+            while attempt <= retries:
+                try:
+                    coro = fn(*args, **kwargs)
+                    raw = await asyncio.wait_for(coro, timeout=timeout_s)
+                    result = _coerce_to_stage_result(raw, name=name, t0=t0, attempt=attempt)
+                    if not allow_degrade and result.provenance.outcome == StageOutcome.DEGRADED:
+                        raise ValueError(
+                            f"stage '{name}' returned DEGRADED but allow_degrade=False"
+                        )
+                    _record(ctx, result, started, name)
+                    return result
+                except (ValidationError, AssertionError):
+                    raise
+                except BaseException as exc:  # noqa: BLE001
+                    if not _is_transient(exc) or attempt == retries:
+                        result = _failed_result(name, t0, attempt, exc)
+                        _record(ctx, result, started, name)
+                        return result
+                    attempt += 1
+            raise RuntimeError("unreachable")  # pragma: no cover
+
+        return async_wrapper  # type: ignore[return-value]
+
+    @wraps(fn)
+    def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> StageResult[T]:
+        ctx = _extract_context(args)
+        started = datetime.now(timezone.utc)
+        t0 = time.perf_counter()
+        attempt = 0
+        while attempt <= retries:
+            try:
+                raw = fn(*args, **kwargs)
+                result = _coerce_to_stage_result(raw, name=name, t0=t0, attempt=attempt)
+                if not allow_degrade and result.provenance.outcome == StageOutcome.DEGRADED:
+                    raise ValueError(
+                        f"stage '{name}' returned DEGRADED but allow_degrade=False"
+                    )
+                _record(ctx, result, started, name)
+                return result
+            except (ValidationError, AssertionError):
+                raise
+            except BaseException as exc:  # noqa: BLE001
+                if not _is_transient(exc) or attempt == retries:
+                    result = _failed_result(name, t0, attempt, exc)
+                    _record(ctx, result, started, name)
+                    return result
+                attempt += 1
+        raise RuntimeError("unreachable")  # pragma: no cover
+
+    return sync_wrapper
+```
+
+- [ ] **Step 4: Run all decorator tests**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_resilience.py -v`
+Expected: 9 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/_resilience.py tests/unit/analysis/stages/test_resilience.py
+rtk git commit -m "feat(stages): @stage async path with per-unit timeout"
+```
+
+---
+
+### Task B4: AST Static Check Script
+
+**Files:**
+- Create: `scripts/check_stage_contract.py`
+- Test: `tests/unit/scripts/__init__.py` (empty)
+- Test: `tests/unit/scripts/test_check_stage_contract.py`
+
+- [ ] **Step 1: Write failing tests against synthetic offending source**
+
+```python
+# tests/unit/scripts/test_check_stage_contract.py
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.check_stage_contract import check_directory
+
+
+def _write(tmp_path: Path, name: str, src: str) -> Path:
+    p = tmp_path / name
+    p.write_text(src)
+    return p
+
+
+def test_check_passes_clean_source(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "ok.py",
+        "import asyncio\n"
+        "async def f():\n"
+        "    await asyncio.gather(*[g()], return_exceptions=True)\n"
+        "async def g():\n"
+        "    return 1\n",
+    )
+    violations = check_directory(tmp_path)
+    assert violations == []
+
+
+def test_check_flags_gather_without_return_exceptions(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "bad.py",
+        "import asyncio\nasync def f():\n    await asyncio.gather(*[g()])\n"
+        "async def g():\n    return 1\n",
+    )
+    violations = check_directory(tmp_path)
+    assert any("return_exceptions=True" in v.message for v in violations)
+
+
+def test_check_flags_allow_degrade_outside_qualify(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "collect.py",
+        "from finwiz.analysis.stages._resilience import stage\n"
+        "@stage(name='collect', timeout_s=5, retries=0, allow_degrade=True)\n"
+        "def f(ctx): return None\n",
+    )
+    violations = check_directory(tmp_path)
+    assert any("allow_degrade" in v.message and "qualify" in v.message for v in violations)
+
+
+def test_check_allows_allow_degrade_in_qualify(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "qualify.py",
+        "from finwiz.analysis.stages._resilience import stage\n"
+        "@stage(name='qualify', timeout_s=5, retries=0, allow_degrade=True)\n"
+        "def f(ctx): return None\n",
+    )
+    violations = check_directory(tmp_path)
+    assert violations == []
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/unit/scripts/test_check_stage_contract.py -v`
+Expected: `ImportError`.
+
+- [ ] **Step 3: Implement the AST checker**
+
+```python
+# scripts/check_stage_contract.py
+"""AST static check enforcing stage-contract rules under analysis/stages/.
+
+Run from CI:
+    uv run python -m scripts.check_stage_contract src/finwiz/analysis/stages
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    message: str
+
+
+def check_directory(path: Path) -> list[Violation]:
+    """Walk *path* and collect violations in every .py file."""
+    violations: list[Violation] = []
+    for py in path.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(), filename=str(py))
+        except SyntaxError as exc:  # pragma: no cover
+            violations.append(Violation(str(py), exc.lineno or 0, f"syntax error: {exc.msg}"))
+            continue
+        violations.extend(_check_file(py, tree))
+    return violations
+
+
+def _check_file(file: Path, tree: ast.AST) -> list[Violation]:
+    violations: list[Violation] = []
+    is_qualify = file.name == "qualify.py"
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            v = _check_call(file, node, is_qualify)
+            if v:
+                violations.append(v)
+    return violations
+
+
+def _check_call(file: Path, node: ast.Call, is_qualify: bool) -> Violation | None:
+    """Inspect one Call node for known offending patterns."""
+    fname = _fully_qualified(node.func)
+    # asyncio.gather without return_exceptions=True
+    if fname == "asyncio.gather":
+        kw = {k.arg: k.value for k in node.keywords if k.arg}
+        ret_exc = kw.get("return_exceptions")
+        if not (isinstance(ret_exc, ast.Constant) and ret_exc.value is True):
+            return Violation(
+                str(file),
+                node.lineno,
+                "asyncio.gather under analysis/stages/ must use return_exceptions=True",
+            )
+    # @stage(allow_degrade=True) outside qualify.py
+    if fname == "stage":
+        for kw in node.keywords:
+            if kw.arg == "allow_degrade" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                if not is_qualify:
+                    return Violation(
+                        str(file),
+                        node.lineno,
+                        "allow_degrade=True forbidden outside qualify.py (only 'qualify' may DEGRADE)",
+                    )
+    return None
+
+
+def _fully_qualified(node: ast.AST) -> str:
+    if isinstance(node, ast.Attribute):
+        return f"{_fully_qualified(node.value)}.{node.attr}"
+    if isinstance(node, ast.Name):
+        return node.id
+    return ""
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: check_stage_contract.py <path>", file=sys.stderr)
+        return 2
+    target = Path(argv[1])
+    if not target.exists():
+        print(f"path does not exist: {target}", file=sys.stderr)
+        return 2
+    violations = check_directory(target)
+    if not violations:
+        print(f"check_stage_contract: {target} clean")
+        return 0
+    for v in violations:
+        print(f"{v.file}:{v.line}: {v.message}", file=sys.stderr)
+    print(f"check_stage_contract: {len(violations)} violation(s)", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv))
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+Run: `uv run pytest tests/unit/scripts/test_check_stage_contract.py -v`
+Expected: 4 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add scripts/check_stage_contract.py tests/unit/scripts/
+rtk git commit -m "feat(scripts): AST check for stage-contract violations"
+```
+
+---
+
+## Phase C — Stage Extraction (Commit 1: Facade)
+
+Move existing stage functions verbatim from `deep_analysis_pipeline.py` into stage modules. Keep the original module as a re-exporting facade. Existing tests must remain green throughout.
+
+### Task C1: Extract Helper Utilities
+
+**Files:**
+- Create: `src/finwiz/analysis/_helpers.py`
+- Modify: `src/finwiz/analysis/deep_analysis_pipeline.py`
+- Test: `tests/unit/analysis/test_helpers.py` (smoke)
+
+- [ ] **Step 1: Write smoke test for the helpers**
+
+```python
+# tests/unit/analysis/test_helpers.py
+from finwiz.analysis._helpers import (
+    _build_sentiment_summary,
+    _filter_numeric_values,
+    _summarize_metrics,
+    _today_french,
+    _truncate_text,
+)
+
+
+def test_today_french_returns_long_date_string() -> None:
+    out = _today_french()
+    assert any(month in out for month in ["janvier", "février", "mars", "avril",
+                                          "mai", "juin", "juillet", "août",
+                                          "septembre", "octobre", "novembre", "décembre"])
+
+
+def test_filter_numeric_values_drops_non_numeric() -> None:
+    assert _filter_numeric_values({"a": 1, "b": "x", "c": 2.5, "d": None}) == {"a": 1.0, "c": 2.5}
+
+
+def test_truncate_text_caps_length() -> None:
+    assert len(_truncate_text("x" * 1000, max_chars=100)) <= 100 + 1  # +1 for ellipsis
+
+
+def test_summarize_metrics_returns_string() -> None:
+    out = _summarize_metrics({"pe_ratio": 18.5, "roe": 0.22}, max_items=10)
+    assert "pe_ratio" in out
+```
+
+- [ ] **Step 2: Move the helper functions verbatim from `deep_analysis_pipeline.py`**
+
+In `src/finwiz/analysis/deep_analysis_pipeline.py`, locate these private helpers and move them — body unchanged — to `src/finwiz/analysis/_helpers.py`:
+
+| Function | Current location | Destination |
+|----------|------------------|-------------|
+| `_today_french` | line 601 | `_helpers.py` |
+| `_summarize_metrics` | line 556 | `_helpers.py` |
+| `_truncate_text` | line 584 | `_helpers.py` |
+| `_filter_numeric_values` | line 669 | `_helpers.py` |
+| `_build_sentiment_summary` | line 477 | `_helpers.py` |
+| `_get_analysis_crew` | line 548 | `_helpers.py` |
+| `_build_crew_inputs` | line 612 | `_helpers.py` |
+
+Add backwards-compat re-exports in `deep_analysis_pipeline.py` so internal callers still resolve:
+
+```python
+# At top of src/finwiz/analysis/deep_analysis_pipeline.py
+from finwiz.analysis._helpers import (
+    _build_crew_inputs,
+    _build_sentiment_summary,
+    _filter_numeric_values,
+    _get_analysis_crew,
+    _summarize_metrics,
+    _today_french,
+    _truncate_text,
+)
+```
+
+- [ ] **Step 3: Run helper tests + existing pipeline tests**
+
+```bash
+uv run pytest tests/unit/analysis/test_helpers.py tests/unit/analysis/test_deep_analysis_pipeline.py -v
+```
+
+Expected: All pass.
+
+- [ ] **Step 4: Run full unit suite**
+
+Run: `make test`
+Expected: All previously passing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/_helpers.py src/finwiz/analysis/deep_analysis_pipeline.py tests/unit/analysis/test_helpers.py
+rtk git commit -m "refactor(analysis): extract private helpers to _helpers.py"
+```
+
+---
+
+### Task C2: Extract `collect` Stage (Verbatim)
+
+**Files:**
+- Create: `src/finwiz/analysis/stages/collect.py`
+- Modify: `src/finwiz/analysis/deep_analysis_pipeline.py`
+
+- [ ] **Step 1: Move `collect_raw_data` body from line 56 to `stages/collect.py`**
+
+```python
+# src/finwiz/analysis/stages/collect.py
+"""Collect stage: pure-Python raw-data gathering for one holding."""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Move the existing collect_raw_data function body here.
+# Imports it currently uses (datetime, SimpleNamespace, DeepAnalysisDataCollector,
+# SentimentMacroCollector, finwiz.flow_state_models.DeepAnalysisResult, etc.)
+# get hoisted to the top of this file. NO behavior change.
+
+def collect_raw_data(
+    ctx: Any,  # AnalysisContext — keep current signature exactly
+) -> dict[str, Any]:
+    """Collect raw market/fundamental/sentiment data. (Body moved verbatim.)"""
+    # ... move existing implementation here exactly as in deep_analysis_pipeline.py:56-110
+    ...
+```
+
+The engineer must paste the existing implementation verbatim (including all `from ... import ...` statements that were inside the function body — they can stay inside or move to module top, but no logic changes).
+
+- [ ] **Step 2: Replace `collect_raw_data` in `deep_analysis_pipeline.py` with re-export**
+
+```python
+# In deep_analysis_pipeline.py replace the original definition with:
+from finwiz.analysis.stages.collect import collect_raw_data  # noqa: F401
+```
+
+- [ ] **Step 3: Run all existing pipeline tests**
+
+Run: `uv run pytest tests/unit/analysis/test_deep_analysis_pipeline.py -v`
+Expected: All pass.
+
+- [ ] **Step 4: Run full unit suite**
+
+Run: `make test`
+Expected: Pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/collect.py src/finwiz/analysis/deep_analysis_pipeline.py
+rtk git commit -m "refactor(analysis): extract collect stage to stages/collect.py"
+```
+
+---
+
+### Task C3: Extract `quantify` Stage (Verbatim)
+
+**Files:**
+- Create: `src/finwiz/analysis/stages/quantify.py`
+- Modify: `src/finwiz/analysis/deep_analysis_pipeline.py`
+
+- [ ] **Step 1: Move `calculate_quantitative` (line 111) to `stages/quantify.py`**
+
+```python
+# src/finwiz/analysis/stages/quantify.py
+"""Quantify stage: deterministic Python scoring."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from finwiz.schemas.hybrid_analysis import QuantitativeAnalysis
+
+
+def calculate_quantitative(ctx: Any, raw: dict[str, Any]) -> QuantitativeAnalysis:
+    # Body moved verbatim from deep_analysis_pipeline.py:111-135
+    ...
+```
+
+- [ ] **Step 2: Replace original with re-export**
+
+```python
+# In deep_analysis_pipeline.py:
+from finwiz.analysis.stages.quantify import calculate_quantitative  # noqa: F401
+```
+
+- [ ] **Step 3: Run pipeline + all tests**
+
+```bash
+uv run pytest tests/unit/analysis/ -v
+make test
+```
+
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/quantify.py src/finwiz/analysis/deep_analysis_pipeline.py
+rtk git commit -m "refactor(analysis): extract quantify stage to stages/quantify.py"
+```
+
+---
+
+### Task C4: Extract `qualify` Stage (Verbatim)
+
+**Files:**
+- Create: `src/finwiz/analysis/stages/qualify.py`
+- Modify: `src/finwiz/analysis/deep_analysis_pipeline.py`
+
+- [ ] **Step 1: Move `generate_qualitative` (line 136) and its support functions to `stages/qualify.py`**
+
+Move these functions verbatim:
+
+| Function | Line |
+|----------|------|
+| `generate_qualitative` | 136 |
+| `_run_qualitative_and_strategic_in_parallel` | 372 |
+| `_safe_strategic` | 409 |
+| `_extract_qualitative` | 722 |
+| `_create_python_qualitative` | 786 |
+| `_create_fallback_qualitative` | 934 |
+| `_has_qualitative_content` | 707 |
+
+- [ ] **Step 2: Re-export from `deep_analysis_pipeline.py`**
+
+```python
+from finwiz.analysis.stages.qualify import (  # noqa: F401
+    generate_qualitative,
+    _create_python_qualitative,
+    _create_fallback_qualitative,
+    _has_qualitative_content,
+)
+```
+
+- [ ] **Step 3: Run pipeline + all tests**
+
+```bash
+uv run pytest tests/unit/analysis/ -v
+make test
+```
+
+Expected: Pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/qualify.py src/finwiz/analysis/deep_analysis_pipeline.py
+rtk git commit -m "refactor(analysis): extract qualify stage to stages/qualify.py"
+```
+
+---
+
+### Task C5: Extract `synthesize` Stage (Verbatim)
+
+**Files:**
+- Create: `src/finwiz/analysis/stages/synthesize.py`
+- Modify: `src/finwiz/analysis/deep_analysis_pipeline.py`
+
+- [ ] **Step 1: Move `synthesize_enriched_analysis` (line 197) and supporting fns**
+
+| Function | Line |
+|----------|------|
+| `synthesize_enriched_analysis` | 197 |
+| `_synthesize_recommendation` | 988 |
+| `_compute_scenario_probabilities` | 1001 |
+| `_bs_nd2` | 1017 |
+| `_compute_options_probabilities` | 1029 |
+| `_apply_strategic_recompute` | 425 |
+| `_result_to_quantitative` | 676 |
+
+- [ ] **Step 2: Re-export from facade**
+
+```python
+from finwiz.analysis.stages.synthesize import synthesize_enriched_analysis  # noqa: F401
+```
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+make test
+```
+
+Expected: Pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/synthesize.py src/finwiz/analysis/deep_analysis_pipeline.py
+rtk git commit -m "refactor(analysis): extract synthesize stage to stages/synthesize.py"
+```
+
+---
+
+### Task C6: Extract `emit` Stage and `analyze_holding` Wrapper
+
+**Files:**
+- Create: `src/finwiz/analysis/stages/emit.py`
+- Modify: `src/finwiz/analysis/deep_analysis_pipeline.py`
+
+- [ ] **Step 1: Move `analyze_holding` (line 320) to `stages/emit.py` as `build_verdict`**
+
+```python
+# src/finwiz/analysis/stages/emit.py
+"""Emit stage: produce DeepAnalysisResult or AnalysePending."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from finwiz.flow_state_models import DeepAnalysisResult
+
+
+def build_verdict(ctx: Any, enriched: Any) -> DeepAnalysisResult:
+    """Build the user-visible verdict from the enriched analysis.
+
+    Body moved verbatim from deep_analysis_pipeline.py:320-371 (analyze_holding's
+    final assembly portion). The orchestration of stage calls moves to
+    `stages/__init__.py:run_pipeline` in Task C7.
+    """
+    ...
+```
+
+For this task only the **build_verdict** body moves; the pipeline orchestration (`analyze_holding` calling each stage in order) stays in `deep_analysis_pipeline.py` as a wrapper for now.
+
+- [ ] **Step 2: Update facade to call build_verdict at end of analyze_holding**
+
+```python
+# Within deep_analysis_pipeline.py — replace the final-assembly block of analyze_holding with:
+from finwiz.analysis.stages.emit import build_verdict
+...
+return build_verdict(ctx, enriched)
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `make test`
+Expected: Pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/emit.py src/finwiz/analysis/deep_analysis_pipeline.py
+rtk git commit -m "refactor(analysis): extract emit stage to stages/emit.py"
+```
+
+---
+
+### Task C7: Hoist `run_pipeline` Orchestration into `stages/__init__.py`
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/__init__.py`
+- Modify: `src/finwiz/analysis/deep_analysis_pipeline.py`
+
+- [ ] **Step 1: Move `analyze_holding`'s sequential orchestration into `run_pipeline`**
+
+```python
+# src/finwiz/analysis/stages/__init__.py
+"""Public stages package surface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from finwiz.analysis.stages.collect import collect_raw_data
+from finwiz.analysis.stages.emit import build_verdict
+from finwiz.analysis.stages.qualify import generate_qualitative
+from finwiz.analysis.stages.quantify import calculate_quantitative
+from finwiz.analysis.stages.synthesize import synthesize_enriched_analysis
+from finwiz.flow_state_models import DeepAnalysisResult
+
+
+def run_pipeline(ctx: Any) -> DeepAnalysisResult:
+    """Sequential orchestration of the five deep-analysis stages.
+
+    Mirrors the original analyze_holding control flow exactly. A later task
+    promotes each call site to use the @stage decorator and StageResult envelope.
+    """
+    raw = collect_raw_data(ctx)
+    quant = calculate_quantitative(ctx, raw)
+    qual = generate_qualitative(ctx, quant, raw)
+    enriched = synthesize_enriched_analysis(ctx, quant, qual, raw)
+    return build_verdict(ctx, enriched)
+```
+
+- [ ] **Step 2: Make `analyze_holding` a thin facade**
+
+```python
+# src/finwiz/analysis/deep_analysis_pipeline.py — replace analyze_holding with:
+from finwiz.analysis.stages import run_pipeline
+from finwiz.flow_state_models import DeepAnalysisResult
+
+
+def analyze_holding(ctx: AnalysisContext) -> DeepAnalysisResult:
+    """Backwards-compatible facade calling the new pipeline."""
+    return run_pipeline(ctx)
+```
+
+`AnalysisContext` (line 47) stays in `deep_analysis_pipeline.py` for now — moving it to `stages/_context.py` is out of scope for v5.1 to keep the diff bounded.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `make test`
+Expected: Pass.
+
+- [ ] **Step 4: Verify file shrunk**
+
+```bash
+wc -l src/finwiz/analysis/deep_analysis_pipeline.py
+```
+
+Expected: ~80–150 lines (down from 1209).
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/__init__.py src/finwiz/analysis/deep_analysis_pipeline.py
+rtk git commit -m "refactor(analysis): move pipeline orchestration to stages.run_pipeline"
+```
+
+---
+
+## Phase D — Contract Wiring (Commit 2: Contract)
+
+Each stage gains the `@stage` decorator and returns `StageResult[T]`. The orchestrator and report use `RunLedger` instead of `_failed_holdings`.
+
+### Task D1: Wire `collect` to Return `StageResult[CollectedData]`
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/collect.py`
+- Create: `src/finwiz/schemas/hybrid_analysis/collected.py` (small wrapper if needed — see step 1)
+- Modify: `src/finwiz/analysis/stages/__init__.py`
+- Test: `tests/unit/analysis/stages/test_collect.py`
+
+- [ ] **Step 1: Decide on payload type**
+
+`collect_raw_data` currently returns `dict[str, Any]`. `StageResult` requires `T: BaseModel`. Wrap with a thin Pydantic model:
+
+```python
+# src/finwiz/schemas/hybrid_analysis/collected.py
+"""Payload model for the collect stage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CollectedData(BaseModel):
+    """Wrapper around the dict produced by collect.
+
+    The shape stays a free-form dict because the underlying tools return
+    heterogenous structures (price history, fundamentals, sentiment, macro).
+    Tightening the schema is out of scope for v5.1.
+    """
+
+    data: dict[str, Any]
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+```
+
+Add to `src/finwiz/schemas/hybrid_analysis/__init__.py`:
+
+```python
+from finwiz.schemas.hybrid_analysis.collected import CollectedData  # noqa: F401
+```
+
+- [ ] **Step 2: Write failing test for collect's StageResult contract**
+
+```python
+# tests/unit/analysis/stages/test_collect.py
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.analysis.stages._resilience import StageContext
+from finwiz.analysis.stages.collect import collect
+from finwiz.schemas.hybrid_analysis.collected import CollectedData
+from finwiz.schemas.stage_contract import StageOutcome, StageResult
+
+
+def test_collect_returns_stage_result(tmp_path: Path, mocker: Any) -> None:
+    mocker.patch(
+        "finwiz.analysis.stages.collect._collect_raw_data_inner",
+        return_value={"price_history": [1, 2, 3]},
+    )
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    result = collect(ctx)
+    assert isinstance(result, StageResult)
+    assert result.provenance.outcome == StageOutcome.OK
+    assert isinstance(result.payload, CollectedData)
+    assert result.payload.data == {"price_history": [1, 2, 3]}
+
+
+def test_collect_records_ledger_entry(tmp_path: Path, mocker: Any) -> None:
+    mocker.patch(
+        "finwiz.analysis.stages.collect._collect_raw_data_inner",
+        return_value={},
+    )
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    collect(ctx)
+    assert any(e.stage == "collect" for e in ctx.ledger.entries)
+
+
+def test_collect_failure_becomes_failed_outcome(tmp_path: Path, mocker: Any) -> None:
+    mocker.patch(
+        "finwiz.analysis.stages.collect._collect_raw_data_inner",
+        side_effect=RuntimeError("data source down"),
+    )
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    result = collect(ctx)
+    assert result.payload is None
+    assert result.provenance.outcome == StageOutcome.FAILED
+    assert "data source down" in (result.provenance.reason or "")
+```
+
+- [ ] **Step 3: Run, expect failure**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_collect.py -v`
+Expected: ImportError on `collect`.
+
+- [ ] **Step 4: Wire the decorator**
+
+```python
+# src/finwiz/analysis/stages/collect.py
+"""Collect stage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from finwiz.analysis.stages._resilience import StageContext, stage
+from finwiz.schemas.hybrid_analysis.collected import CollectedData
+
+
+def _collect_raw_data_inner(ctx: Any) -> dict[str, Any]:
+    """The original collect_raw_data body — extracted for testability."""
+    # ... existing body verbatim ...
+    ...
+
+
+@stage(name="collect", timeout_s=120, retries=1)
+def collect(ctx: StageContext) -> CollectedData:
+    """Stage entry point: wraps the raw-data collector in a typed payload."""
+    raw = _collect_raw_data_inner(ctx)
+    return CollectedData(data=raw)
+
+
+# Backwards-compatible export for existing callers
+def collect_raw_data(ctx: Any) -> dict[str, Any]:
+    """Legacy entry point used by the facade."""
+    return _collect_raw_data_inner(ctx)
+```
+
+- [ ] **Step 5: Update `run_pipeline` to use `collect` + thread `StageContext`**
+
+```python
+# src/finwiz/analysis/stages/__init__.py
+def run_pipeline(ctx: Any, stage_ctx: StageContext) -> DeepAnalysisResult:
+    cr = collect(stage_ctx)
+    if cr.payload is None:
+        return _emit_pending(ctx, stage_ctx, reason=cr.provenance.reason)
+    raw = cr.payload.data
+    quant = calculate_quantitative(ctx, raw)
+    qual = generate_qualitative(ctx, quant, raw)
+    enriched = synthesize_enriched_analysis(ctx, quant, qual, raw)
+    return build_verdict(ctx, enriched)
+```
+
+`_emit_pending` is a small helper that returns a `DeepAnalysisResult` with `grade="N/A"` and the existing "Analyse en attente" prose — defined in `stages/emit.py`.
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+uv run pytest tests/unit/analysis/stages/test_collect.py -v
+make test
+```
+
+Expected: Pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/collect.py src/finwiz/analysis/stages/__init__.py src/finwiz/schemas/hybrid_analysis/collected.py tests/unit/analysis/stages/test_collect.py
+rtk git commit -m "feat(stages): wire collect stage to StageResult contract"
+```
+
+---
+
+### Task D2: Wire `quantify` to `StageResult[QuantitativeAnalysis]`
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/quantify.py`
+- Modify: `src/finwiz/analysis/stages/__init__.py`
+- Test: `tests/unit/analysis/stages/test_quantify.py`
+
+- [ ] **Step 1: Write failing test mirroring D1's pattern**
+
+```python
+# tests/unit/analysis/stages/test_quantify.py
+from pathlib import Path
+from typing import Any
+
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.analysis.stages._resilience import StageContext
+from finwiz.analysis.stages.quantify import quantify
+from finwiz.schemas.hybrid_analysis import QuantitativeAnalysis
+from finwiz.schemas.stage_contract import StageOutcome
+
+
+def test_quantify_returns_ok_with_quantitative(tmp_path: Path, mocker: Any) -> None:
+    fake = QuantitativeAnalysis.model_construct()  # use construct to bypass strict validators in test
+    mocker.patch(
+        "finwiz.analysis.stages.quantify._calculate_quantitative_inner",
+        return_value=fake,
+    )
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    result = quantify(ctx, {})
+    assert result.provenance.outcome == StageOutcome.OK
+    assert result.payload is fake
+
+
+def test_quantify_failure_records_failed(tmp_path: Path, mocker: Any) -> None:
+    mocker.patch(
+        "finwiz.analysis.stages.quantify._calculate_quantitative_inner",
+        side_effect=ValueError("scorer error"),
+    )
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    result = quantify(ctx, {})
+    assert result.payload is None
+    assert result.provenance.outcome == StageOutcome.FAILED
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_quantify.py -v`
+Expected: ImportError on `quantify`.
+
+- [ ] **Step 3: Add the wrapper**
+
+```python
+# src/finwiz/analysis/stages/quantify.py — append:
+from finwiz.analysis.stages._resilience import StageContext, stage
+
+
+def _calculate_quantitative_inner(ctx: Any, raw: dict[str, Any]) -> QuantitativeAnalysis:
+    """Original calculate_quantitative body — extracted for testability."""
+    # ... existing body ...
+    ...
+
+
+@stage(name="quantify", timeout_s=30, retries=0)
+def quantify(ctx: StageContext, raw: dict[str, Any]) -> QuantitativeAnalysis:
+    return _calculate_quantitative_inner(ctx, raw)
+```
+
+`calculate_quantitative` (the legacy name) stays as a thin caller of `_calculate_quantitative_inner` for the facade.
+
+- [ ] **Step 4: Update `run_pipeline` to use `quantify`**
+
+```python
+# stages/__init__.py
+qr = quantify(stage_ctx, raw)
+if qr.payload is None:
+    return _emit_pending(ctx, stage_ctx, reason=qr.provenance.reason)
+quant = qr.payload
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+make test
+```
+
+Expected: Pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/quantify.py src/finwiz/analysis/stages/__init__.py tests/unit/analysis/stages/test_quantify.py
+rtk git commit -m "feat(stages): wire quantify stage to StageResult contract"
+```
+
+---
+
+### Task D3: Wire `qualify` to `StageResult[QualitativeInsights]` (No Degrade Yet)
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/qualify.py`
+- Modify: `src/finwiz/analysis/stages/__init__.py`
+- Test: `tests/unit/analysis/stages/test_qualify.py`
+
+- [ ] **Step 1: Write failing test for OK path**
+
+```python
+# tests/unit/analysis/stages/test_qualify.py
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.analysis.stages._resilience import StageContext
+from finwiz.analysis.stages.qualify import qualify
+from finwiz.schemas.hybrid_analysis import QualitativeInsights, QuantitativeAnalysis
+from finwiz.schemas.stage_contract import StageOutcome
+
+
+def test_qualify_ok_when_ai_returns_valid(tmp_path: Path, mocker: Any) -> None:
+    fake_qual = QualitativeInsights.model_construct()
+    mocker.patch(
+        "finwiz.analysis.stages.qualify._try_ai_qualify",
+        return_value=fake_qual,
+    )
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    quant = QuantitativeAnalysis.model_construct()
+    result = qualify(ctx, quant, {})
+    assert result.provenance.outcome == StageOutcome.OK
+    assert result.payload is fake_qual
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_qualify.py -v`
+Expected: ImportError.
+
+- [ ] **Step 3: Wire the decorator (degrade still implicit/silent for now)**
+
+```python
+# src/finwiz/analysis/stages/qualify.py — append:
+from finwiz.analysis.stages._resilience import StageContext, stage
+
+
+def _try_ai_qualify(ctx: Any, quant: Any, raw: dict[str, Any]) -> QualitativeInsights | None:
+    """Run the qualitative crew. Return None on null/empty/failure.
+
+    Body is the AI-call portion of the existing generate_qualitative function.
+    """
+    # ... existing implementation ...
+    ...
+
+
+def _python_proxy_qualify(ctx: Any, quant: Any) -> QualitativeInsights:
+    """Python-derived qualitative proxy. Existing body of _create_python_qualitative."""
+    ...
+
+
+@stage(name="qualify", timeout_s=180, retries=2, allow_degrade=True)
+def qualify(ctx: StageContext, quant: Any, raw: dict[str, Any]) -> QualitativeInsights:
+    """Qualitative stage — degrade branch wired in Task E1."""
+    ai = _try_ai_qualify(ctx, quant, raw)
+    if ai is not None:
+        return ai
+    # Temporary: still silent for v5.1 contract phase. Task E1 flips this to DEGRADED.
+    return _python_proxy_qualify(ctx, quant)
+```
+
+- [ ] **Step 4: Update run_pipeline**
+
+```python
+# stages/__init__.py
+ql = qualify(stage_ctx, quant, raw)
+if ql.payload is None:
+    return _emit_pending(ctx, stage_ctx, reason=ql.provenance.reason)
+qual = ql.payload
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+make test
+```
+
+Expected: Pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/qualify.py src/finwiz/analysis/stages/__init__.py tests/unit/analysis/stages/test_qualify.py
+rtk git commit -m "feat(stages): wire qualify stage to StageResult (degrade in E1)"
+```
+
+---
+
+### Task D4: Wire `synthesize` to `StageResult[EnrichedAnalysis]`
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/synthesize.py`
+- Modify: `src/finwiz/analysis/stages/__init__.py`
+- Test: `tests/unit/analysis/stages/test_synthesize.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/unit/analysis/stages/test_synthesize.py
+from pathlib import Path
+from typing import Any
+
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.analysis.stages._resilience import StageContext
+from finwiz.analysis.stages.synthesize import synthesize
+from finwiz.schemas.hybrid_analysis import (
+    EnrichedAnalysis,
+    QualitativeInsights,
+    QuantitativeAnalysis,
+)
+from finwiz.schemas.stage_contract import StageOutcome
+
+
+def test_synthesize_returns_ok(tmp_path: Path, mocker: Any) -> None:
+    enriched = EnrichedAnalysis.model_construct()
+    mocker.patch(
+        "finwiz.analysis.stages.synthesize._synthesize_inner",
+        return_value=enriched,
+    )
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    result = synthesize(
+        ctx,
+        QuantitativeAnalysis.model_construct(),
+        QualitativeInsights.model_construct(),
+        {},
+    )
+    assert result.provenance.outcome == StageOutcome.OK
+    assert result.payload is enriched
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_synthesize.py -v`
+
+- [ ] **Step 3: Wire decorator**
+
+```python
+# Append to src/finwiz/analysis/stages/synthesize.py
+from finwiz.analysis.stages._resilience import StageContext, stage
+
+
+def _synthesize_inner(
+    ctx: Any, quant: Any, qual: Any, raw: dict[str, Any]
+) -> EnrichedAnalysis:
+    # original synthesize_enriched_analysis body
+    ...
+
+
+@stage(name="synthesize", timeout_s=30, retries=0)
+def synthesize(
+    ctx: StageContext,
+    quant: QuantitativeAnalysis,
+    qual: QualitativeInsights,
+    raw: dict[str, Any],
+) -> EnrichedAnalysis:
+    return _synthesize_inner(ctx, quant, qual, raw)
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+make test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/synthesize.py src/finwiz/analysis/stages/__init__.py tests/unit/analysis/stages/test_synthesize.py
+rtk git commit -m "feat(stages): wire synthesize stage to StageResult"
+```
+
+---
+
+### Task D5: Wire `emit` to `StageResult[DeepAnalysisResult]` + AnalysePending
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/emit.py`
+- Modify: `src/finwiz/analysis/stages/__init__.py`
+- Test: `tests/unit/analysis/stages/test_emit.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/unit/analysis/stages/test_emit.py
+from pathlib import Path
+from typing import Any
+
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.analysis.stages._resilience import StageContext
+from finwiz.analysis.stages.emit import emit, _emit_pending
+from finwiz.flow_state_models import DeepAnalysisResult
+from finwiz.schemas.hybrid_analysis import EnrichedAnalysis
+from finwiz.schemas.stage_contract import StageOutcome
+
+
+def test_emit_ok_returns_verdict(tmp_path: Path, mocker: Any) -> None:
+    verdict = DeepAnalysisResult(ticker="AAPL", grade="A", composite_score=0.9, recommendation="BUY")
+    mocker.patch("finwiz.analysis.stages.emit._build_verdict_inner", return_value=verdict)
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    result = emit(ctx, EnrichedAnalysis.model_construct())
+    assert result.provenance.outcome == StageOutcome.OK
+    assert result.payload is verdict
+
+
+def test_emit_pending_returns_na_grade(tmp_path: Path) -> None:
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    pending = _emit_pending(ctx, reason="upstream collect failure")
+    assert pending.grade == "N/A"
+    assert pending.composite_score == 0.0
+    assert "Analyse en attente" in pending.recommended_action
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_emit.py -v`
+
+- [ ] **Step 3: Implement emit + _emit_pending**
+
+```python
+# src/finwiz/analysis/stages/emit.py
+"""Emit stage: produce DeepAnalysisResult or AnalysePending."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from finwiz.analysis.stages._resilience import StageContext, stage
+from finwiz.flow_state_models import DeepAnalysisResult
+from finwiz.schemas.hybrid_analysis import EnrichedAnalysis
+
+
+def _build_verdict_inner(ctx: Any, enriched: EnrichedAnalysis) -> DeepAnalysisResult:
+    """Original build_verdict body."""
+    ...
+
+
+@stage(name="emit", timeout_s=10, retries=0)
+def emit(ctx: StageContext, enriched: EnrichedAnalysis) -> DeepAnalysisResult:
+    return _build_verdict_inner(ctx, enriched)
+
+
+def _emit_pending(ctx: StageContext, reason: str | None = None) -> DeepAnalysisResult:
+    """Build the 'Analyse en attente' placeholder used when a prior stage FAILED."""
+    return DeepAnalysisResult(
+        ticker=ctx.ticker,
+        grade="N/A",
+        composite_score=0.0,
+        recommendation="WAIT",
+        recommended_action="⏳ Analyse en attente — ne pas décider sur ce holding",
+        notes=reason or "",
+    )
+
+
+# Legacy facade
+def build_verdict(ctx: Any, enriched: EnrichedAnalysis) -> DeepAnalysisResult:
+    return _build_verdict_inner(ctx, enriched)
+```
+
+- [ ] **Step 4: Update run_pipeline final stage**
+
+```python
+# stages/__init__.py
+sr = synthesize(stage_ctx, quant, qual, raw)
+if sr.payload is None:
+    return _emit_pending(stage_ctx, reason=sr.provenance.reason)
+er = emit(stage_ctx, sr.payload)
+return er.payload if er.payload is not None else _emit_pending(stage_ctx, reason=er.provenance.reason)
+```
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+make test
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/emit.py src/finwiz/analysis/stages/__init__.py tests/unit/analysis/stages/test_emit.py
+rtk git commit -m "feat(stages): wire emit stage with AnalysePending fallback"
+```
+
+---
+
+### Task D6: Wire `RunLedger` Through the Orchestrator
+
+**Files:**
+- Modify: `src/finwiz/orchestrators/deep_analysis_orchestrator.py`
+- Modify: `src/finwiz/flow_state.py`
+- Modify: `src/finwiz/analysis/deep_analysis_pipeline.py` (facade adjustments)
+- Test: `tests/unit/orchestrators/test_deep_analysis_orchestrator.py` (existing — adjust)
+
+- [ ] **Step 1: Replace `_failed_holdings` and direct `deep_analysis_coverage` writes with ledger-derived views**
+
+In `src/finwiz/orchestrators/deep_analysis_orchestrator.py`:
+
+```python
+# Replace self._failed_holdings: list[str] = [] with:
+from pathlib import Path
+from uuid import uuid4
+
+from finwiz.analysis.stages._ledger import RunLedger
+
+class DeepAnalysisOrchestrator:
+    def __init__(self, state: Any, ...) -> None:
+        ...
+        run_id = state.run_id or uuid4().hex
+        self._ledger = RunLedger(
+            run_id=run_id,
+            artifact_dir=Path("output/run_ledger"),
+        )
+        state.run_ledger = self._ledger  # expose to flow / orchestrator-as-source-of-truth
+
+    @property
+    def _failed_holdings(self) -> list[str]:
+        return self._ledger.failed_tickers()
+```
+
+Remove every `self._failed_holdings.append(...)` — those writes now happen automatically via the `@stage` decorator.
+
+- [ ] **Step 2: Update `FinwizState` to expose ledger-derived coverage**
+
+```python
+# src/finwiz/flow_state.py — replace direct deep_analysis_coverage tuple with property
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from finwiz.analysis.stages._ledger import RunLedger
+
+
+class FinwizState(BaseModel):
+    ...
+    run_ledger: "RunLedger | None" = None  # populated by orchestrator at start
+
+    @property
+    def deep_analysis_coverage(self) -> tuple[int, int]:
+        """Backwards-compatible (analyzed, total) view."""
+        if self.run_ledger is None:
+            return (0, 0)
+        s = self.run_ledger.coverage()
+        return (s.analyzed, s.total)
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+```
+
+(Existing `deep_analysis_coverage: tuple[int, int]` field is replaced by this computed property.)
+
+- [ ] **Step 3: Build `StageContext` in the per-holding entry point**
+
+In `deep_analysis_pipeline.py:analyze_holding` (the facade), thread the ledger:
+
+```python
+def analyze_holding(ctx: AnalysisContext) -> DeepAnalysisResult:
+    from finwiz.analysis.stages import run_pipeline
+    from finwiz.analysis.stages._resilience import StageContext
+
+    stage_ctx = StageContext(
+        ticker=ctx.ticker,
+        run_id=ctx.run_id,
+        ledger=ctx.ledger,  # threaded in by the orchestrator
+    )
+    return run_pipeline(ctx, stage_ctx)
+```
+
+`AnalysisContext` (line 47 of `deep_analysis_pipeline.py`) gains `ledger: RunLedger` and `run_id: str` fields. The orchestrator populates them from `self._ledger`.
+
+- [ ] **Step 4: Update existing orchestrator tests**
+
+Existing tests that asserted on `_failed_holdings.append` now assert on ledger entries:
+
+```python
+# tests/unit/orchestrators/test_deep_analysis_orchestrator.py
+def test_orchestrator_tracks_failed_via_ledger(tmp_path: Path, mocker: Any) -> None:
+    # ... existing setup, but:
+    assert "BAD_TICKER" in orch._ledger.failed_tickers()
+```
+
+(The engineer must inspect the file and adjust 5–10 assertions accordingly. Run the file after each adjustment.)
+
+- [ ] **Step 5: Run orchestrator tests then full suite**
+
+```bash
+uv run pytest tests/unit/orchestrators/test_deep_analysis_orchestrator.py -v
+make test
+```
+
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add src/finwiz/orchestrators/deep_analysis_orchestrator.py src/finwiz/flow_state.py src/finwiz/analysis/deep_analysis_pipeline.py tests/unit/orchestrators/test_deep_analysis_orchestrator.py
+rtk git commit -m "feat(orchestrator): replace _failed_holdings with RunLedger view"
+```
+
+---
+
+### Task D7: Wire AST Check into `make check`
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Read existing `check` target**
+
+```bash
+grep -A 8 "^check:" Makefile
+```
+
+- [ ] **Step 2: Add `check-stage-contract` target**
+
+In `Makefile` add:
+
+```makefile
+.PHONY: check-stage-contract
+check-stage-contract:
+	uv run python -m scripts.check_stage_contract src/finwiz/analysis/stages
+```
+
+And modify the existing `check` target to depend on it:
+
+```makefile
+check: lint test check-unittest-mock check-stage-contract validate-docs
+```
+
+(Adjust to match the actual order present in the file. Don't reorder existing targets.)
+
+- [ ] **Step 3: Verify it runs**
+
+```bash
+make check-stage-contract
+```
+
+Expected: prints `check_stage_contract: src/finwiz/analysis/stages clean` exit 0.
+
+- [ ] **Step 4: Verify full check still passes**
+
+```bash
+make check
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add Makefile
+rtk git commit -m "build: wire stage-contract AST check into make check"
+```
+
+---
+
+### Task D8: Property-Based Invariant Tests
+
+**Files:**
+- Create: `tests/unit/analysis/stages/test_property_invariants.py`
+
+- [ ] **Step 1: Write Hypothesis property tests**
+
+```python
+# tests/unit/analysis/stages/test_property_invariants.py
+"""Hypothesis property tests for stage contract invariants."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from finwiz.schemas.run_ledger import CoverageSummary, TrustBanner
+from finwiz.schemas.stage_contract import StageOutcome
+
+
+@given(
+    analyzed=st.integers(min_value=0, max_value=100),
+    degraded=st.integers(min_value=0, max_value=100),
+    failed=st.integers(min_value=0, max_value=100),
+    total=st.integers(min_value=0, max_value=300),
+)
+def test_banner_state_is_one_of_four(
+    analyzed: int, degraded: int, failed: int, total: int
+) -> None:
+    if analyzed + degraded + failed > total:
+        return  # invalid input
+    summary = CoverageSummary(
+        analyzed=analyzed, degraded=degraded, failed=failed, total=total
+    )
+    banner = TrustBanner.from_coverage(summary)
+    assert banner.state in {"green", "amber", "red", "blocked"}
+
+
+@given(st.sampled_from(list(StageOutcome)))
+def test_str_enum_round_trip(outcome: StageOutcome) -> None:
+    assert StageOutcome(outcome.value) == outcome
+
+
+@given(
+    analyzed=st.integers(min_value=1, max_value=50),
+    total=st.integers(min_value=1, max_value=50),
+)
+def test_green_state_implies_no_block(analyzed: int, total: int) -> None:
+    if analyzed != total:
+        return
+    s = CoverageSummary(analyzed=analyzed, degraded=0, failed=0, total=total)
+    banner = TrustBanner.from_coverage(s)
+    if banner.state == "green":
+        assert banner.block_decisions is False
+```
+
+- [ ] **Step 2: Run**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_property_invariants.py -v`
+Expected: 3 properties pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+rtk git add tests/unit/analysis/stages/test_property_invariants.py
+rtk git commit -m "test(stages): hypothesis property tests for trust-spine invariants"
+```
+
+---
+
+## Phase E — Honest Degradation (Commit 3: Trust)
+
+The `qualify` stage flips its silent Python fallback to a labeled `DEGRADED` outcome. Reporting reads the provenance and renders an amber badge. A regression test guards against the v0.3.0 silent-success class.
+
+### Task E1: `qualify` Returns DEGRADED on Python Fallback
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/qualify.py`
+- Modify: `tests/unit/analysis/stages/test_qualify.py`
+
+- [ ] **Step 1: Write failing test for degraded path**
+
+```python
+# Append to tests/unit/analysis/stages/test_qualify.py
+def test_qualify_degraded_when_ai_returns_none(tmp_path: Path, mocker: Any) -> None:
+    mocker.patch("finwiz.analysis.stages.qualify._try_ai_qualify", return_value=None)
+    fake_proxy = QualitativeInsights.model_construct()
+    mocker.patch(
+        "finwiz.analysis.stages.qualify._python_proxy_qualify", return_value=fake_proxy
+    )
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    quant = QuantitativeAnalysis.model_construct()
+    result = qualify(ctx, quant, {})
+    assert result.provenance.outcome == StageOutcome.DEGRADED
+    assert result.provenance.fallback_used == "python_proxy_qualitative"
+    assert result.payload is fake_proxy
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_qualify.py::test_qualify_degraded_when_ai_returns_none -v`
+Expected: outcome is OK (current silent behaviour), fails the assertion.
+
+- [ ] **Step 3: Flip the qualify body to return StageResult directly when degrading**
+
+```python
+# src/finwiz/analysis/stages/qualify.py
+from finwiz.schemas.stage_contract import (
+    StageOutcome,
+    StageProvenance,
+    StageResult,
+)
+
+
+@stage(name="qualify", timeout_s=180, retries=2, allow_degrade=True)
+def qualify(
+    ctx: StageContext, quant: Any, raw: dict[str, Any]
+) -> StageResult[QualitativeInsights]:
+    """Qualitative stage. Returns OK on AI success, DEGRADED on Python fallback."""
+    ai = _try_ai_qualify(ctx, quant, raw)
+    if ai is not None:
+        return StageResult(
+            payload=ai,
+            provenance=StageProvenance(
+                stage="qualify",
+                outcome=StageOutcome.OK,
+                duration_ms=0,  # decorator backfills
+            ),
+        )
+    proxy = _python_proxy_qualify(ctx, quant)
+    return StageResult(
+        payload=proxy,
+        provenance=StageProvenance(
+            stage="qualify",
+            outcome=StageOutcome.DEGRADED,
+            fallback_used="python_proxy_qualitative",
+            reason="AI provider returned null/empty after retries",
+            duration_ms=0,
+        ),
+    )
+```
+
+The decorator's `_coerce_to_stage_result` already handles a returned `StageResult` correctly (`Task B2, step 3` — patches `retries_used` and `duration_ms` if not set).
+
+- [ ] **Step 4: Run tests, expect pass**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_qualify.py -v`
+Expected: All 2 tests pass.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `make test`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/qualify.py tests/unit/analysis/stages/test_qualify.py
+rtk git commit -m "feat(stages): qualify emits DEGRADED on Python fallback"
+```
+
+---
+
+### Task E2: Synthesize and Emit Read Provenance for Confidence Marker
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/synthesize.py`
+- Modify: `src/finwiz/analysis/stages/__init__.py`
+- Modify: `src/finwiz/flow_state_models.py` (add `confidence` field to `DeepAnalysisResult` if missing)
+- Test: `tests/unit/analysis/stages/test_synthesize.py`
+
+- [ ] **Step 1: Add `confidence` field to `DeepAnalysisResult` if not already there**
+
+Check first:
+
+```bash
+grep "confidence" src/finwiz/flow_state_models.py
+```
+
+If missing:
+
+```python
+# src/finwiz/flow_state_models.py — within DeepAnalysisResult:
+confidence: Literal["high", "low"] = "high"
+```
+
+- [ ] **Step 2: Write failing test for low-confidence propagation**
+
+```python
+# Append to tests/unit/analysis/stages/test_synthesize.py
+def test_synthesize_marks_low_confidence_when_qualify_degraded(tmp_path, mocker):
+    enriched = EnrichedAnalysis.model_construct()
+    mocker.patch(
+        "finwiz.analysis.stages.synthesize._synthesize_inner",
+        return_value=enriched,
+    )
+    ctx = StageContext(
+        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    quant = QuantitativeAnalysis.model_construct()
+    qual = QualitativeInsights.model_construct()
+    # The orchestrator passes the prior qualify provenance via stage_ctx.extras
+    ctx.extras["qualify_outcome"] = StageOutcome.DEGRADED
+    result = synthesize(ctx, quant, qual, {})
+    assert result.payload is not None
+    # The synthesize body reads ctx.extras to set the marker
+    assert getattr(result.payload, "confidence", "high") == "low"
+```
+
+- [ ] **Step 3: Modify `_synthesize_inner` to read `ctx.extras["qualify_outcome"]`**
+
+```python
+# src/finwiz/analysis/stages/synthesize.py — within _synthesize_inner:
+def _synthesize_inner(
+    ctx: Any, quant: Any, qual: Any, raw: dict[str, Any]
+) -> EnrichedAnalysis:
+    enriched = ...  # existing synthesis logic
+    if isinstance(ctx, StageContext) and ctx.extras.get("qualify_outcome") == StageOutcome.DEGRADED:
+        # Mark the enriched analysis's downstream confidence
+        enriched = enriched.model_copy(update={"confidence": "low"})
+    return enriched
+```
+
+- [ ] **Step 4: Update `run_pipeline` to thread the qualify outcome via extras**
+
+```python
+# stages/__init__.py
+ql = qualify(stage_ctx, quant, raw)
+if ql.payload is None:
+    return _emit_pending(stage_ctx, reason=ql.provenance.reason)
+qual = ql.payload
+stage_ctx.extras["qualify_outcome"] = ql.provenance.outcome
+sr = synthesize(stage_ctx, quant, qual, raw)
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+make test
+```
+
+Expected: Pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add src/finwiz/analysis/stages/synthesize.py src/finwiz/analysis/stages/__init__.py src/finwiz/flow_state_models.py tests/unit/analysis/stages/test_synthesize.py
+rtk git commit -m "feat(stages): synthesize marks low confidence when qualify degraded"
+```
+
+---
+
+### Task E3: Reporting Layer Renders Amber Badge for DEGRADED Holdings
+
+**Files:**
+- Modify: `src/finwiz/reporting/section_generators.py`
+- Test: `tests/unit/reporting/test_section_generators.py`
+
+- [ ] **Step 1: Write failing test for amber badge rendering**
+
+```python
+# tests/unit/reporting/test_section_generators.py
+def test_holding_row_renders_amber_badge_when_confidence_low() -> None:
+    from finwiz.flow_state_models import DeepAnalysisResult
+    from finwiz.reporting.section_generators import render_holding_row
+
+    holding = DeepAnalysisResult(
+        ticker="AAPL",
+        grade="B",
+        composite_score=0.7,
+        recommendation="HOLD",
+        confidence="low",
+    )
+    html = render_holding_row(holding)
+    assert "Insight IA indisponible" in html
+    assert "amber" in html.lower() or "warning" in html.lower()
+
+
+def test_holding_row_no_badge_for_high_confidence() -> None:
+    from finwiz.flow_state_models import DeepAnalysisResult
+    from finwiz.reporting.section_generators import render_holding_row
+
+    holding = DeepAnalysisResult(
+        ticker="AAPL",
+        grade="A",
+        composite_score=0.9,
+        recommendation="BUY",
+        confidence="high",
+    )
+    html = render_holding_row(holding)
+    assert "Insight IA indisponible" not in html
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `uv run pytest tests/unit/reporting/test_section_generators.py -v`
+
+- [ ] **Step 3: Add the badge branch in `section_generators.py`**
+
+Find the holding-row template (currently around line 269 — search `Analyse en attente`):
+
+```python
+# In render_holding_row(...) — after the existing grade/score cells:
+def _confidence_badge(holding: DeepAnalysisResult) -> str:
+    if getattr(holding, "confidence", "high") == "low":
+        return (
+            '<span class="badge-amber" '
+            'title="Insight IA indisponible — proxy quantitatif Python affiché">'
+            '⚠️ Insight IA indisponible</span>'
+        )
+    return ""
+```
+
+Insert `{_confidence_badge(holding)}` into the existing row template right after the grade cell. Keep the `Analyse en attente` branch unchanged for the N/A grade.
+
+- [ ] **Step 4: Run tests**
+
+Run: `make test`
+Expected: Pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/reporting/section_generators.py tests/unit/reporting/test_section_generators.py
+rtk git commit -m "feat(reporting): render amber badge for low-confidence holdings"
+```
+
+---
+
+### Task E4: Report Banner Reads `TrustBanner` Literally
+
+**Files:**
+- Modify: `src/finwiz/reporting/python_report_generator.py`
+- Test: `tests/unit/reporting/test_python_report_generator.py`
+
+- [ ] **Step 1: Locate the current banner-rendering code**
+
+```bash
+grep -n "deep_analysis_coverage" src/finwiz/reporting/python_report_generator.py
+```
+
+- [ ] **Step 2: Write failing test for banner rendering by state**
+
+```python
+# tests/unit/reporting/test_python_report_generator.py
+import pytest
+
+from finwiz.reporting.python_report_generator import render_trust_banner
+from finwiz.schemas.run_ledger import CoverageSummary, TrustBanner
+
+
+@pytest.mark.parametrize(
+    ("summary", "expected_class"),
+    [
+        (CoverageSummary(analyzed=5, degraded=0, failed=0, total=5), "trust-banner-green"),
+        (CoverageSummary(analyzed=4, degraded=1, failed=0, total=5), "trust-banner-amber"),
+        (CoverageSummary(analyzed=1, degraded=0, failed=4, total=5), "trust-banner-red"),
+        (CoverageSummary(analyzed=0, degraded=0, failed=0, total=5), "trust-banner-blocked"),
+    ],
+)
+def test_render_trust_banner_uses_state_class(summary, expected_class) -> None:
+    banner = TrustBanner.from_coverage(summary)
+    html = render_trust_banner(banner)
+    assert expected_class in html
+    assert banner.message in html
+```
+
+- [ ] **Step 3: Replace banner-rendering code with TrustBanner-driven function**
+
+```python
+# src/finwiz/reporting/python_report_generator.py
+from finwiz.schemas.run_ledger import TrustBanner
+
+_BANNER_CLASS = {
+    "green": "trust-banner-green",
+    "amber": "trust-banner-amber",
+    "red": "trust-banner-red",
+    "blocked": "trust-banner-blocked",
+}
+
+
+def render_trust_banner(banner: TrustBanner) -> str:
+    cls = _BANNER_CLASS[banner.state]
+    return (
+        f'<div class="{cls}" data-block-decisions="{str(banner.block_decisions).lower()}">'
+        f'<strong>Couverture:</strong> {banner.analyzed}/{banner.total} '
+        f"({banner.degraded} dégradés, {banner.failed} échoués). "
+        f"{banner.message}"
+        f"</div>"
+    )
+```
+
+Replace previous threshold-driven HTML in the report generator with a call to `render_trust_banner(state.run_ledger.to_banner())`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+make test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/finwiz/reporting/python_report_generator.py tests/unit/reporting/test_python_report_generator.py
+rtk git commit -m "feat(reporting): banner is rendered from TrustBanner literally"
+```
+
+---
+
+### Task E5: v0.3.0 Trust-Crisis Regression Test
+
+**Files:**
+- Create: `tests/regression/__init__.py` (empty)
+- Create: `tests/regression/test_trust_crisis_v030.py`
+
+- [ ] **Step 1: Create the regression file**
+
+```python
+# tests/regression/test_trust_crisis_v030.py
+"""Regression test for the v0.3.0 silent-success bug.
+
+Original symptom: AI returned null for 62 of 63 holdings, yet the report rendered
+"✅ FinWiz analysis workflow completed successfully" with placeholder grade='D'
+and composite_score=0.6 indistinguishable from a real verdict.
+
+Under v5.1, the same scenario must produce DEGRADED outcomes with the amber
+"Insight IA indisponible" badge and a red trust banner — never a silent OK.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.analysis.stages._resilience import StageContext
+from finwiz.analysis.stages.qualify import qualify
+from finwiz.schemas.hybrid_analysis import QualitativeInsights, QuantitativeAnalysis
+from finwiz.schemas.run_ledger import TrustBanner
+from finwiz.schemas.stage_contract import StageOutcome
+
+
+def test_ai_null_never_emits_silent_ok(tmp_path: Path, mocker: Any) -> None:
+    """If AI returns null, qualify must produce DEGRADED — never OK."""
+    mocker.patch("finwiz.analysis.stages.qualify._try_ai_qualify", return_value=None)
+    mocker.patch(
+        "finwiz.analysis.stages.qualify._python_proxy_qualify",
+        return_value=QualitativeInsights.model_construct(),
+    )
+    ctx = StageContext(
+        ticker="DELL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
+    )
+    result = qualify(ctx, QuantitativeAnalysis.model_construct(), {})
+    assert result.provenance.outcome == StageOutcome.DEGRADED, (
+        "v0.3.0 regression: AI null must NEVER produce a silent OK — got "
+        f"{result.provenance.outcome}"
+    )
+    assert result.provenance.fallback_used == "python_proxy_qualitative"
+
+
+def test_red_banner_when_majority_fail(tmp_path: Path) -> None:
+    """A run where 62/63 holdings fail must render a red 'do not decide' banner."""
+    ledger = RunLedger(run_id="r1", artifact_dir=tmp_path, total=63)
+    # 1 successful pipeline + 62 failures at qualify
+    for s in ("collect", "quantify", "qualify", "synthesize", "emit"):
+        ledger.record(_make_entry("AAPL", s, StageOutcome.OK))
+    for ticker in (f"FAIL{i}" for i in range(62)):
+        ledger.record(_make_entry(ticker, "qualify", StageOutcome.FAILED))
+    banner = ledger.to_banner()
+    assert banner.state == "red"
+    assert banner.block_decisions is True
+    assert "NE PAS" in banner.message
+
+
+def _make_entry(ticker: str, stage: str, outcome: StageOutcome) -> Any:
+    from datetime import datetime, timezone
+
+    from finwiz.schemas.run_ledger import RunLedgerEntry
+
+    now = datetime(2026, 4, 27, tzinfo=timezone.utc)
+    return RunLedgerEntry(
+        run_id="r1",
+        ticker=ticker,
+        started_at=now,
+        finished_at=now,
+        stage=stage,
+        outcome=outcome,
+    )
+```
+
+- [ ] **Step 2: Add `regression` marker to `pyproject.toml` (if not present) so it's runnable**
+
+```bash
+grep -n "regression" pyproject.toml
+```
+
+If the marker doesn't exist, add to the `[tool.pytest.ini_options]` markers list:
+
+```toml
+markers = [
+    # ... existing ...
+    "regression: regression test guarding against a previously-shipped bug",
+]
+```
+
+- [ ] **Step 3: Run the regression suite**
+
+```bash
+uv run pytest tests/regression/ -v
+```
+
+Expected: 2 passing.
+
+- [ ] **Step 4: Run full test suite + AST check**
+
+```bash
+make check
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add tests/regression/ pyproject.toml
+rtk git commit -m "test(regression): guard against v0.3.0 silent-success class"
+```
+
+---
+
+### Task E6: End-to-End Integration Test (3-Holding Pipeline)
+
+**Files:**
+- Create: `tests/unit/analysis/stages/test_pipeline.py`
+
+- [ ] **Step 1: Write the three-holding integration test**
+
+```python
+# tests/unit/analysis/stages/test_pipeline.py
+"""Three-holding pipeline integration: OK, DEGRADED, FAILED."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from finwiz.analysis.stages import run_pipeline
+from finwiz.analysis.stages._ledger import RunLedger
+from finwiz.analysis.stages._resilience import StageContext
+
+
+@pytest.fixture
+def ledger(tmp_path: Path) -> RunLedger:
+    return RunLedger(run_id="integ", artifact_dir=tmp_path, total=3)
+
+
+def _ctx(ticker: str, ledger: RunLedger) -> StageContext:
+    return StageContext(ticker=ticker, run_id="integ", ledger=ledger)
+
+
+def test_three_holding_pipeline(
+    ledger: RunLedger, mocker: Any, stock_data: Any
+) -> None:
+    """One holding succeeds, one degrades, one fails — banner is amber."""
+    # Holding 1 (HAPPY): everything succeeds.
+    # Holding 2 (DEGRADED): AI returns None, Python proxy fills in.
+    # Holding 3 (FAILED): collect raises.
+
+    def _ai_for_ticker(ctx: Any, *args: Any) -> Any | None:
+        return None if ctx.ticker == "DEGRADED_TKR" else _fake_ai_payload()
+
+    def _collect_for_ticker(ctx: Any) -> dict[str, Any]:
+        if ctx.ticker == "FAILED_TKR":
+            raise RuntimeError("data source down")
+        return {"price_history": [1, 2, 3]}
+
+    mocker.patch("finwiz.analysis.stages.collect._collect_raw_data_inner",
+                 side_effect=_collect_for_ticker)
+    mocker.patch("finwiz.analysis.stages.qualify._try_ai_qualify", side_effect=_ai_for_ticker)
+    mocker.patch("finwiz.analysis.stages.qualify._python_proxy_qualify",
+                 return_value=_fake_ai_payload())
+    mocker.patch("finwiz.analysis.stages.quantify._calculate_quantitative_inner",
+                 return_value=_fake_quant())
+    mocker.patch("finwiz.analysis.stages.synthesize._synthesize_inner",
+                 return_value=_fake_enriched())
+    mocker.patch("finwiz.analysis.stages.emit._build_verdict_inner",
+                 return_value=_fake_verdict())
+
+    for ticker in ("HAPPY_TKR", "DEGRADED_TKR", "FAILED_TKR"):
+        ctx = _make_analysis_context(ticker)  # helper that builds AnalysisContext
+        run_pipeline(ctx, _ctx(ticker, ledger))
+
+    summary = ledger.coverage()
+    assert summary.analyzed == 2  # happy + degraded reach emit
+    assert summary.degraded == 1
+    assert summary.failed == 1
+    banner = ledger.to_banner()
+    assert banner.state == "amber"
+
+
+# Test fixtures (kept inline for readability; engineer may extract to conftest.py)
+def _fake_ai_payload() -> Any:
+    from finwiz.schemas.hybrid_analysis import QualitativeInsights
+    return QualitativeInsights.model_construct()
+
+
+def _fake_quant() -> Any:
+    from finwiz.schemas.hybrid_analysis import QuantitativeAnalysis
+    return QuantitativeAnalysis.model_construct()
+
+
+def _fake_enriched() -> Any:
+    from finwiz.schemas.hybrid_analysis import EnrichedAnalysis
+    return EnrichedAnalysis.model_construct()
+
+
+def _fake_verdict() -> Any:
+    from finwiz.flow_state_models import DeepAnalysisResult
+    return DeepAnalysisResult(
+        ticker="x", grade="A", composite_score=0.9, recommendation="BUY"
+    )
+
+
+def _make_analysis_context(ticker: str) -> Any:
+    from finwiz.analysis.deep_analysis_pipeline import AnalysisContext
+    return AnalysisContext.model_construct(ticker=ticker)
+```
+
+- [ ] **Step 2: Run**
+
+Run: `uv run pytest tests/unit/analysis/stages/test_pipeline.py -v`
+Expected: passing.
+
+- [ ] **Step 3: Run full check**
+
+Run: `make check`
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add tests/unit/analysis/stages/test_pipeline.py
+rtk git commit -m "test(stages): three-holding pipeline integration (OK/DEGRADED/FAILED)"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Run the full quality gate**
+
+```bash
+make check
+```
+
+Expected: lint, all tests, unittest.mock check, stage-contract AST check, docs validation — all green.
+
+- [ ] **Step 2: Coverage check**
+
+```bash
+make coverage
+```
+
+Expected: ≥ 65% (existing threshold).
+
+- [ ] **Step 3: Smoke-test the kickoff path**
+
+```bash
+uv run python -c "from finwiz.analysis.stages import run_pipeline; print('ok')"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 4: Verify file shrinkage**
+
+```bash
+wc -l src/finwiz/analysis/deep_analysis_pipeline.py src/finwiz/analysis/stages/*.py
+```
+
+Expected: `deep_analysis_pipeline.py` < 200 lines (down from 1209). Stage modules each focused and bounded.
+
+- [ ] **Step 5: Verify no aggregate-timeout regression possible**
+
+```bash
+make check-stage-contract
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Cleanup commit (if any pending)**
+
+```bash
+rtk git status
+# If anything stranded — uncommitted:
+rtk git add <files>
+rtk git commit -m "chore(v5.1): final cleanup"
+```
+
+---
+
+## Out of Scope (logged for follow-up specs)
+
+- **v5.2** — Grounded Qualitative (Perplexity fact-pack injection into `qualify`)
+- Audit pass on the 7 non-deep-analysis `asyncio.gather` sites
+- Decompose `reporting/section_generators.py` (1037 lines)
+- Decompose `orchestrators/reporting_orchestrator.py` (873 lines)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2 Stage architecture → Tasks C1–C7
+- §3 Stage contract (StageOutcome / StageProvenance / StageResult, invariants I1–I5) → Tasks A1–A3 (I1–I3) + B2/B3 (I4–I5 enforced by decorator)
+- §4 Run ledger → Tasks A4 + B1 + D6
+- §5 Resilience contract (decorator + AST check) → Tasks B2, B3, B4, D7
+- §6 Trust banner → Task A4 + Task E4
+- §7 Honest degradation → Tasks E1, E2, E3
+- §8 Migration path (3 commits) → Phase C (commit 1: facade), Phase D (commit 2: contract), Phase E (commit 3: trust)
+- §9 Test strategy (unit / property / integration / regression / static) → Phase A/B/D/E tests + B4 + D8 + E5 + E6
+
+**Placeholder scan:** No "TBD", "implement later", or stub-only steps. Every step shows the actual code or command needed.
+
+**Type consistency:** `StageOutcome`, `StageProvenance`, `StageResult`, `RunLedgerEntry`, `CoverageSummary`, `TrustBanner`, `StageContext`, `RunLedger` — names used identically across all task code blocks. The `@stage` decorator signature `name`/`timeout_s`/`retries`/`allow_degrade` is identical in B2/B3 (sync/async path) and every consumer (D1–D5, E1).
+
+**Notes for the executor:**
+- Existing tests under `tests/unit/analysis/test_deep_analysis_pipeline.py` (657 lines from `wc -l`) must stay green throughout Phase C (verbatim extraction). When they break in Phase D from the new typed return values, adjust assertions but keep test *intent* unchanged.
+- Existing `_failed_holdings.append(...)` usage at `deep_analysis_orchestrator.py:241,246,304,330,334` is the touchpoint for D6.
+- The `Pydantic v2 strict` ban on dict→object coercion may require `model_config = ConfigDict(arbitrary_types_allowed=True)` on `FinwizState` for the `RunLedger` field (added in D6 step 2).

--- a/docs/superpowers/specs/2026-04-27-v5.1-trust-spine-design.md
+++ b/docs/superpowers/specs/2026-04-27-v5.1-trust-spine-design.md
@@ -1,0 +1,257 @@
+# v5.1 — Trust Spine
+
+**Status:** Approved (brainstorm), pending implementation plan
+**Date:** 2026-04-27
+**Owner:** FinWiz core
+**Supersedes:** N/A
+**Related:** v5.2 — Grounded Qualitative (fact pack injection); follows-up to v0.3.0/0.3.1 trust-crisis fixes
+
+## Context
+
+The v0.3.0 and v0.3.1 releases (April 2026) shipped patches for three classes of *trust-crisis* bugs in the deep-analysis pipeline:
+
+- **Silent success** — A run produced 0 deep analyses for 62 of 63 holdings yet reported `"✅ FinWiz analysis workflow completed successfully"` because a hidden kill switch defaulted to `false` and the placeholder `grade="D"` rendered as a real verdict.
+- **Aggregate timeout discarded completed work** — The 1800s `GLOBAL_PHASE_TIMEOUT` wrapped `asyncio.gather` and threw away every already-completed future when it fired.
+- **Hallucinated corporate facts** — DELL was assessed as still owning VMware (sold November 2021) because the qualitative agent ran in zero-tool mode and used training memory.
+
+Each fix worked, but the underlying cause is structural: the deep-analysis pipeline is one 1209-line module (`src/finwiz/analysis/deep_analysis_pipeline.py`) where stages exist as functions but not as bounded modules, invariants are implicit, resilience is scattered across 8+ files, and trust state (`_failed_holdings`, `deep_analysis_coverage`, `"Analyse en attente"`) was bolted on the orchestrator reactively.
+
+This spec promotes the four already-existing pipeline stages from "functions in a 1209-line file" to first-class modules with typed contracts, explicit invariants, per-stage resilience, and a persistent run ledger — so silent failure becomes a Pydantic validation error rather than a discovered-in-prod bug.
+
+## Goal
+
+Make silent pipeline failure structurally impossible by:
+
+1. Splitting `deep_analysis_pipeline.py` into 5 stage modules under `src/finwiz/analysis/stages/`.
+2. Defining a typed `StageResult` contract every stage must return.
+3. Codifying the per-unit-timeout / no-aggregate-gather rule that v0.3.1 discovered the hard way.
+4. Centralising trust state in a `RunLedger` that the report consumes literally.
+5. Making the qualitative stage's Python-fallback explicit (`DEGRADED`) instead of impersonating real AI output.
+
+## Non-Goals
+
+- No change to scoring math (40/30/30 composite stays).
+- No change to crew prompts (that's v5.2 — Grounded Qualitative).
+- No refactor of the 7 non-deep-analysis crews' `asyncio.gather` sites (logged as follow-up audit).
+- No new UI; existing report layout retained.
+- No public API changes — `analyze_holding(ctx) -> DeepAnalysisResult` signature stays stable.
+
+## Architecture
+
+```
+src/finwiz/analysis/
+├── deep_analysis_pipeline.py   # thin facade (~80 lines), re-exports analyze_holding
+├── _helpers.py                 # _today_french, _summarize_metrics, _truncate_text, etc.
+└── stages/
+    ├── __init__.py             # exports run_pipeline(ctx) -> DeepAnalysisResult
+    ├── _contract.py            # StageInput, StageResult, StageOutcome, StageProvenance
+    ├── _ledger.py              # RunLedger, RunLedgerEntry, JSONL writer
+    ├── _resilience.py          # @stage decorator: timeout, retry, outcome capture
+    ├── collect.py              # collect_raw_data → RawDataResult
+    ├── quantify.py             # calculate_quantitative → QuantitativeResult
+    ├── qualify.py              # generate_qualitative → QualitativeResult (only stage allowed to degrade)
+    ├── synthesize.py           # synthesize_enriched_analysis → EnrichedResult
+    └── emit.py                 # build_verdict → DeepAnalysisResult or AnalysePending
+```
+
+`deep_analysis_pipeline.py` shrinks to a thin facade so existing imports keep working without callers changing.
+
+## Stage Contract
+
+Defined in `analysis/stages/_contract.py`:
+
+```python
+class StageOutcome(StrEnum):
+    OK = "ok"
+    DEGRADED = "degraded"   # only valid for QUALIFY stage
+    FAILED = "failed"
+
+class StageProvenance(BaseModel):
+    stage: Literal["collect", "quantify", "qualify", "synthesize", "emit"]
+    outcome: StageOutcome
+    reason: str | None = None        # human-readable cause
+    duration_ms: int
+    retries_used: int = 0
+    fallback_used: str | None = None # e.g. "python_proxy_qualitative"
+    model_config = ConfigDict(extra="forbid")
+
+class StageResult[T](BaseModel):
+    payload: T | None                # None iff outcome == FAILED
+    provenance: StageProvenance
+    model_config = ConfigDict(extra="forbid")
+```
+
+**Invariants enforced by Pydantic validators in `_contract.py`:**
+
+| # | Invariant | Where checked |
+|---|-----------|---------------|
+| I1 | `collect`, `quantify`, `synthesize`, `emit` may return `OK` or `FAILED` only | `StageProvenance.model_validator` |
+| I2 | `payload is None` if and only if `outcome == FAILED` | `StageResult.model_validator` |
+| I3 | `fallback_used is not None` implies `outcome == DEGRADED` | `StageProvenance.model_validator` |
+| I4 | `retries_used <= stage.retries` (configured cap) | `@stage` decorator |
+| I5 | `duration_ms <= stage.timeout_s * 1000` (within timeout window) | `@stage` decorator |
+
+Violations raise `ValidationError` at stage boundary — not silently absorbed.
+
+## Run Ledger
+
+Defined in `analysis/stages/_ledger.py`:
+
+```python
+class RunLedgerEntry(BaseModel):
+    run_id: str             # ULID, set once per pipeline kickoff
+    ticker: str
+    started_at: datetime
+    finished_at: datetime
+    stage: str
+    outcome: StageOutcome
+    reason: str | None
+    fallback_used: str | None
+    retries_used: int
+    cost_usd: float = 0.0   # populated for AI stages
+
+class RunLedger:
+    def record(self, entry: RunLedgerEntry) -> None: ...
+    def coverage(self) -> CoverageSummary: ...                  # (analyzed, degraded, failed, total)
+    def failures_for(self, ticker: str) -> list[StageProvenance]: ...
+    def to_banner(self) -> TrustBanner: ...
+```
+
+**Persistence:** append-only JSONL at `output/run_ledger/<run_id>.jsonl`, one row per `(holding, stage, outcome)`. Replayable, `jq`-friendly, no DB dependency.
+
+The ledger is the *single source of truth* the report consumes. `_failed_holdings` and `deep_analysis_coverage` on `FinwizState` become thin views over `RunLedger.coverage()`.
+
+## Resilience Contract
+
+`@stage` decorator in `analysis/stages/_resilience.py`:
+
+```python
+@stage(name="qualify", timeout_s=180, retries=2, allow_degrade=True)
+def qualify(ctx: AnalysisContext, quant: QuantitativeAnalysis) -> StageResult[QualitativeInsights]:
+    ...
+```
+
+The decorator does five things, and only these:
+
+1. Wraps body in `asyncio.wait_for(..., timeout_s)` — **per-unit only, never aggregates**.
+2. Retries on transient errors up to `retries`. **Transient** is defined concretely as: `OSError`, `asyncio.TimeoutError`, `httpx.HTTPStatusError` where `response.status_code >= 500`, and `httpcore.RemoteProtocolError`. Never retries `pydantic.ValidationError` or `AssertionError`. Stage bodies must be idempotent (retries can re-execute the full body).
+3. Catches uncaught exceptions and converts to `StageResult(payload=None, outcome=FAILED, reason=str(e))`.
+4. Records a `RunLedgerEntry`.
+5. Validates the `allow_degrade` invariant — only `qualify` may set it `True`.
+
+**Static enforcement.** `scripts/check_stage_contract.py` runs as part of `make check`. It uses AST parsing to fail CI when:
+
+- Any code under `analysis/stages/` calls `asyncio.gather` without `return_exceptions=True`.
+- Any code under `analysis/stages/` wraps multiple `@stage`-decorated calls in a single `asyncio.wait_for`.
+- Any new `@stage` declares `allow_degrade=True` outside `qualify.py`.
+
+This codifies the v0.3.1 lesson — the next contributor can't reintroduce a global aggregate timeout.
+
+## Trust Banner
+
+Derived in `analysis/stages/_ledger.py:RunLedger.to_banner()`:
+
+```python
+class TrustBanner(BaseModel):
+    state: Literal["green", "amber", "red", "blocked"]
+    analyzed: int
+    degraded: int
+    failed: int
+    total: int
+    message: str            # French, user-visible
+    block_decisions: bool   # True iff state in {red, blocked}
+```
+
+State rules — pure deterministic function of coverage:
+
+| Condition | State | Behavior |
+|-----------|-------|----------|
+| `total == 0` | `blocked` | RuntimeError raised at flow level, no report rendered |
+| `analyzed == 0` and `total > 0` | `blocked` | RuntimeError raised at flow level, no report rendered |
+| `2 * failed > total` (more than half failed) | `red` | Banner: "NE PAS prendre de décisions sur ce rapport" |
+| `degraded > 0` or `0 < 2 * failed <= total` | `amber` | Banner shows count + tickers in expander |
+| `analyzed == total` and `degraded == 0` and `failed == 0` | `green` | Standard banner |
+
+Integer arithmetic only — `2 * failed` instead of `failed > total / 2` to remove float ambiguity. Rules are evaluated top-to-bottom; first match wins.
+
+The HTML renderer reads `TrustBanner` literally — no ad-hoc threshold logic in templates. Threshold changes happen in one place.
+
+## Honest Degradation in `qualify`
+
+Today `_create_python_qualitative` impersonates AI output. Under v5.1:
+
+```python
+@stage(name="qualify", timeout_s=180, retries=2, allow_degrade=True)
+def qualify(ctx, quant) -> StageResult[QualitativeInsights]:
+    ai_result = _try_ai_qualify(ctx, quant)
+    if ai_result is not None:
+        return StageResult(
+            payload=ai_result,
+            provenance=StageProvenance(stage="qualify", outcome=StageOutcome.OK, ...),
+        )
+    py_result = _python_proxy_qualify(ctx, quant)
+    return StageResult(
+        payload=py_result,
+        provenance=StageProvenance(
+            stage="qualify",
+            outcome=StageOutcome.DEGRADED,
+            fallback_used="python_proxy_qualitative",
+            reason="AI provider returned null/empty after retries",
+        ),
+    )
+```
+
+`synthesize` reads `prev.provenance.outcome`:
+
+- `OK` → emits normal verdict
+- `DEGRADED` → emits verdict with `confidence="low"` and amber badge in HTML: *"Insight IA indisponible — proxy quantitatif Python affiché"*
+- `FAILED` → caller catches, emits `AnalysePending`
+
+The Python fallback isn't removed — it's *labeled*. Useful information ("AI provider is flaking") that v0.3.0 silently masked.
+
+## Migration Path
+
+Three commits, each green on `make check`:
+
+### Commit 1 — Extract
+
+Copy stage functions to `analysis/stages/*.py` verbatim. Original `deep_analysis_pipeline.py` becomes a facade re-exporting `analyze_holding`. No behavior change. Existing tests pass unmodified.
+
+### Commit 2 — Contract
+
+Wrap each stage with `@stage` decorator and `StageResult` envelope. Introduce `RunLedger`. Replace `_failed_holdings` and `deep_analysis_coverage` accessors on `FinwizState` with thin views over the ledger. Orchestrator API unchanged. Existing tests pass with cosmetic adjustments only.
+
+### Commit 3 — Honest Degrade
+
+`qualify` stage flips Python fallback from silent to `DEGRADED`. Report renderer (`reporting/section_generators.py`) gains the amber-badge branch reading `provenance.outcome`. New tests cover the three outcome states. Add regression test for v0.3.0 bug (AI returns null → must produce `DEGRADED`, never silent `OK`).
+
+## Test Strategy
+
+- **Unit** — each stage tested with `(ctx, prev_result) -> StageResult` table-driven tests covering `OK`, `FAILED`, and (for `qualify` only) `DEGRADED`.
+- **Property** — Hypothesis tests for ledger invariants: no `OK` payload `is None`; no `DEGRADED` outside `qualify`; `retries_used <= cap`.
+- **Integration** — full pipeline against fixture portfolios with three holdings (one OK, one degraded, one failed) → assert banner state, ledger contents, report HTML markers.
+- **Regression** — revival test for v0.3.0 trust-crisis bug. AI mocked to return null → assertion that the run produces a `DEGRADED` outcome and an amber badge in the HTML, and never a silent `OK` with a `composite_score=0.6` placeholder.
+- **Static** — `scripts/check_stage_contract.py` invocation added to `make check`.
+
+## AI Minimalism Compliance
+
+The trust-spine refactor is pure Python — no new LLM calls. The only AI-touching change is making the existing qualitative-stage Python fallback honest about being Python. This aligns with the project's AI Minimalism rule: Python for deterministic plumbing, AI only for qualitative reasoning.
+
+## Out of Scope (logged for follow-up specs)
+
+- **v5.2 — Grounded Qualitative** — Perplexity-grounded fact pack injection into the qualitative prompt, plugging into `qualify`'s contract.
+- **Audit pass** on the 7 non-deep-analysis `asyncio.gather` sites identified during exploration: `crews/portfolio_rebalancing_crew/portfolio_rebalancing_crew.py`, `tools/perplexity_structured.py`, `tools/analysis/analysis_coordinator.py`, `tools/portfolio_cache_service.py`, `tools/portfolio_price_service.py`, `tools/perplexity_performance_benchmark.py`, `tools/sentiment_analyzer.py`, `analysis/strategic_research.py`.
+- **Decompose `reporting/section_generators.py`** (1037 lines).
+- **Decompose `orchestrators/reporting_orchestrator.py`** (873 lines).
+
+## Open Questions
+
+None — design approved 2026-04-27.
+
+## References
+
+- Recent trust-crisis commits: `2a5983d` (v0.3.1), `703af9b` (v0.3.0), `53375b1` (Phase 3 timeout fix)
+- AI Minimalism feedback memory: `feedback_no_aggregate_timeouts.md`, `feedback_qualitative_scores_from_ai.md`
+- Current pipeline: `src/finwiz/analysis/deep_analysis_pipeline.py`
+- Current trust state: `src/finwiz/orchestrators/deep_analysis_orchestrator.py`
+- Current banner: `src/finwiz/reporting/section_generators.py:75`

--- a/src/finwiz/core/app_initializer.py
+++ b/src/finwiz/core/app_initializer.py
@@ -20,8 +20,8 @@ from finwiz.flow_state import FinwizState
 from finwiz.flows.orchestrator import FinwizFlow
 from finwiz.tools.logger import get_logger, setup_logging
 
-# Load .env at module import so env-based toggles (e.g. INVESTMENT_DISCOVERY_ENABLED)
-# are available regardless of which crew modules get imported first.
+# Load .env at module import so configuration from .env is available regardless
+# of which crew modules get imported first.
 load_dotenv()
 
 # Setup logging configuration
@@ -62,15 +62,13 @@ def kickoff() -> None:
         finwiz_flow = FinwizFlow(state=flow_state)
         logger.debug("FinwizFlow instance created with FinwizState")
 
-        # Step 5: Resolve runtime toggles from env vars into CrewAI flow inputs.
-        # This is the canonical CrewAI pattern: flow.kickoff(inputs={...})
-        # populates structured state before any @start() method runs.
-        discovery_enabled = os.getenv("INVESTMENT_DISCOVERY_ENABLED", "false").lower() == "true"
-        flow_inputs: dict[str, object] = {"discovery_enabled": discovery_enabled}
-
-        # Step 6: Execute the flow
-        logger.info("🚀 Starting FinWiz analysis execution (discovery_enabled=%s)", discovery_enabled)
-        finwiz_flow.kickoff(inputs=flow_inputs)
+        # Step 5: Execute the flow. Phase 4 (Investment Discovery) ALWAYS runs —
+        # the INVESTMENT_DISCOVERY_ENABLED kill switch was removed because
+        # downstream alternatives-matching depends on discovery output and
+        # turning it off silently produced the "no alternatives found" warning
+        # class. Same philosophy as the v0.3.0 deep-analysis fix.
+        logger.info("🚀 Starting FinWiz analysis execution")
+        finwiz_flow.kickoff()
         logger.info("✅ FinWiz analysis workflow completed successfully")
 
         # Step 7: Force-exit the process so third-party thread pools

--- a/src/finwiz/crews/helpers/data_integration_helpers.py
+++ b/src/finwiz/crews/helpers/data_integration_helpers.py
@@ -56,7 +56,7 @@ class DiscoveryStatusHelper:
             logger.info("No discovery data found in inputs or files")
             return {
                 "has_results": False,
-                "message": "A+ discovery not run - set INVESTMENT_DISCOVERY_ENABLED=true to enable discovery analysis",
+                "message": "A+ discovery produced no output for this run",
                 "status": "not_run",
             }
 

--- a/src/finwiz/flows/orchestrator.py
+++ b/src/finwiz/flows/orchestrator.py
@@ -190,7 +190,7 @@ class FinwizFlow(Flow[FinwizState]):
             1. Data validation
             2. Portfolio review (loads holdings from CSV)
             3. Deep analysis (analyzes the loaded holdings)
-            4. Discovery (if enabled)
+            4. Discovery (A+ investment discovery; always runs)
             5. Alternative matching
             6. Reporting
 
@@ -258,8 +258,7 @@ class FinwizFlow(Flow[FinwizState]):
         self.discovery_orch.check_crypto()
         self.discovery_orch.check_stock()
         self.discovery_orch.check_etf()
-        discovery_result = self.discovery_orch.check_investment_discovery()
-        discovery_data = discovery_result if discovery_result else {}
+        discovery_data = self.discovery_orch.check_investment_discovery() or {}
 
         # Phase 5: Alternative Matching
         logger.info("=" * 80)

--- a/src/finwiz/flows/orchestrator.py
+++ b/src/finwiz/flows/orchestrator.py
@@ -245,24 +245,21 @@ class FinwizFlow(Flow[FinwizState]):
                 self.state.stress_test_error = str(e)
                 logger.warning(f"Stress testing skipped: {e}")
 
-        # Phase 4: Discovery (if enabled)
-        # Toggle sources (either path works):
-        #   1. state.discovery_enabled — populated from flow.kickoff(inputs={"discovery_enabled": True})
-        #   2. INVESTMENT_DISCOVERY_ENABLED=true env var (forwarded by app_initializer.kickoff)
-        import os
-
-        discovery_data = {}
-        discovery_enabled = self.state.discovery_enabled or (os.getenv("INVESTMENT_DISCOVERY_ENABLED", "false").lower() == "true")
-        if discovery_enabled:
-            logger.info("=" * 80)
-            logger.info("PHASE 4: Investment Discovery")
-            logger.info("=" * 80)
-            self.discovery_orch.check_crypto()
-            self.discovery_orch.check_stock()
-            self.discovery_orch.check_etf()
-            discovery_result = self.discovery_orch.check_investment_discovery()
-            if discovery_result:
-                discovery_data = discovery_result
+        # Phase 4: Discovery — ALWAYS runs.
+        # The previous INVESTMENT_DISCOVERY_ENABLED kill switch was removed:
+        # without discovery, the alternatives-matching phase has no A+ candidates
+        # to suggest, which produced the "no alternatives found" warning class
+        # and meant downstream sell/keep recommendations had nothing to point at.
+        # Same philosophy as the v0.3.0 deep-analysis fix: financial trust
+        # requires unconditional execution of pipeline phases.
+        logger.info("=" * 80)
+        logger.info("PHASE 4: Investment Discovery")
+        logger.info("=" * 80)
+        self.discovery_orch.check_crypto()
+        self.discovery_orch.check_stock()
+        self.discovery_orch.check_etf()
+        discovery_result = self.discovery_orch.check_investment_discovery()
+        discovery_data = discovery_result if discovery_result else {}
 
         # Phase 5: Alternative Matching
         logger.info("=" * 80)

--- a/src/finwiz/orchestrators/discovery/aplus_discovery_accessor.py
+++ b/src/finwiz/orchestrators/discovery/aplus_discovery_accessor.py
@@ -132,7 +132,7 @@ class APlusDiscoveryAccessor:
             results = self.load_discovery_results()
 
             if results is None:
-                return "A+ discovery not run - set INVESTMENT_DISCOVERY_ENABLED=true to identify investment opportunities"
+                return "A+ discovery produced no output for this run"
 
             total_opportunities = results.get("total_opportunities", 0)
 

--- a/src/finwiz/tools/alternative_finder_tool.py
+++ b/src/finwiz/tools/alternative_finder_tool.py
@@ -160,9 +160,8 @@ class AlternativeFinder:
         else:
             self.logger.warning(
                 f"⚠️ No alternatives found for {holding.ticker} (grade: {holding.grade}). "
-                f"Reasons: 1) Discovery crew may not have run, 2) No A+ candidates match asset class, "
-                f"3) Sector/cost matching not yet implemented. "
-                f"Enable discovery via INVESTMENT_DISCOVERY_ENABLED=true or flow.kickoff(inputs={{'discovery_enabled': True}}).",
+                f"Possible reasons: no A+ candidates match this asset class in the current "
+                f"discovery output, or sector/cost matching has no eligible pairs.",
                 extra={
                     "ticker": holding.ticker,
                     "grade": holding.grade,
@@ -179,7 +178,7 @@ class AlternativeFinder:
         # Check for latest discovery output
         latest_file = self.discovery_output_dir / "discovery_latest.json"
         if not latest_file.exists():
-            self.logger.warning(f"No discovery crew output found at {latest_file}. Enable discovery via INVESTMENT_DISCOVERY_ENABLED=true to generate A+ alternatives.")
+            self.logger.warning(f"No discovery crew output found at {latest_file}; A+ alternatives unavailable for this run.")
             return alternatives
 
         try:

--- a/tests/unit/flows/test_discovery_toggle.py
+++ b/tests/unit/flows/test_discovery_toggle.py
@@ -1,66 +1,56 @@
 """
-Tests for Fix 2: discovery toggle via CrewAI-native mechanisms.
+Tests guarding the always-runs invariant for Phase 4 (A+ Investment Discovery).
 
-Covers:
-- FinwizState.discovery_enabled field exists and defaults to False.
-- app_initializer.kickoff() forwards INVESTMENT_DISCOVERY_ENABLED env var
-  as a flow input (CrewAI canonical pattern), not via argparse.
+History:
+- v0.2.x had an `INVESTMENT_DISCOVERY_ENABLED` env-var kill switch that gated
+  Phase 4 behind an opt-in. Without discovery, alternatives matching produced
+  the "no alternatives found" warning class for every holding — same shape as
+  the v0.3.0 deep-analysis silent-success bug.
+- The kill switch was removed: discovery now ALWAYS runs.
+- The `discovery_enabled` field on `FinwizState` is preserved as legitimate
+  CrewAI flow-input API (callers may pass `flow.kickoff(inputs={...})`); it is
+  no longer consulted as a gate.
+
+These tests pin the invariants:
+1. The state field still exists for API stability.
+2. `app_initializer.kickoff()` does NOT read any env-var toggle and forwards
+   no kickoff inputs — discovery runs unconditionally.
 """
 
 from __future__ import annotations
-
-import pytest
 
 from finwiz.flow_state_models import FinwizState
 
 
 class TestDiscoveryStateField:
-    """FinwizState must carry a discovery_enabled boolean for CrewAI flow inputs."""
+    """`discovery_enabled` field exists on FinwizState for API stability."""
 
-    def test_default_is_false(self):
+    def test_default_is_false(self) -> None:
         state = FinwizState()
         assert state.discovery_enabled is False
 
-    def test_can_be_set_via_constructor(self):
+    def test_can_be_set_via_constructor(self) -> None:
+        # The field accepts the kwarg even though it no longer gates behavior.
         state = FinwizState(discovery_enabled=True)
         assert state.discovery_enabled is True
 
 
-class TestAppInitializerForwardsEnvVarAsFlowInput:
-    """app_initializer.kickoff() must forward env var to flow.kickoff(inputs=...)."""
+class TestAppInitializerDoesNotForwardKillSwitch:
+    """`app_initializer.kickoff()` runs discovery unconditionally — no inputs."""
 
-    @pytest.fixture
-    def patched_kickoff(self, mocker):
-        """Patch every expensive step in app_initializer.kickoff()."""
+    def test_kickoff_called_without_inputs(self, mocker) -> None:
+        """The kill switch was removed, so flow.kickoff() takes no inputs."""
         mocker.patch("finwiz.validation.validate_template_variables_at_startup")
         mocker.patch("finwiz.core.app_initializer.initialize_configuration")
         mocker.patch("finwiz.core.app_initializer.initialize_environment")
         mocker.patch("finwiz.core.app_initializer.logging.shutdown")
         mocker.patch("finwiz.core.app_initializer.os._exit")
         flow_cls_mock = mocker.patch("finwiz.core.app_initializer.FinwizFlow")
-        return flow_cls_mock.return_value
 
-    def test_forwards_true_when_env_var_set(self, mocker, patched_kickoff):
-        mocker.patch.dict("os.environ", {"INVESTMENT_DISCOVERY_ENABLED": "true"}, clear=False)
         from finwiz.core.app_initializer import kickoff
 
         kickoff()
 
-        patched_kickoff.kickoff.assert_called_once_with(inputs={"discovery_enabled": True})
-
-    def test_forwards_false_when_env_var_absent(self, mocker, patched_kickoff):
-        mocker.patch.dict("os.environ", {}, clear=False)
-        mocker.patch.dict("os.environ", {"INVESTMENT_DISCOVERY_ENABLED": ""}, clear=False)
-        from finwiz.core.app_initializer import kickoff
-
-        kickoff()
-
-        patched_kickoff.kickoff.assert_called_once_with(inputs={"discovery_enabled": False})
-
-    def test_env_var_is_case_insensitive(self, mocker, patched_kickoff):
-        mocker.patch.dict("os.environ", {"INVESTMENT_DISCOVERY_ENABLED": "TRUE"}, clear=False)
-        from finwiz.core.app_initializer import kickoff
-
-        kickoff()
-
-        patched_kickoff.kickoff.assert_called_once_with(inputs={"discovery_enabled": True})
+        # Asserts kickoff() was called with no positional args and no keyword args
+        # (discovery is always-on, so no inputs are forwarded).
+        flow_cls_mock.return_value.kickoff.assert_called_once_with()

--- a/tests/unit/integration/test_aplus_discovery_accessor.py
+++ b/tests/unit/integration/test_aplus_discovery_accessor.py
@@ -234,8 +234,7 @@ class TestAPlusDiscoveryAccessor:
         summary = accessor.get_opportunities_summary()
 
         # Assert
-        assert "not run" in summary.lower()
-        assert "INVESTMENT_DISCOVERY_ENABLED" in summary
+        assert "no output" in summary.lower()
 
     def test_should_generate_summary_when_no_opportunities(self, accessor, sample_crypto_discovery):
         """Test summary generation when no opportunities found."""


### PR DESCRIPTION
## Summary

A user portfolio kickoff produced `⚠️ No alternatives found for ETH-USD (grade: D). … Enable discovery via INVESTMENT_DISCOVERY_ENABLED=true` warnings for every D-graded holding because Phase 4 (A+ Investment Discovery) defaulted to off. Without discovery, alternatives matching has no A+ candidates to suggest, so every sell/keep recommendation lands without a proposed alternative — same shape as the v0.3.0 silent-success class.

This PR removes the kill switch so Phase 4 runs unconditionally.

## Changes

**Switch removed:**
- `flows/orchestrator.py` — drop the `if discovery_enabled:` gate; always run the four discovery checks.
- `core/app_initializer.py` — drop the env-var read; `flow.kickoff()` is called with no inputs.

**API surface preserved (per "remove the switch, not the field"):**
- `FinwizState.discovery_enabled` field stays as a no-op for callers that pass `flow.kickoff(inputs={...})`.

**Cleanup:**
- 3 warning messages dropped the "set INVESTMENT_DISCOVERY_ENABLED=true" hint (the env var no longer does anything).
- `test_discovery_toggle.py` rewritten — pins the new invariants: field default + `flow.kickoff()` is called without inputs.
- `test_aplus_discovery_accessor.py` assertion updated to match the new warning text.
- `.env`, `.env.example`, `CLAUDE.md`, `ARCHITECTURE.md` updated.

## Philosophy

Same as v0.3.0's deep-analysis fix: financial trust requires unconditional execution of pipeline phases that downstream consumers depend on.

## Test plan

- [x] `tests/unit/flows/test_discovery_toggle.py` — 3 tests pin the new invariants
- [x] `tests/unit/integration/test_aplus_discovery_accessor.py` — 29 tests still green with updated assertion
- [x] Full unit suite — no regressions
- [ ] Live `crewai flow kickoff` smoke test — confirm Phase 4 runs and warning class disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Investment Discovery (Phase 4) now executes unconditionally for all users; the optional `INVESTMENT_DISCOVERY_ENABLED` configuration setting has been removed.

* **Documentation**
  * Added Trust Spine design specification for v5.1 defining stage execution reliability contracts and error handling.
  * Updated all documentation and error messages to reflect mandatory Investment Discovery execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->