### PR TITLE
chore(deps): enable Dependabot weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+# Dependabot config — weekly automated dependency updates.
+#
+# Strategy
+# --------
+# - Two ecosystems: Python (uv-managed pyproject.toml + uv.lock) and
+#   GitHub Actions (workflow YAMLs).
+# - Weekly cadence on Mondays — predictable review window, low PR noise.
+# - Patch + minor updates GROUPED into single PRs per ecosystem to avoid
+#   one-PR-per-bump churn. Major bumps stay separate so they get individual
+#   review (most likely place for breaking changes).
+# - PR limit bounded so a noisy upstream burst can't flood the queue.
+#
+# Adding a manual upgrade path: set `versioning-strategy: increase` so
+# Dependabot prefers raising the minimum specified version when it can
+# (rather than re-pinning the entire range).
+
+version: 2
+updates:
+  # Python — uv reads pyproject.toml; Dependabot's `pip` ecosystem covers it.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      python-patch-and-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+  # GitHub Actions — keeps `uses:` pinned versions current (security-relevant
+  # since Actions execute with repo token scope).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      actions-patch-and-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
## Summary
- Add \`.github/dependabot.yml\` covering both \`pip\` (Python) and \`github-actions\` ecosystems.
- Weekly Monday cadence, patch + minor updates grouped per ecosystem to bound PR noise; majors stay individual for review.
- Preventative infrastructure — \`pip-audit\` reports zero known CVEs at HEAD.

## Behavior
| Ecosystem | Cadence | PR limit | Strategy |
|---|---|---|---|
| Python (\`pip\`) | Mon 06:00 Europe/Paris | 5 | One grouped PR for patch+minor; majors separate |
| GitHub Actions | Mon 06:00 Europe/Paris | 3 | Same |

## Test plan
- [x] \`yamllint\`-clean (validated by editor)
- [ ] After merge: confirm Dependabot bot is enabled on the repo (Settings → Code security → Dependabot)
- [ ] Wait for next Monday to see the first batched update PR (or trigger manually via GitHub Insights → Dependency graph → Dependabot)
- [ ] Verify grouped PRs include \`labels: dependencies\` for triage workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)