### PR TITLE
feat: tactical price targets and sell-level floors per holding (ADR-011)

### DIFF
--- a/docs/adr/ADR-011-tactical-price-targets-and-sell-levels.md
+++ b/docs/adr/ADR-011-tactical-price-targets-and-sell-levels.md
@@ -1,0 +1,88 @@
+# ADR-011: Tactical Price Targets and Sell-Level Floors per Holding
+
+- **Status:** Accepted
+- **Date:** 2026-04-30
+- **Deciders:** FinWiz Core Team
+
+## Context
+
+The deep-analysis report shows a verdict per holding (grade, recommendation, narrative) but no actionable *price levels*. Users reading the family financial plan have to do their own arithmetic to answer two questions every position raises:
+
+1. **"À quel prix ce titre vaudrait sa juste valeur dans 3-6 mois ?"** (objectif de cours)
+2. **"À quel prix devrais-je vendre si la thèse se casse ?"** (niveau de vente / stop-loss)
+
+The compute primitives already exist:
+- `quantitative/price_targets.py` — DCF, P/E, technical, support/resistance, consensus.
+- `quantitative/derivative_pricing.py` — full Black-Scholes + Greeks.
+- `quantitative/technical/` + TA-Lib — ATR, Fibonacci, support/resistance.
+- `schemas/portfolio_review.py:PriceTargets` — already a field on `HoldingDecision`, currently always `None`.
+- Price history is collected by `analysis/stages/collect.py` and reused by quantify; no new external API call is needed.
+
+What is missing is (a) a single per-holding helper that orchestrates these primitives consistently across asset classes, and (b) the wiring that surfaces the result in the rendered HTML report.
+
+The user explicitly framed this as a "with our existing data" feature (no new sources, no new costs). AI Minimalism (ADR-003) requires deterministic Python for any computation that is mechanically derivable — both targets and sell-levels are.
+
+## Decision
+
+Compute and surface, for every holding in the deep-analysis report, two deterministic price levels driven by the existing price history:
+
+- **Objectif de cours** (3-6 month tactical target): the higher of the next major technical resistance and a volatility-projected drift, capped at ±25% (stocks, ETFs) or ±40% (crypto).
+- **Niveau de vente** (stop-loss floor): the higher of the nearest technical support and `current_price − 2 × ATR(14)` — whichever triggers earlier, ensuring the floor is neither below a credible technical level nor unreasonably far in quiet markets.
+
+A new module `src/finwiz/quantitative/tactical_pricing.py` exposes a single public entry point:
+
+```python
+def compute_tactical_pricing(
+    ticker: str,
+    asset_class: Literal["stock", "etf", "crypto"],
+    price_history: pd.Series,
+    current_price: float,
+    *,
+    horizon_months: int = 4,
+) -> PriceTargets | None
+```
+
+It returns the existing `schemas/portfolio_review.PriceTargets` Pydantic model. `None` is returned only when the input has fewer than 60 trading days — every other edge case (missing ATR inputs, non-finite prices, collapsed ranges) yields safe defaults with a logged warning, matching the round-2 backtester resilience pattern.
+
+Wiring path (each step is one short edit):
+
+1. `analysis/stages/quantify.py` calls the helper after the existing technical-indicator computation and attaches the result to `QuantitativeAnalysis.price_targets` (new optional field).
+2. `orchestrators/portfolio_review/merge.py` copies `quantitative.price_targets` onto `HoldingDecision.price_targets` for both the success and N/A branches.
+3. `reporting/section_generators.py` adds two compact columns to the holdings table (target with `±%` delta, sell-level with `−%` delta) and renders a "🎯 Targets" detail panel inside each ticker's per-holding HTML report (`output/{asset_class}/{ticker}_report.html`) showing target, sell-level, and a one-sentence French rationale per number with a confidence badge (high/medium/low).
+
+Confidence is high when the resistance/support level and the volatility-drift number agree directionally (within 10%), medium when they differ by ≤10%, low when they differ by more than 10% or when price history covers fewer than 120 trading days.
+
+DCF and P/E primitives are deliberately **not** used in this scope: they revert on multi-year cycles and don't fit a 3-6 month horizon. The existing helpers stay available for a future "12-month strategic target" addition.
+
+## Consequences
+
+### Positive
+
+- Every holding in the report carries two actionable numbers users can plug straight into broker stop-loss / take-profit orders.
+- 100% deterministic Python — same inputs produce the same outputs, no AI cost, no external API call beyond the price history we already collect.
+- Reuses existing schemas (`PriceTargets`) and existing math (`quantitative.price_targets`, `quantitative.technical`); the new module is thin orchestration.
+- Works uniformly across stocks, ETFs, and crypto — no per-asset-class output asymmetry that confuses users.
+- Confidence label flags wide-band cases (e.g., a recently-IPO'd stock with 90 days of history) so users don't read precision that isn't there.
+
+### Negative
+
+- Two more columns in the holdings table tighten horizontal layout on narrow screens. Mitigated by keeping each column to a single `$X (±Y%)` format.
+- The 3-6 month horizon is a single point on the spectrum; users running a multi-year buy-and-hold strategy may want a longer-horizon strategic target later. (Followup: revive the existing DCF/PE helpers behind a separate "strategic target" ADR if requested.)
+- ATR-based stop-loss does not adapt to fundamental regime shifts (earnings miss, sector rotation). It catches volatility-aware breaks, not narrative breaks; the qualitative section of the report is still where regime information lives.
+
+### Risks
+
+- **False precision:** users may treat the target as a forecast instead of a tactical reference. Mitigation: explicit "tactical 3-6 mois" label in every rendering site, plus the confidence badge.
+- **Stale price history:** if the data collector returns a frame that's quietly truncated (e.g., yfinance hiccup), targets and sell-levels would lock onto a stale anchor. Mitigation: `compute_tactical_pricing` requires the most-recent date in `price_history` to be within 7 calendar days of "now", otherwise returns `None` and the report shows a `—` placeholder.
+- **Crypto volatility blowing through caps:** the ±40% cap occasionally clips a justified target during fast moves. Acceptable trade-off given the alternative (uncapped projections producing absurd numbers).
+
+## References
+
+- ADR-003: AI Minimalism (drives the deterministic-Python-only constraint).
+- ADR-008: Options-Implied Scenario Probabilities (companion deterministic-derivative work).
+- `src/finwiz/quantitative/price_targets.py` — DCF, P/E, technical, consensus primitives.
+- `src/finwiz/quantitative/derivative_pricing.py` — Black-Scholes used elsewhere.
+- `src/finwiz/schemas/portfolio_review.py:PriceTargets` — destination Pydantic model.
+- `src/finwiz/analysis/stages/quantify.py` — integration point for compute step.
+- `src/finwiz/orchestrators/portfolio_review/merge.py` — propagation point into HoldingDecision.
+- `src/finwiz/reporting/section_generators.py` — render point for both compact and detail surfaces.

--- a/docs/superpowers/plans/2026-04-30-tactical-price-targets.md
+++ b/docs/superpowers/plans/2026-04-30-tactical-price-targets.md
@@ -1,0 +1,1244 @@
+# Tactical Price Targets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic 3-6 month "objectif de cours" (target) and a "niveau de vente" (stop-loss floor) to every holding in the deep-analysis report, computed entirely from price history we already collect.
+
+**Architecture:** New thin orchestration module `quantitative/tactical_pricing.py` that combines existing primitives (`calculate_support_resistance_targets`, ATR, log-return drift) into a `PriceTargets` Pydantic instance. Wiring path: quantify stage → `QuantitativeAnalysis.price_targets` (new optional field) → merge.py copies onto `HoldingDecision.price_targets` (existing optional field) → `section_generators.py` renders compact columns + a detail panel in the per-ticker HTML. 100% Python — no AI.
+
+**Tech Stack:** Python 3.12, Pydantic v2, pandas, NumPy, TA-Lib (already a dep), pytest + pytest-mock.
+
+**Spec:** [docs/adr/ADR-011-tactical-price-targets-and-sell-levels.md](../../adr/ADR-011-tactical-price-targets-and-sell-levels.md).
+
+---
+
+## File Plan
+
+| File | Status | Responsibility |
+|---|---|---|
+| `src/finwiz/quantitative/tactical_pricing.py` | NEW | Public `compute_tactical_pricing()` returning `PriceTargets`. Uses ATR + support/resistance + drift. |
+| `tests/unit/quantitative/test_tactical_pricing.py` | NEW | Unit tests for the helper across asset classes + edge cases. |
+| `src/finwiz/schemas/hybrid_analysis/quantitative.py` | MODIFY | Add `price_targets: PriceTargets \| None = None` field. |
+| `src/finwiz/analysis/stages/quantify.py` | MODIFY | Call `compute_tactical_pricing` after scoring; attach to `QuantitativeAnalysis`. |
+| `tests/unit/analysis/stages/test_quantify.py` | NEW (or extend) | Verify quantify stage propagates `price_targets`. |
+| `src/finwiz/orchestrators/portfolio_review/merge.py` | MODIFY | Copy `quant.price_targets` → `decision.price_targets`. |
+| `tests/unit/orchestrators/test_merge.py` | EXTEND | Verify price_targets propagation. |
+| `src/finwiz/reporting/section_generators.py` | MODIFY | Render two compact columns in holdings table; add table header. |
+| `tests/unit/reporting/test_section_generators.py` | EXTEND | Render compact columns; verify HTML escape + N/A rendering. |
+| `src/finwiz/templates/enriched_analysis_report.html` | MODIFY | Detail panel "🎯 Targets" with confidence badge. |
+| `src/finwiz/reporting/enriched_analysis_report_generator.py` | MODIFY | Pass `price_targets` into template_vars. |
+| `tests/property/test_enriched_analysis_report_properties.py` | EXTEND | Detail panel renders when price_targets present. |
+
+---
+
+## Task 1: Create `tactical_pricing.py` core module
+
+**Files:**
+- Create: `src/finwiz/quantitative/tactical_pricing.py`
+- Test: `tests/unit/quantitative/test_tactical_pricing.py`
+
+- [ ] **Step 1.1: Write the failing test file**
+
+```python
+# tests/unit/quantitative/test_tactical_pricing.py
+"""Tests for tactical_pricing.compute_tactical_pricing helper."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from finwiz.quantitative.tactical_pricing import compute_tactical_pricing
+from finwiz.schemas.portfolio_review import PriceTargets
+
+
+def _series(values: list[float], freq: str = "B") -> pd.Series:
+    """Build a business-day-indexed price series ending today."""
+    end = pd.Timestamp.now().normalize()
+    idx = pd.bdate_range(end=end, periods=len(values))
+    return pd.Series(values, index=idx, dtype=float)
+
+
+class TestStockTactical:
+    def test_returns_pricetargets_for_stock(self) -> None:
+        # 250-day uptrend with mild noise — a typical liquid stock.
+        rng = np.random.default_rng(seed=42)
+        base = np.linspace(100.0, 130.0, 250)
+        noise = rng.normal(0.0, 1.0, 250)
+        prices = _series((base + noise).tolist())
+        result = compute_tactical_pricing(
+            ticker="AAPL",
+            asset_class="stock",
+            price_history=prices,
+            current_price=130.0,
+        )
+        assert isinstance(result, PriceTargets)
+        assert result.current_price == pytest.approx(130.0)
+        assert result.currency == "USD"
+        assert result.sell_target_primary is not None
+        assert result.buy_target_primary is not None
+        # Target above current (stock is in uptrend), sell-level below current.
+        assert result.buy_target_primary > 130.0
+        assert result.sell_target_primary < 130.0
+
+    def test_target_capped_at_25pct_for_stock(self) -> None:
+        # Pathological 10x rip — drift would project crazy upside; cap at +25%.
+        prices = _series([10.0] * 50 + list(np.linspace(10.0, 100.0, 200)))
+        result = compute_tactical_pricing(
+            ticker="MEME",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.0,
+        )
+        assert result is not None
+        assert result.buy_target_primary is not None
+        assert result.buy_target_primary <= 100.0 * 1.25 + 1e-6
+
+    def test_sell_level_uses_higher_of_support_or_atr_floor(self) -> None:
+        # Flat-ish series so technical support is right below current price.
+        # ATR floor = current - 2*ATR; support is the local low.
+        # Whichever is HIGHER (more conservative) wins.
+        prices = _series([100.0, 99.0, 101.0, 100.5, 99.5, 100.2, 100.8] * 30)
+        result = compute_tactical_pricing(
+            ticker="STABLE",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.8,
+        )
+        assert result is not None
+        assert result.sell_target_primary is not None
+        # ATR is small so the floor stays close to current.
+        assert result.sell_target_primary >= 95.0
+        assert result.sell_target_primary <= 100.8
+
+
+class TestETFTactical:
+    def test_returns_pricetargets_for_etf(self) -> None:
+        prices = _series(list(np.linspace(50.0, 60.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="VOO",
+            asset_class="etf",
+            price_history=prices,
+            current_price=60.0,
+        )
+        assert result is not None
+        assert result.buy_rationale.lower().startswith(("target", "objectif", "résistance"))
+
+    def test_etf_uses_same_25pct_cap(self) -> None:
+        prices = _series(list(np.linspace(10.0, 100.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="HYPE",
+            asset_class="etf",
+            price_history=prices,
+            current_price=100.0,
+        )
+        assert result is not None
+        assert result.buy_target_primary <= 100.0 * 1.25 + 1e-6
+
+
+class TestCryptoTactical:
+    def test_crypto_uses_40pct_cap(self) -> None:
+        # Crypto lets drift run further than stocks.
+        prices = _series(list(np.linspace(1000.0, 10000.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="BTC-USD",
+            asset_class="crypto",
+            price_history=prices,
+            current_price=10000.0,
+        )
+        assert result is not None
+        # 40% cap must be respected and must be ABOVE the 25% stock cap.
+        assert result.buy_target_primary <= 10000.0 * 1.40 + 1e-6
+        assert result.buy_target_primary > 10000.0 * 1.25  # widened from stocks
+
+
+class TestEdgeCases:
+    def test_short_history_returns_none(self) -> None:
+        prices = _series([100.0] * 30)  # < 60 days
+        result = compute_tactical_pricing(
+            ticker="NEW",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.0,
+        )
+        assert result is None
+
+    def test_stale_history_returns_none(self) -> None:
+        # Last price is 10 days old → stale; don't lock onto stale anchor.
+        end = pd.Timestamp.now().normalize() - pd.Timedelta(days=10)
+        idx = pd.bdate_range(end=end, periods=120)
+        prices = pd.Series([100.0] * 120, index=idx, dtype=float)
+        result = compute_tactical_pricing(
+            ticker="STALE",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.0,
+        )
+        assert result is None
+
+    def test_zero_current_price_returns_none(self) -> None:
+        prices = _series([100.0] * 120)
+        result = compute_tactical_pricing(
+            ticker="ZERO",
+            asset_class="stock",
+            price_history=prices,
+            current_price=0.0,
+        )
+        assert result is None
+
+    def test_breakout_target_uses_drift_only(self) -> None:
+        # Build prices where current is ABOVE all historical resistance.
+        prices = _series(list(np.linspace(80.0, 100.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="BRK",
+            asset_class="stock",
+            price_history=prices,
+            current_price=110.0,  # above the entire history
+        )
+        assert result is not None
+        assert "breakout" in result.buy_rationale.lower() or "drift" in result.buy_rationale.lower()
+
+
+class TestConfidence:
+    def test_high_confidence_when_signals_agree(self) -> None:
+        # Steady drift + clear resistance → both methods agree directionally.
+        prices = _series(list(np.linspace(100.0, 130.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="AGREE",
+            asset_class="stock",
+            price_history=prices,
+            current_price=130.0,
+        )
+        assert result is not None
+        assert "high" in (result.buy_rationale + result.sell_rationale).lower() or \
+            "élevée" in (result.buy_rationale + result.sell_rationale).lower()
+
+    def test_low_confidence_when_history_short(self) -> None:
+        # 80 days of history, just over the 60-day floor but below 120 → low confidence.
+        prices = _series(list(np.linspace(100.0, 110.0, 80)))
+        result = compute_tactical_pricing(
+            ticker="THIN",
+            asset_class="stock",
+            price_history=prices,
+            current_price=110.0,
+        )
+        assert result is not None
+        rationale = (result.buy_rationale + result.sell_rationale).lower()
+        assert "low" in rationale or "faible" in rationale
+```
+
+- [ ] **Step 1.2: Run the test file to verify it fails (module not yet created)**
+
+```bash
+rtk uv run pytest tests/unit/quantitative/test_tactical_pricing.py --no-cov -v 2>&1 | tail -10
+```
+
+Expected: `ModuleNotFoundError: No module named 'finwiz.quantitative.tactical_pricing'` or import-time collection error on every test.
+
+- [ ] **Step 1.3: Create the module**
+
+Create `src/finwiz/quantitative/tactical_pricing.py`:
+
+```python
+"""Tactical (3-6 month) price targets and sell-level floors per holding.
+
+Thin orchestration over existing primitives:
+- ``calculate_support_resistance_targets`` for technical levels.
+- TA-Lib ATR for volatility-adjusted floor.
+- Log-return drift over the trailing year for forward projection.
+
+Returns a :class:`PriceTargets` Pydantic model already wired into
+``HoldingDecision``. AI-Minimalism (ADR-003) preserved — pure Python.
+
+See ADR-011 for the full design rationale.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+from finwiz.quantitative.price_targets import calculate_support_resistance_targets
+from finwiz.schemas.portfolio_review import PriceTargets
+
+logger = logging.getLogger(__name__)
+
+
+# Drift caps — keep upside projections tied to plausibility.
+_DRIFT_CAP_STOCK_ETF = 0.25
+_DRIFT_CAP_CRYPTO = 0.40
+
+# Minimum history before any computation is meaningful.
+_MIN_HISTORY_DAYS = 60
+_LOW_CONFIDENCE_THRESHOLD_DAYS = 120
+
+# Reject a price series whose last bar is older than this — stale anchor risk.
+_MAX_HISTORY_LAG_DAYS = 7
+
+
+def _atr(prices: pd.Series, period: int = 14) -> float:
+    """Average True Range proxy from a close-only series.
+
+    The full ATR uses high/low/close; here we approximate with abs daily
+    returns × current price, which is a common simplification when only
+    closes are available and is sufficient for a stop-loss floor.
+    """
+    if len(prices) < period + 1:
+        return float("nan")
+    daily_changes = prices.diff().abs().dropna()
+    if daily_changes.empty:
+        return float("nan")
+    rolled = daily_changes.rolling(window=period, min_periods=period).mean()
+    last = rolled.iloc[-1]
+    return float(last) if np.isfinite(last) else float("nan")
+
+
+def _annualized_log_return(prices: pd.Series) -> float:
+    """Compute annualized log return over the supplied window."""
+    if len(prices) < 2:
+        return 0.0
+    log_ret = np.log(prices.iloc[-1] / prices.iloc[0])
+    days = (prices.index[-1] - prices.index[0]).days or 1
+    annualized = float(log_ret) * (365.25 / days)
+    if not np.isfinite(annualized):
+        return 0.0
+    return annualized
+
+
+def _confidence(prices: pd.Series, target: float, drift_target: float, current: float) -> str:
+    """Three-bucket confidence label based on history depth + signal agreement.
+
+    'high'   when both signals agree directionally (within 10%) AND we have
+             enough history (≥ 120 trading days).
+    'low'    when history is short (< 120 days) or the two signals disagree
+             by more than 10%.
+    'medium' otherwise.
+    """
+    if len(prices) < _LOW_CONFIDENCE_THRESHOLD_DAYS:
+        return "low"
+    if current <= 0 or target <= 0 or drift_target <= 0:
+        return "low"
+    pct_diff = abs(target - drift_target) / current
+    if pct_diff <= 0.10:
+        return "high"
+    if pct_diff <= 0.20:
+        return "medium"
+    return "low"
+
+
+def _is_history_fresh(prices: pd.Series) -> bool:
+    """Reject obviously stale price history."""
+    if prices.empty:
+        return False
+    last_dt = prices.index[-1]
+    if not isinstance(last_dt, pd.Timestamp):
+        last_dt = pd.Timestamp(last_dt)
+    age = pd.Timestamp.now().normalize() - last_dt.normalize()
+    return age <= pd.Timedelta(days=_MAX_HISTORY_LAG_DAYS)
+
+
+def compute_tactical_pricing(
+    ticker: str,
+    asset_class: Literal["stock", "etf", "crypto"],
+    price_history: pd.Series,
+    current_price: float,
+    *,
+    horizon_months: int = 4,
+    currency: str = "USD",
+) -> PriceTargets | None:
+    """Compute a 3-6 month tactical target and a stop-loss floor.
+
+    Returns ``None`` when input is unusable:
+    - fewer than 60 trading days of history
+    - last price more than 7 calendar days old (stale anchor risk)
+    - current_price not finite or non-positive
+    """
+    if not np.isfinite(current_price) or current_price <= 0:
+        logger.warning(f"tactical_pricing: invalid current_price={current_price} for {ticker}")
+        return None
+    if len(price_history) < _MIN_HISTORY_DAYS:
+        logger.warning(
+            f"tactical_pricing: insufficient history for {ticker} "
+            f"({len(price_history)} < {_MIN_HISTORY_DAYS} days)",
+        )
+        return None
+    if not _is_history_fresh(price_history):
+        logger.warning(f"tactical_pricing: stale history for {ticker} — skipping")
+        return None
+
+    # ---- target: max(technical resistance, drift projection) capped per asset class ----
+    sr = calculate_support_resistance_targets(price_history, current_price=current_price)
+    resistance = float(sr["resistance"].target_price) or current_price * 1.10
+    support = float(sr["support"].target_price) or current_price * 0.90
+
+    # Annualised log-return → time-projected drift over horizon_months.
+    horizon_years = horizon_months / 12.0
+    annual_log_ret = _annualized_log_return(price_history)
+    drift_target = float(current_price * np.exp(annual_log_ret * horizon_years))
+    if not np.isfinite(drift_target) or drift_target <= 0:
+        drift_target = current_price
+
+    cap = _DRIFT_CAP_CRYPTO if asset_class == "crypto" else _DRIFT_CAP_STOCK_ETF
+    drift_target_capped = float(min(drift_target, current_price * (1.0 + cap)))
+
+    is_breakout = resistance <= current_price
+    if is_breakout:
+        target = drift_target_capped
+        target_method = "breakout — drift-based projection"
+    else:
+        target = float(max(resistance, drift_target_capped))
+        target = float(min(target, current_price * (1.0 + cap)))
+        target_method = "max(résistance technique, dérive projetée)"
+
+    # ---- sell-level: max(support, current - 2*ATR) — more conservative wins ----
+    atr = _atr(price_history)
+    if not np.isfinite(atr):
+        atr_floor = current_price * 0.85  # generous default when ATR can't compute
+    else:
+        atr_floor = current_price - 2.0 * atr
+
+    sell_level = float(max(support, atr_floor))
+    if sell_level >= current_price:  # support above current → use ATR-only
+        sell_level = atr_floor
+    if not np.isfinite(sell_level) or sell_level <= 0:
+        sell_level = current_price * 0.85
+
+    # ---- confidence label ----
+    confidence = _confidence(price_history, target, drift_target_capped, current_price)
+    confidence_fr = {"high": "élevée", "medium": "moyenne", "low": "faible"}[confidence]
+
+    buy_rationale = (
+        f"Target {target_method} sur {horizon_months} mois — confiance {confidence_fr}."
+    )
+    sell_rationale = (
+        f"Plancher = max(support technique, prix − 2×ATR) — confiance {confidence_fr}."
+    )
+
+    return PriceTargets(
+        current_price=current_price,
+        currency=currency,
+        fair_value_estimate=None,  # tactical; no fundamental fair value here
+        buy_target_primary=target,
+        buy_target_secondary=None,
+        buy_rationale=buy_rationale,
+        sell_target_primary=sell_level,
+        sell_target_secondary=None,
+        stop_loss_level=sell_level,
+        sell_rationale=sell_rationale,
+    )
+```
+
+- [ ] **Step 1.4: Run the tests; confirm all pass**
+
+```bash
+rtk uv run pytest tests/unit/quantitative/test_tactical_pricing.py --no-cov -v 2>&1 | tail -25
+```
+
+Expected: 11 tests pass.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/finwiz/quantitative/tactical_pricing.py tests/unit/quantitative/test_tactical_pricing.py
+git commit -m "feat(quant): add tactical_pricing helper for 3-6 month targets and stop floors
+
+Pure-Python orchestration over existing price_targets / TA-Lib primitives.
+Returns the existing PriceTargets schema; ready to be wired into the
+quantify stage in the next task. See ADR-011."
+```
+
+---
+
+## Task 2: Add `price_targets` field to `QuantitativeAnalysis` schema
+
+**Files:**
+- Modify: `src/finwiz/schemas/hybrid_analysis/quantitative.py`
+- Test: extend `tests/unit/schemas/test_hybrid_analysis_schemas.py` (or create if absent)
+
+- [ ] **Step 2.1: Inspect existing test file**
+
+```bash
+ls tests/unit/schemas/test_hybrid_*.py 2>&1 || echo "no schema tests yet"
+```
+
+If no test exists, create `tests/unit/schemas/test_quantitative_schema.py`. Otherwise extend.
+
+- [ ] **Step 2.2: Write the failing test**
+
+In `tests/unit/schemas/test_quantitative_schema.py`:
+
+```python
+"""Schema-level tests for QuantitativeAnalysis.price_targets (ADR-011)."""
+
+from datetime import datetime
+
+from finwiz.schemas.hybrid_analysis.quantitative import QuantitativeAnalysis
+from finwiz.schemas.hybrid_analysis.metadata import DataQualityMetrics
+from finwiz.schemas.portfolio_review import PriceTargets
+
+
+def _build_quant(price_targets: PriceTargets | None = None) -> QuantitativeAnalysis:
+    return QuantitativeAnalysis(
+        composite_score=0.7,
+        fundamental_score=0.7,
+        technical_score=0.7,
+        risk_score=2.0,
+        grade="B",
+        preliminary_recommendation="HOLD",
+        fundamental_metrics={},
+        technical_indicators={},
+        risk_metrics={},
+        calculation_timestamp=datetime.now(),
+        data_quality=DataQualityMetrics(
+            completeness_score=0.9,
+            freshness_score=1.0,
+            accuracy_confidence=0.9,
+            source_reliability=0.85,
+        ),
+        confidence_level=0.9,
+        python_rationale="placeholder rationale",
+        price_targets=price_targets,
+    )
+
+
+def test_quantitative_analysis_accepts_none_price_targets() -> None:
+    quant = _build_quant(price_targets=None)
+    assert quant.price_targets is None
+
+
+def test_quantitative_analysis_accepts_pricetargets_instance() -> None:
+    pt = PriceTargets(
+        current_price=100.0,
+        currency="USD",
+        buy_target_primary=120.0,
+        sell_target_primary=85.0,
+        buy_rationale="r1",
+        sell_rationale="r2",
+    )
+    quant = _build_quant(price_targets=pt)
+    assert quant.price_targets is not None
+    assert quant.price_targets.buy_target_primary == 120.0
+```
+
+- [ ] **Step 2.3: Run the test; expect it to fail**
+
+```bash
+rtk uv run pytest tests/unit/schemas/test_quantitative_schema.py --no-cov -v 2>&1 | tail -10
+```
+
+Expected: `TypeError: ... got an unexpected keyword argument 'price_targets'` or pydantic `extra fields forbidden`.
+
+- [ ] **Step 2.4: Modify the schema**
+
+In `src/finwiz/schemas/hybrid_analysis/quantitative.py`, add the field directly under `python_rationale` (around line 63):
+
+```python
+    # ADR-011: tactical price target + stop-loss floor for the holding.
+    # Optional because computation can return None for short / stale history.
+    # Imported here (not at module top) to avoid a circular import; PriceTargets
+    # lives in portfolio_review which already imports from common/risk.
+    from finwiz.schemas.portfolio_review import PriceTargets  # noqa: E402
+
+    price_targets: PriceTargets | None = Field(
+        default=None,
+        description="Tactical 3-6 month price target and stop-loss floor (ADR-011)",
+    )
+```
+
+If the inline-import approach trips Pydantic forward-ref resolution, move the import to the module top. Verify the schema's existing `model_config` is compatible with the optional field.
+
+- [ ] **Step 2.5: Run the tests; expect pass**
+
+```bash
+rtk uv run pytest tests/unit/schemas/test_quantitative_schema.py --no-cov -v 2>&1 | tail -10
+```
+
+Expected: 2 / 2 pass.
+
+- [ ] **Step 2.6: Run mypy + lint to catch import-cycle regressions**
+
+```bash
+rtk make lint 2>&1 | tail -5
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add src/finwiz/schemas/hybrid_analysis/quantitative.py tests/unit/schemas/test_quantitative_schema.py
+git commit -m "feat(schema): add QuantitativeAnalysis.price_targets (ADR-011)
+
+Optional Pydantic field. None when tactical_pricing returns None
+(short / stale history)."
+```
+
+---
+
+## Task 3: Wire `compute_tactical_pricing` into the quantify stage
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/quantify.py`
+- Test: extend `tests/unit/analysis/stages/test_quantify.py`
+
+- [ ] **Step 3.1: Inspect quantify.py**
+
+```bash
+sed -n '60,95p' src/finwiz/analysis/stages/quantify.py
+```
+
+The integration point is `_result_to_quantitative` around line 60-95. The price history is already available via `HistoricalDataManager` used by the technical engine.
+
+- [ ] **Step 3.2: Write the failing test**
+
+In `tests/unit/analysis/stages/test_quantify.py`, add (or create the file if absent):
+
+```python
+"""Quantify stage attaches tactical price_targets when history is available."""
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from finwiz.analysis.deep_analysis_pipeline import AnalysisContext
+from finwiz.analysis.stages.quantify import calculate_quantitative
+
+
+class _FakeScorer:
+    """Minimal stand-in to avoid heavy DeepAnalysisScorer setup in unit tests."""
+
+    def calculate_composite_score(self, ticker: str, asset_class: str, raw: dict[str, Any]):
+        from finwiz.flow_state_models import DeepAnalysisResult
+
+        return DeepAnalysisResult.model_construct(
+            ticker=ticker,
+            asset_class=asset_class,
+            crew_name="test",
+            composite_score=0.7,
+            grade="B",
+            recommendation="HOLD",
+            rationale="placeholder",
+            risk_details={},
+            fundamental_score=0.7,
+            technical_score=0.7,
+            risk_score=2.0,
+            fundamental_details={},
+            technical_details={},
+            data_freshness_hours=0.5,
+            confidence_level=0.9,
+            warnings=[],
+            data_quality=None,
+            lineage=None,
+            cached=False,
+        )
+
+
+def test_quantify_attaches_price_targets_when_history_available(mocker: Any) -> None:
+    mocker.patch("finwiz.scoring.deep_analysis_scorer.DeepAnalysisScorer", _FakeScorer)
+    end = pd.Timestamp.now().normalize()
+    idx = pd.bdate_range(end=end, periods=250)
+    prices = pd.Series(np.linspace(100.0, 130.0, 250), index=idx)
+    raw = {"current_price": 130.0, "price_history": prices}
+    ctx = AnalysisContext(ticker="AAPL", asset_class="stock", company_name="Apple")
+    result, quant = calculate_quantitative(ctx, raw)
+    assert quant.price_targets is not None
+    assert quant.price_targets.buy_target_primary > 130.0
+    assert quant.price_targets.sell_target_primary < 130.0
+
+
+def test_quantify_no_price_targets_when_history_missing(mocker: Any) -> None:
+    mocker.patch("finwiz.scoring.deep_analysis_scorer.DeepAnalysisScorer", _FakeScorer)
+    raw = {"current_price": 130.0}  # no price_history key
+    ctx = AnalysisContext(ticker="AAPL", asset_class="stock", company_name="Apple")
+    result, quant = calculate_quantitative(ctx, raw)
+    assert quant.price_targets is None
+```
+
+- [ ] **Step 3.3: Run the failing test**
+
+```bash
+rtk uv run pytest tests/unit/analysis/stages/test_quantify.py --no-cov -v 2>&1 | tail -10
+```
+
+Expected: assertion failure on `quant.price_targets is not None` (currently always None).
+
+- [ ] **Step 3.4: Modify quantify.py**
+
+Edit `_calculate_quantitative_inner` to compute and attach price_targets, and edit `_result_to_quantitative` to accept the new arg:
+
+Replace the `_calculate_quantitative_inner` body (around lines 18-32):
+
+```python
+def _calculate_quantitative_inner(
+    ctx: AnalysisContext,
+    raw_data: dict[str, Any],
+) -> tuple[DeepAnalysisResult, QuantitativeAnalysis]:
+    """The original calculate_quantitative body — extracted for testability."""
+    from finwiz.scoring.deep_analysis_scorer import DeepAnalysisScorer
+
+    logger.info(f"Calculating quantitative metrics for {ctx.ticker}")
+    scorer = DeepAnalysisScorer()
+    result = scorer.calculate_composite_score(ctx.ticker, ctx.asset_class, raw_data)
+
+    # ADR-011: compute tactical price targets when we have usable history.
+    price_targets = _maybe_compute_price_targets(ctx, raw_data)
+
+    quant = _result_to_quantitative(result, price_targets=price_targets)
+    logger.info(f"Quantitative: {ctx.ticker} grade={quant.grade} score={quant.composite_score:.2f}")
+    return result, quant
+
+
+def _maybe_compute_price_targets(
+    ctx: AnalysisContext,
+    raw_data: dict[str, Any],
+) -> "PriceTargets | None":
+    """Best-effort tactical pricing. Logs and returns None on any failure."""
+    from finwiz.quantitative.tactical_pricing import compute_tactical_pricing
+
+    history = raw_data.get("price_history")
+    current = raw_data.get("current_price")
+    currency = str(raw_data.get("currency") or "USD")
+    if history is None or current is None:
+        return None
+    try:
+        return compute_tactical_pricing(
+            ticker=ctx.ticker,
+            asset_class=ctx.asset_class,
+            price_history=history,
+            current_price=float(current),
+            currency=currency,
+        )
+    except Exception as exc:  # never let pricing failure derail scoring
+        logger.warning(f"tactical_pricing failed for {ctx.ticker}: {exc}")
+        return None
+```
+
+Add `price_targets` arg to `_result_to_quantitative` (it currently has none) and pass through to the constructor:
+
+```python
+def _result_to_quantitative(
+    result: DeepAnalysisResult,
+    price_targets: "PriceTargets | None" = None,
+) -> QuantitativeAnalysis:
+    """Convert DeepAnalysisResult to QuantitativeAnalysis schema."""
+    # ... existing body unchanged ...
+    return QuantitativeAnalysis(
+        # ... existing fields ...
+        python_rationale=result.rationale,
+        price_targets=price_targets,
+    )
+```
+
+Add the TYPE_CHECKING import at the top of quantify.py:
+
+```python
+if TYPE_CHECKING:
+    from finwiz.analysis.deep_analysis_pipeline import AnalysisContext
+    from finwiz.schemas.portfolio_review import PriceTargets
+```
+
+- [ ] **Step 3.5: Run the test; expect pass**
+
+```bash
+rtk uv run pytest tests/unit/analysis/stages/test_quantify.py --no-cov -v 2>&1 | tail -10
+```
+
+Expected: 2 / 2 pass.
+
+- [ ] **Step 3.6: Verify the data collector populates `price_history` in raw_data**
+
+```bash
+grep -n "price_history\|hist\[" src/finwiz/orchestrators/deep_analysis_data_collector.py | head -10
+```
+
+If `price_history` is NOT a key the collector sets, then the integration test passes only because we mocked it. Check whether the data collector already returns a price series the scorer could use. If not, file the wiring as a sub-task: in `_collect_raw_data` (or the data_collector), after fetching historical prices for the technical analyzer, also expose them as `raw_data["price_history"] = close_series`.
+
+If this sub-task is needed, do it here:
+
+```bash
+grep -n "fetch_historical_data\|HistoricalDataManager" src/finwiz/orchestrators/deep_analysis_data_collector.py | head -5
+```
+
+Add a single line after the existing fetch:
+
+```python
+# ADR-011: expose closes for tactical_pricing.
+collected_data["price_history"] = hist["Close"].dropna()
+```
+
+(Actual code depends on what variables are in scope at the call site — read the surrounding 20 lines first.)
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add src/finwiz/analysis/stages/quantify.py src/finwiz/orchestrators/deep_analysis_data_collector.py tests/unit/analysis/stages/test_quantify.py
+git commit -m "feat(quantify): wire tactical_pricing into quantify stage (ADR-011)
+
+When price_history + current_price are available in raw_data, attach a
+tactical PriceTargets to the QuantitativeAnalysis output. Failure to
+compute tactical pricing never fails the scoring pipeline."
+```
+
+---
+
+## Task 4: Propagate `price_targets` through merge to `HoldingDecision`
+
+**Files:**
+- Modify: `src/finwiz/orchestrators/portfolio_review/merge.py`
+- Test: extend `tests/unit/orchestrators/test_merge.py`
+
+- [ ] **Step 4.1: Write the failing test**
+
+Add to `tests/unit/orchestrators/test_merge.py`:
+
+```python
+def test_merge_propagates_price_targets() -> None:
+    """ADR-011: when a successful deep_result carries price_targets via its
+    enriched analysis, merge.py copies them onto HoldingDecision.price_targets.
+    """
+    from finwiz.flow_state_models import DeepAnalysisResult
+    from finwiz.schemas.portfolio_review import PriceTargets
+
+    decisions = [_stub_decision()]
+    pt = PriceTargets(
+        current_price=100.0,
+        currency="USD",
+        buy_target_primary=120.0,
+        sell_target_primary=85.0,
+        buy_rationale="r1",
+        sell_rationale="r2",
+    )
+    good = DeepAnalysisResult.model_construct(
+        ticker="ASML",
+        asset_class="stock",
+        crew_name="test",
+        composite_score=0.85,
+        grade="A",
+        recommendation="BUY",
+        rationale="ok",
+        confidence="high",
+        cached=False,
+    )
+    # The merge currently inspects deep_result.fact_pack via getattr —
+    # follow the same idiom for price_targets so model_construct shapes
+    # without the field still work.
+    object.__setattr__(good, "price_targets", pt)
+
+    flow_state = _FakeFlowState({"ASML": good})
+    merged = merge_deep_analysis_from_flow_state(decisions, flow_state)
+    assert merged[0].price_targets is not None
+    assert merged[0].price_targets.buy_target_primary == 120.0
+```
+
+- [ ] **Step 4.2: Run the test; expect failure**
+
+```bash
+rtk uv run pytest tests/unit/orchestrators/test_merge.py::test_merge_propagates_price_targets --no-cov -v 2>&1 | tail -8
+```
+
+Expected: `assert merged[0].price_targets is not None` fails (None).
+
+- [ ] **Step 4.3: Modify merge.py**
+
+In `src/finwiz/orchestrators/portfolio_review/merge.py`, inside the `if ticker in deep_analysis_results:` branch (where the existing `decision.fact_pack` line lives), add right after:
+
+```python
+                decision.fact_pack = getattr(deep_result, "fact_pack", None)
+                # ADR-011: propagate tactical price targets when present.
+                decision.price_targets = getattr(deep_result, "price_targets", None)
+```
+
+Note: `DeepAnalysisResult` does not have a `price_targets` field directly. The plan stores it on the **enriched** `QuantitativeAnalysis`. The merge needs to dig: `flow_state.deep_analysis_results[ticker]` is `DeepAnalysisResult`, but enriched is in a separate map. Adjust:
+
+```python
+                # ADR-011: pull price_targets from the enriched analysis if available.
+                enriched_map = getattr(flow_state, "_enriched_analyses", {}) or {}
+                enriched = enriched_map.get(ticker)
+                if enriched is not None and getattr(enriched, "quantitative", None) is not None:
+                    decision.price_targets = getattr(enriched.quantitative, "price_targets", None)
+```
+
+Verify the actual location of enriched results in flow_state by reading `deep_analysis_orchestrator.py:225-260` (the `_store_enriched_analysis` storage path).
+
+- [ ] **Step 4.4: Run the test; expect pass**
+
+```bash
+rtk uv run pytest tests/unit/orchestrators/test_merge.py --no-cov -v 2>&1 | tail -10
+```
+
+Expected: all merge tests pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/finwiz/orchestrators/portfolio_review/merge.py tests/unit/orchestrators/test_merge.py
+git commit -m "feat(merge): propagate price_targets onto HoldingDecision (ADR-011)"
+```
+
+---
+
+## Task 5: Render compact target/sell columns in the holdings table
+
+**Files:**
+- Modify: `src/finwiz/reporting/section_generators.py`
+- Test: extend `tests/unit/reporting/test_section_generators.py`
+
+- [ ] **Step 5.1: Locate the holdings table header + row renderer**
+
+```bash
+grep -n "Position\|Grade\|<th>" src/finwiz/reporting/section_generators.py | head -20
+```
+
+Two surfaces to update: the `<thead>` row (add two `<th>` columns) and `_render_holding_row` (add the two `<td>` cells).
+
+- [ ] **Step 5.2: Write the failing test**
+
+Append to `tests/unit/reporting/test_section_generators.py`:
+
+```python
+def test_holding_row_renders_target_and_sell_columns_when_present() -> None:
+    """ADR-011: holdings with price_targets show two extra columns."""
+    from finwiz.schemas.portfolio_review import PriceTargets
+
+    holding = _build_holding(grade="A", confidence="high")
+    holding.price_targets = PriceTargets(
+        current_price=100.0,
+        currency="USD",
+        buy_target_primary=120.0,
+        sell_target_primary=85.0,
+        buy_rationale="rationale-up",
+        sell_rationale="rationale-down",
+    )
+    html = _render_holding_row(holding)
+    assert "120" in html or "$120" in html  # target value
+    assert "85" in html  # sell-level value
+    assert "+20" in html or "20.0%" in html  # target delta
+    assert "-15" in html or "15.0%" in html or "−15" in html  # sell delta
+
+
+def test_holding_row_renders_dash_when_price_targets_missing() -> None:
+    holding = _build_holding(grade="A", confidence="high")
+    holding.price_targets = None
+    html = _render_holding_row(holding)
+    # The two extra columns must render with em-dash placeholders.
+    # Count td's containing the em-dash to confirm no crash and proper graceful display.
+    assert "—" in html
+```
+
+- [ ] **Step 5.3: Run the test; expect failure**
+
+```bash
+rtk uv run pytest tests/unit/reporting/test_section_generators.py --no-cov -v 2>&1 | tail -10
+```
+
+Expected: assertion failures on missing price values.
+
+- [ ] **Step 5.4: Modify section_generators.py — add helper + update row + update header**
+
+Add a private helper near the top of the file:
+
+```python
+def _format_target_cell(price_targets, current_price: float | None, kind: str) -> str:
+    """Render one of the two ADR-011 columns ('target' or 'sell').
+
+    Returns "<td>—</td>" when no price_targets or current_price is unusable.
+    Otherwise produces "$X (±Y%)" with HTML-safe escaping.
+    """
+    if price_targets is None or current_price is None or current_price <= 0:
+        return '<td class="muted">—</td>'
+    value = (
+        price_targets.buy_target_primary
+        if kind == "target"
+        else price_targets.sell_target_primary
+    )
+    if value is None:
+        return '<td class="muted">—</td>'
+    delta_pct = (value - current_price) / current_price * 100
+    sign = "+" if delta_pct >= 0 else ""
+    return f"<td>${value:,.2f}<br><small>{sign}{delta_pct:.1f}%</small></td>"
+```
+
+In `_render_holding_row`, add the two cells right before the closing `</tr>` of the analyzed branch (do NOT add them to the pending branch — pending rows already have an em-dash filler):
+
+```python
+    # ADR-011 columns
+    target_cell = _format_target_cell(
+        holding.price_targets,
+        getattr(holding.price_targets, "current_price", None) if holding.price_targets else None,
+        kind="target",
+    )
+    sell_cell = _format_target_cell(
+        holding.price_targets,
+        getattr(holding.price_targets, "current_price", None) if holding.price_targets else None,
+        kind="sell",
+    )
+    return f"""
+        <tr>
+          ...existing cells...
+          {target_cell}
+          {sell_cell}
+        </tr>"""
+```
+
+In the table header (the `generate_holdings_analysis` or `generate_holdings_table` function — find via grep), add two new `<th>` cells in the same position:
+
+```html
+<th>Objectif (3-6 mo)</th>
+<th>Niveau de vente</th>
+```
+
+For the **pending** row branch in `_render_holding_row`, add two muted cells so the grid stays aligned:
+
+```python
+        <tr class="row-pending">
+          ...existing cells...
+          <td class="muted">—</td>
+          <td class="muted">—</td>
+        </tr>
+```
+
+- [ ] **Step 5.5: Run the test; expect pass**
+
+```bash
+rtk uv run pytest tests/unit/reporting/test_section_generators.py --no-cov -v 2>&1 | tail -10
+```
+
+Expected: all tests pass (existing ones still + the two new ones).
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add src/finwiz/reporting/section_generators.py tests/unit/reporting/test_section_generators.py
+git commit -m "feat(report): add target/sell columns to holdings table (ADR-011)
+
+Compact two-column block per holding: 'Objectif (3-6 mo)' and 'Niveau de
+vente'. Pending rows show em-dash placeholders so the table grid stays
+aligned. Cells render via _format_target_cell helper with HTML-safe
+escaping."
+```
+
+---
+
+## Task 6: Render "🎯 Targets" detail panel in per-ticker HTML
+
+**Files:**
+- Modify: `src/finwiz/reporting/enriched_analysis_report_generator.py`
+- Modify: `src/finwiz/templates/enriched_analysis_report.html`
+- Test: extend `tests/property/test_enriched_analysis_report_properties.py`
+
+- [ ] **Step 6.1: Write the failing test**
+
+Add to `tests/property/test_enriched_analysis_report_properties.py`, near `TestRendererToleratesSkippedAnalysis`:
+
+```python
+class TestRendererShowsPriceTargets:
+    """ADR-011: per-ticker HTML report shows a Targets panel when price_targets
+    is present; gracefully omits it when None."""
+
+    def _payload_with_targets(self) -> dict:
+        return {
+            "ticker": "AAPL",
+            "company_name": "Apple Inc.",
+            "asset_class": "stock",
+            "analysis_date": datetime.now(),
+            "executive_summary": "summary",
+            "investment_rationale": "rat",
+            "final_grade": "A",
+            "final_recommendation": "BUY",
+            "recommendation_confidence": "HIGH",
+            "final_score": 0.85,
+            "report_word_count": 2000,
+            "unique_insights_count": 5,
+            "processing_time_seconds": 5.0,
+            "llm_cost_dollars": 0.05,
+            "quantitative": {
+                "composite_score": 0.85,
+                "fundamental_score": 0.85,
+                "technical_score": 0.85,
+                "risk_score": 1.5,
+                "grade": "A",
+                "preliminary_recommendation": "BUY",
+                "fundamental_metrics": {},
+                "technical_indicators": {},
+                "risk_metrics": {},
+                "price_targets": {
+                    "current_price": 100.0,
+                    "currency": "USD",
+                    "buy_target_primary": 120.0,
+                    "sell_target_primary": 85.0,
+                    "buy_rationale": "drift + résistance — confiance élevée",
+                    "sell_rationale": "ATR floor — confiance élevée",
+                },
+            },
+            "qualitative": {},
+        }
+
+    def test_detail_panel_renders_when_price_targets_present(self) -> None:
+        gen = EnrichedAnalysisReportGenerator()
+        html = gen.generate_report(self._payload_with_targets())
+        assert "Objectif" in html or "🎯" in html
+        assert "120" in html
+        assert "85" in html
+        assert "élevée" in html or "high" in html.lower()
+
+    def test_detail_panel_omitted_when_price_targets_none(self) -> None:
+        payload = self._payload_with_targets()
+        payload["quantitative"]["price_targets"] = None
+        gen = EnrichedAnalysisReportGenerator()
+        html = gen.generate_report(payload)
+        # Body must not contain the 🎯 panel headline when no targets.
+        assert "🎯 Targets" not in html and "🎯 Objectifs" not in html
+```
+
+- [ ] **Step 6.2: Run the failing test**
+
+```bash
+rtk uv run pytest tests/property/test_enriched_analysis_report_properties.py::TestRendererShowsPriceTargets --no-cov -v 2>&1 | tail -10
+```
+
+Expected: failures on missing template content.
+
+- [ ] **Step 6.3: Pass `price_targets` into template_vars**
+
+In `src/finwiz/reporting/enriched_analysis_report_generator.py`, in `_prepare_template_variables`, after the existing quant/qual extraction (around line 209), append:
+
+```python
+        # ADR-011: surface tactical price targets for the detail panel.
+        template_vars["price_targets"] = quant.get("price_targets") if quant else None
+```
+
+- [ ] **Step 6.4: Add the detail panel block in the template**
+
+In `src/finwiz/templates/enriched_analysis_report.html`, add inside the `{% else %}` (non-skipped) branch, between the recommendation block and the existing quantitative section:
+
+```html
+        {% if price_targets %}
+        <div class="section">
+            <h2>🎯 Objectifs Tactiques (3-6 mois)</h2>
+            <div class="metrics-grid">
+                <div class="metric-card">
+                    <h4>Objectif de cours</h4>
+                    <p class="metric-value">${{ "%.2f"|format(price_targets.buy_target_primary) }}</p>
+                    <small>{{ price_targets.buy_rationale }}</small>
+                </div>
+                <div class="metric-card">
+                    <h4>Niveau de vente</h4>
+                    <p class="metric-value">${{ "%.2f"|format(price_targets.sell_target_primary) }}</p>
+                    <small>{{ price_targets.sell_rationale }}</small>
+                </div>
+                <div class="metric-card">
+                    <h4>Prix actuel</h4>
+                    <p class="metric-value">${{ "%.2f"|format(price_targets.current_price) }}</p>
+                    <small>{{ price_targets.currency }}</small>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+```
+
+- [ ] **Step 6.5: Run the tests; expect pass**
+
+```bash
+rtk uv run pytest tests/property/test_enriched_analysis_report_properties.py::TestRendererShowsPriceTargets --no-cov -v 2>&1 | tail -10
+```
+
+Expected: 2 / 2 pass.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add src/finwiz/reporting/enriched_analysis_report_generator.py src/finwiz/templates/enriched_analysis_report.html tests/property/test_enriched_analysis_report_properties.py
+git commit -m "feat(report): per-ticker '🎯 Objectifs Tactiques' detail panel (ADR-011)
+
+Three metric cards in the per-ticker HTML report when price_targets is
+populated: target, sell-level, and current price (with currency). Panel
+is omitted entirely when targets are None — no empty placeholder."
+```
+
+---
+
+## Task 7: Run the full lint + test sweep
+
+- [ ] **Step 7.1: Lint**
+
+```bash
+rtk make lint 2>&1 | tail -10
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 7.2: Touched-area test sweep**
+
+```bash
+rtk uv run pytest \
+  tests/unit/quantitative/test_tactical_pricing.py \
+  tests/unit/schemas/test_quantitative_schema.py \
+  tests/unit/analysis/stages/test_quantify.py \
+  tests/unit/orchestrators/test_merge.py \
+  tests/unit/reporting/test_section_generators.py \
+  tests/property/test_enriched_analysis_report_properties.py \
+  --no-cov -v --timeout 60 2>&1 | tail -15
+```
+
+Expected: all green.
+
+- [ ] **Step 7.3: Broader regression sweep — adjacent paths**
+
+```bash
+rtk uv run pytest tests/unit/quantitative/ tests/unit/analysis/ tests/unit/orchestrators/ tests/unit/reporting/ --no-cov -q --timeout 60 2>&1 | tail -10
+```
+
+Expected: no regressions.
+
+- [ ] **Step 7.4: Push branch + open PR**
+
+```bash
+rtk git push -u origin feat/tactical-price-targets
+rtk gh pr create --title "feat: tactical price targets and sell-level floors per holding (ADR-011)" --body "$(cat <<'EOF'
+## Summary
+Implements ADR-011. Adds two deterministic price levels to every holding in the deep-analysis report:
+- **Objectif de cours** (3-6 month tactical target)
+- **Niveau de vente** (stop-loss floor = max(support, current − 2×ATR))
+
+Reuses existing primitives in \`quantitative/price_targets.py\` and TA-Lib's ATR. 100% Python — AI Minimalism (ADR-003) preserved.
+
+## Behaviour
+- Compact two columns in the holdings table.
+- "🎯 Objectifs Tactiques" detail panel in the per-ticker HTML report.
+- Confidence label (élevée / moyenne / faible) based on history depth and signal agreement.
+- Returns \`None\` for short (<60d) or stale (>7d lag) history; report shows em-dash placeholders.
+
+## Test plan
+- [x] Unit tests for tactical_pricing across asset classes + edge cases (11 tests)
+- [x] Schema tests for QuantitativeAnalysis.price_targets (2 tests)
+- [x] Quantify stage integration test (2 tests)
+- [x] Merge propagation test
+- [x] Renderer tests — compact columns + detail panel
+- [ ] End-to-end: replay the family portfolio and verify each ticker shows two numbers
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7.5: Final commit (if any leftover changes)**
+
+```bash
+git status --short
+```
+
+If there are leftover changes (from inline import fixes, etc.), commit them with `chore: misc cleanup post-implementation`.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every section of ADR-011 maps to a task above (compute → schema → wiring → render). Compact columns (Q2-C inline) → Task 5; detail panel (Q2-C drill-down) → Task 6; deterministic floor (Q1-A) → Task 1; tactical horizon (Q3-B) → Task 1.
+- **Placeholders:** none — all step content shows the actual code.
+- **Type consistency:** `compute_tactical_pricing` returns `PriceTargets | None`; `QuantitativeAnalysis.price_targets` is `PriceTargets | None`; `HoldingDecision.price_targets` already exists as `PriceTargets | None`. Names consistent across all tasks.
+- **Risk:** Step 3.6 conditionally adds a one-line edit to the data collector; the exact location depends on what's already in scope. The plan flags this and tells the implementer to grep first. Acceptable — alternative would be reading 200 lines of the collector inline.

--- a/src/finwiz/analysis/stages/quantify.py
+++ b/src/finwiz/analysis/stages/quantify.py
@@ -8,11 +8,46 @@ from typing import TYPE_CHECKING, Any
 from finwiz.analysis.stages._resilience import StageContext, stage
 from finwiz.flow_state_models import DeepAnalysisResult
 from finwiz.schemas.hybrid_analysis import QuantitativeAnalysis
+from finwiz.schemas.portfolio_review import PriceTargets
 
 if TYPE_CHECKING:
     from finwiz.analysis.deep_analysis_pipeline import AnalysisContext
 
 logger = logging.getLogger(__name__)
+
+
+def _maybe_compute_price_targets(
+    ctx: AnalysisContext,
+    raw_data: dict[str, Any],
+) -> PriceTargets | None:
+    """Best-effort tactical pricing. Logs and returns None on any failure.
+
+    Failure paths (all return None, never raise upward):
+    - Missing price_history or current_price in raw_data.
+    - compute_tactical_pricing returns None (short / stale / degenerate history).
+    - compute_tactical_pricing itself raises (defensive — pricing is non-critical).
+    """
+    from typing import Literal, cast
+
+    from finwiz.quantitative.tactical_pricing import compute_tactical_pricing
+
+    history = raw_data.get("price_history")
+    current = raw_data.get("current_price")
+    if history is None or current is None:
+        return None
+    currency = str(raw_data.get("currency") or "USD")
+    asset_class = cast(Literal["stock", "etf", "crypto"], ctx.asset_class)
+    try:
+        return compute_tactical_pricing(
+            ticker=ctx.ticker,
+            asset_class=asset_class,
+            price_history=history,
+            current_price=float(current),
+            currency=currency,
+        )
+    except Exception as exc:
+        logger.warning(f"tactical_pricing failed for {ctx.ticker}: {exc}")
+        return None
 
 
 def _calculate_quantitative_inner(
@@ -25,7 +60,11 @@ def _calculate_quantitative_inner(
     logger.info(f"Calculating quantitative metrics for {ctx.ticker}")
     scorer = DeepAnalysisScorer()
     result = scorer.calculate_composite_score(ctx.ticker, ctx.asset_class, raw_data)
-    quant = _result_to_quantitative(result)
+
+    # ADR-011: best-effort tactical price_targets. Never fails the pipeline.
+    price_targets = _maybe_compute_price_targets(ctx, raw_data)
+
+    quant = _result_to_quantitative(result, price_targets=price_targets)
     logger.info(f"Quantitative: {ctx.ticker} grade={quant.grade} score={quant.composite_score:.2f}")
     return result, quant
 
@@ -55,7 +94,7 @@ def calculate_quantitative(
     return _calculate_quantitative_inner(ctx, raw_data)
 
 
-def _result_to_quantitative(result: DeepAnalysisResult) -> QuantitativeAnalysis:
+def _result_to_quantitative(result: DeepAnalysisResult, *, price_targets: PriceTargets | None = None) -> QuantitativeAnalysis:
     """Convert DeepAnalysisResult to QuantitativeAnalysis schema."""
     from datetime import datetime
 
@@ -88,4 +127,5 @@ def _result_to_quantitative(result: DeepAnalysisResult) -> QuantitativeAnalysis:
         ),
         confidence_level=result.confidence_level,
         python_rationale=result.rationale,
+        price_targets=price_targets,
     )

--- a/src/finwiz/flow_state_models.py
+++ b/src/finwiz/flow_state_models.py
@@ -58,6 +58,10 @@ class DeepAnalysisResult(BaseModel):
     # the report renderer's provenance footer. Avoid circular import via late binding.
     fact_pack: Any = Field(default=None, description="FactPack from v5.2 fact_pack stage (Any to avoid circular import)")
 
+    # ADR-011: tactical price targets surfaced to the merge / renderer.
+    # Optional Any to avoid a circular import with hybrid_analysis.PriceTargets.
+    price_targets: Any = Field(default=None, description="Tactical PriceTargets (ADR-011); Any to avoid circular import")
+
     # Sentiment scoring (Phase 14)
     sentiment_score: float | None = Field(None, ge=-1.0, le=1.0, description="Sentiment score from news analysis (-1 bearish to +1 bullish). None = no news data.")
     sentiment_confidence: float | None = Field(None, ge=0.0, le=1.0, description="Confidence in sentiment score. None = no news data.")

--- a/src/finwiz/orchestrators/deep_analysis_data_collector.py
+++ b/src/finwiz/orchestrators/deep_analysis_data_collector.py
@@ -98,6 +98,9 @@ class DeepAnalysisDataCollector:
         if asset_class.lower() in ("stock", "etf") and flattened.get("current_price"):
             self._collect_options_iv(ticker, float(flattened["current_price"]), flattened)
 
+        # ADR-011: expose Close price history for tactical pricing (all asset classes, fails silently)
+        self._collect_price_history(ticker, flattened)
+
         self.logger.info(f"✅ Python collected {len(flattened)} fields: {list(flattened.keys())[:10]}")
         return flattened
 
@@ -400,6 +403,33 @@ class DeepAnalysisDataCollector:
                 self.logger.info(f"✅ Options IV fetched for {ticker}: bull_iv={bull_iv:.3f}, bear_iv={bear_iv:.3f}, T={T:.2f}y")
         except Exception as exc:
             self.logger.warning(f"Options IV fetch skipped for {ticker}: {exc}")
+
+    def _collect_price_history(self, ticker: str, raw_data: dict[str, Any]) -> None:
+        """Fetch 1y daily Close prices and expose as raw_data["price_history"] (pd.Series).
+
+        Reuses the cached HistoricalDataManager — no duplicate yfinance network call when
+        _collect_quantitative_data already fetched for the same ticker/period.
+        Fails silently: price_history simply remains absent from raw_data.
+        """
+        try:
+            from datetime import datetime, timedelta
+
+            from finwiz.quantitative.data import get_historical_data_manager
+
+            end_date = datetime.now()
+            start_date = end_date - timedelta(days=365)
+            data_manager = get_historical_data_manager()
+            hist = data_manager.fetch_historical_data(ticker, start_date, end_date)
+            if hist is None or hist.empty:
+                return
+            close_col = "Close" if "Close" in hist.columns else hist.columns[0]
+            closes = hist[close_col].dropna()
+            if closes.empty:
+                return
+            raw_data["price_history"] = closes
+            self.logger.debug(f"price_history exposed for {ticker}: {len(closes)} days")
+        except Exception as exc:
+            self.logger.warning(f"price_history fetch skipped for {ticker}: {exc}")
 
     def flatten_collected_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """

--- a/src/finwiz/orchestrators/deep_analysis_orchestrator.py
+++ b/src/finwiz/orchestrators/deep_analysis_orchestrator.py
@@ -205,6 +205,12 @@ class DeepAnalysisOrchestrator:
             try:
                 # Functional pipeline - returns BOTH DeepAnalysisResult AND EnrichedAnalysis
                 result, enriched = analyze_holding(ticker, asset_class, company_name, ledger=self._ledger, run_id=self._ledger.run_id)
+
+                # ADR-011: copy tactical price targets onto the result so the merge layer
+                # can propagate them to HoldingDecision without reaching back into _enriched_analyses.
+                if enriched is not None and getattr(enriched.quantitative, "price_targets", None) is not None:
+                    result = result.model_copy(update={"price_targets": enriched.quantitative.price_targets})
+
                 results[ticker] = result
 
                 # Store enriched analysis for HTML generation
@@ -383,6 +389,10 @@ class DeepAnalysisOrchestrator:
 
         for ticker, result, enriched in completed:
             if result:
+                # ADR-011: copy tactical price targets onto the result so the merge layer
+                # can propagate them to HoldingDecision without reaching back into _enriched_analyses.
+                if enriched is not None and getattr(enriched.quantitative, "price_targets", None) is not None:
+                    result = result.model_copy(update={"price_targets": enriched.quantitative.price_targets})
                 results[ticker] = result
                 if enriched:
                     self._enriched_analyses[ticker] = enriched

--- a/src/finwiz/orchestrators/portfolio_review/merge.py
+++ b/src/finwiz/orchestrators/portfolio_review/merge.py
@@ -34,7 +34,9 @@ def merge_deep_analysis_from_flow_state(
                 deep_result = deep_analysis_results[ticker]
 
                 decision.crew_analysis_used = deep_result.crew_name
-                decision.analysis_date = deep_result.analyzed_at
+                # DeepAnalysisResult uses analysis_timestamp (str); cache models use analyzed_at (datetime).
+                # Use getattr with None fallback so both shapes work without crashing.
+                decision.analysis_date = getattr(deep_result, "analyzed_at", None) or getattr(deep_result, "analysis_timestamp", None)
                 decision.composite_score = deep_result.composite_score
                 decision.grade = deep_result.grade
 
@@ -45,6 +47,8 @@ def merge_deep_analysis_from_flow_state(
                 decision.data_freshness = "fresh" if not deep_result.cached else "recent"
                 decision.confidence = getattr(deep_result, "confidence", "high")
                 decision.fact_pack = getattr(deep_result, "fact_pack", None)
+                # ADR-011: propagate tactical price targets through to the renderer.
+                decision.price_targets = getattr(deep_result, "price_targets", None)
 
                 holdings_with_deep_analysis += 1
                 logger.debug(f"Merged deep analysis for {ticker}: grade={deep_result.grade}")

--- a/src/finwiz/quantitative/tactical_pricing.py
+++ b/src/finwiz/quantitative/tactical_pricing.py
@@ -1,0 +1,198 @@
+# src/finwiz/quantitative/tactical_pricing.py
+"""Tactical (3-6 month) price targets and sell-level floors per holding.
+
+Thin orchestration over existing primitives:
+- ``calculate_support_resistance_targets`` for technical levels.
+- A close-only ATR proxy for volatility-adjusted floor.
+- Log-return drift over the trailing window for forward projection.
+
+Returns a :class:`PriceTargets` Pydantic model already wired into
+``HoldingDecision``. AI-Minimalism (ADR-003) preserved — pure Python.
+
+See ADR-011 for the full design rationale.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+from finwiz.quantitative.price_targets import calculate_support_resistance_targets
+from finwiz.schemas.portfolio_review import PriceTargets
+
+logger = logging.getLogger(__name__)
+
+
+# Drift caps — keep upside projections tied to plausibility.
+_DRIFT_CAP_STOCK_ETF = 0.25
+_DRIFT_CAP_CRYPTO = 0.40
+
+# Minimum history before any computation is meaningful.
+_MIN_HISTORY_DAYS = 60
+_LOW_CONFIDENCE_THRESHOLD_DAYS = 120
+
+# Reject a price series whose last bar is older than this — stale anchor risk.
+_MAX_HISTORY_LAG_DAYS = 7
+
+
+def _atr(prices: pd.Series, period: int = 14) -> float:
+    """Average True Range proxy from a close-only series."""
+    if len(prices) < period + 1:
+        return float("nan")
+    daily_changes = prices.diff().abs().dropna()
+    if daily_changes.empty:
+        return float("nan")
+    rolled = daily_changes.rolling(window=period, min_periods=period).mean()
+    last = rolled.iloc[-1]
+    return float(last) if np.isfinite(last) else float("nan")
+
+
+def _annualized_log_return(prices: pd.Series) -> float:
+    """Compute annualized log return over the supplied window."""
+    if len(prices) < 2:
+        return 0.0
+    if prices.iloc[0] <= 0 or prices.iloc[-1] <= 0:
+        return 0.0
+    log_ret = np.log(prices.iloc[-1] / prices.iloc[0])
+    days = (prices.index[-1] - prices.index[0]).days or 1
+    annualized = float(log_ret) * (365.25 / days)
+    if not np.isfinite(annualized):
+        return 0.0
+    return annualized
+
+
+def _confidence(prices: pd.Series, target: float, drift_target: float, current: float) -> str:
+    """Three-bucket confidence label."""
+    if len(prices) < _LOW_CONFIDENCE_THRESHOLD_DAYS:
+        return "low"
+    if current <= 0 or target <= 0 or drift_target <= 0:
+        return "low"
+    pct_diff = abs(target - drift_target) / current
+    if pct_diff <= 0.10:
+        return "high"
+    if pct_diff <= 0.20:
+        return "medium"
+    return "low"
+
+
+def _is_history_fresh(prices: pd.Series) -> bool:
+    """Reject obviously stale price history."""
+    if prices.empty:
+        return False
+    last_dt = prices.index[-1]
+    if not isinstance(last_dt, pd.Timestamp):
+        last_dt = pd.Timestamp(last_dt)
+    # Match the timezone of the input so the subtraction never crashes.
+    if last_dt.tzinfo is not None:
+        now = pd.Timestamp.now(tz=last_dt.tzinfo)
+    else:
+        now = pd.Timestamp.now()
+    age = now.normalize() - last_dt.normalize()
+    return age <= pd.Timedelta(days=_MAX_HISTORY_LAG_DAYS)
+
+
+def compute_tactical_pricing(
+    ticker: str,
+    asset_class: Literal["stock", "etf", "crypto"],
+    price_history: pd.Series,
+    current_price: float,
+    *,
+    horizon_months: int = 4,
+    currency: str = "USD",
+) -> PriceTargets | None:
+    """Compute a 3-6 month tactical target and a stop-loss floor.
+
+    Returns ``None`` when input is unusable:
+    - fewer than 60 trading days of history
+    - last price more than 7 calendar days old
+    - current_price not finite or non-positive
+    """
+    if not np.isfinite(current_price) or current_price <= 0:
+        logger.warning(f"tactical_pricing: invalid current_price={current_price} for {ticker}")
+        return None
+    if len(price_history) < _MIN_HISTORY_DAYS:
+        logger.warning(
+            f"tactical_pricing: insufficient history for {ticker} ({len(price_history)} < {_MIN_HISTORY_DAYS} days)",
+        )
+        return None
+    if not _is_history_fresh(price_history):
+        logger.warning(f"tactical_pricing: stale history for {ticker} — skipping")
+        return None
+
+    # ADR-011 follow-up: reject degenerate price history (NaN-heavy, all-zero).
+    clean = price_history.replace([np.inf, -np.inf], np.nan).dropna()
+    if len(clean) < _MIN_HISTORY_DAYS:
+        logger.warning(
+            f"tactical_pricing: only {len(clean)} clean bars for {ticker} after NaN/inf filter (< {_MIN_HISTORY_DAYS}); skipping",
+        )
+        return None
+    if clean.max() <= 0:
+        logger.warning(f"tactical_pricing: non-positive price series for {ticker}; skipping")
+        return None
+
+    # ---- target: max(technical resistance, drift) capped per asset class ----
+    sr = calculate_support_resistance_targets(clean, current_price=current_price)
+    resistance = float(sr["resistance"].target_price) or current_price * 1.10
+    support = float(sr["support"].target_price) or current_price * 0.90
+
+    horizon_years = horizon_months / 12.0
+    annual_log_ret = _annualized_log_return(clean)
+    drift_target = float(current_price * np.exp(annual_log_ret * horizon_years))
+    if not np.isfinite(drift_target) or drift_target <= 0:
+        drift_target = current_price
+
+    cap = _DRIFT_CAP_CRYPTO if asset_class == "crypto" else _DRIFT_CAP_STOCK_ETF
+    drift_target_capped = float(min(drift_target, current_price * (1.0 + cap)))
+
+    # Breakout: current price has exceeded the historical trading range top.
+    # The S/R function may still return a projected resistance above current price
+    # in this scenario; use the historical high as the breakout detector instead.
+    historical_high = float(clean.max())
+    is_breakout = current_price > historical_high
+    if is_breakout:
+        target = drift_target_capped
+        target_method = "cassure haussière — projection par dérive"
+    else:
+        target = float(max(resistance, drift_target_capped))
+        target = float(min(target, current_price * (1.0 + cap)))
+        target_method = "max(résistance technique, dérive projetée)"
+
+    # ---- sell-level: max(support, current - 2*ATR) ----
+    atr = _atr(clean)
+    if not np.isfinite(atr) or atr == 0.0:
+        atr_floor = current_price * 0.85
+    else:
+        atr_floor = current_price - 2.0 * atr
+
+    sell_level = float(max(support, atr_floor))
+    if sell_level >= current_price:
+        sell_level = atr_floor
+    if not np.isfinite(sell_level) or sell_level <= 0:
+        sell_level = current_price * 0.85
+
+    confidence = _confidence(clean, target, drift_target_capped, current_price)
+    confidence_fr = {"high": "élevée", "medium": "moyenne", "low": "faible"}[confidence]
+
+    buy_rationale = f"Objectif: {target_method} sur {horizon_months} mois — confiance {confidence_fr}."
+    sell_rationale = f"Plancher: max(support technique, prix − 2×ATR) — confiance {confidence_fr}."
+
+    return PriceTargets(
+        current_price=current_price,
+        currency=currency,
+        fair_value_estimate=None,
+        buy_target_primary=target,
+        buy_target_secondary=None,
+        buy_rationale=buy_rationale,
+        sell_target_primary=sell_level,
+        sell_target_secondary=None,
+        stop_loss_level=sell_level,
+        sell_rationale=sell_rationale,
+        calculation_method="tactical_pricing/support_resistance+drift+atr",
+        confidence_level={"high": 0.8, "medium": 0.6, "low": 0.4}[confidence],
+        data_as_of=datetime.now(tz=UTC),
+        data_sources=["price_history"],
+    )

--- a/src/finwiz/reporting/enriched_analysis_report_generator.py
+++ b/src/finwiz/reporting/enriched_analysis_report_generator.py
@@ -213,6 +213,11 @@ class EnrichedAnalysisReportGenerator:
             template_vars["technical_indicators"] = quant.get("technical_indicators", {})
             template_vars["risk_metrics"] = quant.get("risk_metrics", {})
 
+            # ADR-011: pass tactical price targets through for the per-ticker detail panel.
+            template_vars["price_targets"] = quant.get("price_targets") if quant else None
+        else:
+            template_vars["price_targets"] = None
+
         # Extract nested qualitative data for easier template access
         if "qualitative" in data:
             qual = data["qualitative"]

--- a/src/finwiz/reporting/section_generators.py
+++ b/src/finwiz/reporting/section_generators.py
@@ -229,6 +229,28 @@ def _get_deep_analysis_link(ticker: str, asset_class: str) -> str:
     return f"{asset_class_lower}/{ticker}_report.html"
 
 
+def _format_target_cell(price_targets: Any, kind: str) -> str:
+    """Render one of the two ADR-011 compact columns ('target' or 'sell').
+
+    Returns ``<td class="muted">—</td>`` when there is no usable price_targets.
+    Otherwise produces ``<td>$X.XX<br><small>±Y.Y%</small></td>`` with HTML
+    escaping for safety. The ± delta is computed against ``price_targets.current_price``.
+    """
+    if price_targets is None:
+        return '<td class="muted">—</td>'
+    current = getattr(price_targets, "current_price", None)
+    if current is None or current <= 0:
+        return '<td class="muted">—</td>'
+    value = price_targets.buy_target_primary if kind == "target" else price_targets.sell_target_primary
+    if value is None:
+        return '<td class="muted">—</td>'
+    delta_pct = (value - current) / current * 100
+    sign = "+" if delta_pct >= 0 else "−"  # use Unicode minus for tasteful negatives
+    abs_pct = abs(delta_pct)
+    # f-string formatted floats — no operator-supplied content, but escape for defense in depth.
+    return f"<td>${value:,.2f}<br><small>{sign}{abs_pct:.1f}%</small></td>"
+
+
 def _confidence_badge(holding: HoldingDecision) -> str:
     """Render the amber 'Insight IA indisponible' badge when confidence is low.
 
@@ -270,6 +292,8 @@ def _render_holding_row(holding: HoldingDecision) -> str:
           <td class="muted">—</td>
           <td class="muted">—</td>
           <td><small class="muted">Analyse approfondie non disponible — relancer l'analyse pour obtenir un verdict.</small></td>
+          <td class="muted">—</td>
+          <td class="muted">—</td>
         </tr>"""
 
     deep_analysis_link = _get_deep_analysis_link(ticker, holding.asset_class or "stock")
@@ -284,6 +308,9 @@ def _render_holding_row(holding: HoldingDecision) -> str:
     # Render fact pack provenance footer if the holding carries one (v5.2+)
     fp = getattr(holding, "fact_pack", None)
     fact_pack_footer = _fact_pack_provenance_footer(fp) if fp is not None else ""
+    # ADR-011: compact target/sell columns
+    target_cell = _format_target_cell(holding.price_targets, kind="target")
+    sell_cell = _format_target_cell(holding.price_targets, kind="sell")
     return f"""
         <tr>
           <td><strong>{ticker_html}</strong><br><small>{name_safe}</small></td>
@@ -292,6 +319,8 @@ def _render_holding_row(holding: HoldingDecision) -> str:
           <td>{composite_score:.3f}</td>
           <td>{rec_badge}</td>
           <td><small>{rationale_safe}</small>{fact_pack_footer}</td>
+          {target_cell}
+          {sell_cell}
         </tr>"""
 
 
@@ -318,6 +347,8 @@ def generate_holdings_analysis(holdings: list[HoldingDecision]) -> str:
           <th>Score</th>
           <th>Recommendation</th>
           <th>Rationale</th>
+          <th>Objectif (3-6 mo)</th>
+          <th>Niveau de vente</th>
         </tr>
       </thead>
       <tbody>

--- a/src/finwiz/schemas/hybrid_analysis/quantitative.py
+++ b/src/finwiz/schemas/hybrid_analysis/quantitative.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pydantic import BaseModel, Field
 
 from finwiz.schemas.hybrid_analysis.metadata import DataQualityMetrics
+from finwiz.schemas.portfolio_review import PriceTargets
 
 
 class QuantitativeAnalysis(BaseModel):
@@ -61,6 +62,14 @@ class QuantitativeAnalysis(BaseModel):
 
     # Template-based rationale (to be enhanced by AI)
     python_rationale: str = Field(..., min_length=10, description="Template-generated rationale from Python")
+
+    # ADR-011: tactical 3-6 month price target + stop-loss floor.
+    # Optional because compute_tactical_pricing returns None for short / stale /
+    # degenerate history.
+    price_targets: PriceTargets | None = Field(
+        default=None,
+        description="Tactical 3-6 month price target and stop-loss floor (ADR-011)",
+    )
 
     model_config = {
         "str_strip_whitespace": True,

--- a/src/finwiz/templates/enriched_analysis_report.html
+++ b/src/finwiz/templates/enriched_analysis_report.html
@@ -731,6 +731,30 @@
             {% endif %}
         </div>
 
+        {% if price_targets %}
+        <!-- ADR-011: Tactical price targets detail panel -->
+        <div class="section">
+            <h2>🎯 Objectifs Tactiques (3-6 mois)</h2>
+            <div class="metrics-grid">
+                <div class="metric-card">
+                    <h4>Objectif de cours</h4>
+                    <p class="metric-value">${{ "%.2f"|format(price_targets.buy_target_primary) }}</p>
+                    <small>{{ price_targets.buy_rationale }}</small>
+                </div>
+                <div class="metric-card">
+                    <h4>Niveau de vente</h4>
+                    <p class="metric-value">${{ "%.2f"|format(price_targets.sell_target_primary) }}</p>
+                    <small>{{ price_targets.sell_rationale }}</small>
+                </div>
+                <div class="metric-card">
+                    <h4>Prix actuel</h4>
+                    <p class="metric-value">${{ "%.2f"|format(price_targets.current_price) }}</p>
+                    <small>{{ price_targets.currency }}</small>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
         <!-- Quantitative Metrics -->
         <div class="section">
             <h2>📊 Métriques Quantitatives (Python)</h2>

--- a/tests/property/test_enriched_analysis_report_properties.py
+++ b/tests/property/test_enriched_analysis_report_properties.py
@@ -231,6 +231,76 @@ class TestEnrichedAnalysisReportProperties:
         assert "monitoring" in html_content.lower() or "surveillance" in html_content.lower(), "Report must contain monitoring points"
         assert "exit" in html_content.lower() or "sortie" in html_content.lower(), "Report must contain exit triggers"
 
+
+class TestRendererShowsPriceTargets:
+    """ADR-011: per-ticker HTML report shows a Targets panel when price_targets
+    is present; gracefully omits it when None.
+    """
+
+    def _payload_with_targets(self) -> dict:
+        return {
+            "ticker": "AAPL",
+            "company_name": "Apple Inc.",
+            "asset_class": "stock",
+            "analysis_date": datetime.now(),
+            "executive_summary": "summary " * 250,  # past 200-word floor
+            "investment_rationale": "rat " * 600,
+            "final_grade": "A",
+            "final_recommendation": "BUY",
+            "recommendation_confidence": "HIGH",
+            "final_score": 0.85,
+            "report_word_count": 2200,
+            "unique_insights_count": 6,
+            "processing_time_seconds": 5.0,
+            "llm_cost_dollars": 0.05,
+            "quantitative": {
+                "composite_score": 0.85,
+                "fundamental_score": 0.85,
+                "technical_score": 0.85,
+                "risk_score": 1.5,
+                "grade": "A",
+                "preliminary_recommendation": "BUY",
+                "fundamental_metrics": {},
+                "technical_indicators": {},
+                "risk_metrics": {},
+                "price_targets": {
+                    "current_price": 100.0,
+                    "currency": "USD",
+                    "buy_target_primary": 120.0,
+                    "sell_target_primary": 85.0,
+                    "buy_rationale": "Objectif: drift + résistance — confiance élevée.",
+                    "sell_rationale": "Plancher: ATR floor — confiance élevée.",
+                },
+            },
+            "qualitative": {"ai_confidence": 0.9},
+        }
+
+    def test_detail_panel_renders_when_price_targets_present(self) -> None:
+        gen = EnrichedAnalysisReportGenerator()
+        html = gen.generate_report(self._payload_with_targets())
+        # Section heading present.
+        assert "Objectifs Tactiques" in html or "🎯" in html
+        # Both numbers visible.
+        assert "120.00" in html or "$120" in html
+        assert "85.00" in html or "$85" in html
+        # Confidence rationale text appears (escaped or as-is).
+        assert "élevée" in html or "élev" in html  # may be HTML-escaped accent
+
+    def test_detail_panel_omitted_when_price_targets_none(self) -> None:
+        payload = self._payload_with_targets()
+        payload["quantitative"]["price_targets"] = None
+        gen = EnrichedAnalysisReportGenerator()
+        html = gen.generate_report(payload)
+        # Section heading must NOT appear.
+        assert "Objectifs Tactiques" not in html
+
+    def test_detail_panel_omitted_when_price_targets_missing_from_quant(self) -> None:
+        payload = self._payload_with_targets()
+        del payload["quantitative"]["price_targets"]
+        gen = EnrichedAnalysisReportGenerator()
+        html = gen.generate_report(payload)
+        assert "Objectifs Tactiques" not in html
+
     # Additional property: Report generation succeeds for valid data
     @given(enriched_data=enriched_analysis_strategy())
     @settings(max_examples=50, deadline=500, suppress_health_check=[HealthCheck.function_scoped_fixture])

--- a/tests/unit/analysis/stages/test_quantify_price_targets.py
+++ b/tests/unit/analysis/stages/test_quantify_price_targets.py
@@ -1,0 +1,102 @@
+"""Quantify stage attaches price_targets when price_history is available (ADR-011)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from finwiz.analysis.deep_analysis_pipeline import AnalysisContext
+from finwiz.analysis.stages.quantify import calculate_quantitative
+from finwiz.flow_state_models import DeepAnalysisResult
+
+
+class _FakeScorer:
+    """Stand-in for DeepAnalysisScorer to avoid heavy real-data setup."""
+
+    def calculate_composite_score(self, ticker: str, asset_class: str, raw: dict[str, Any]) -> DeepAnalysisResult:
+        return DeepAnalysisResult.model_construct(
+            ticker=ticker,
+            asset_class=asset_class,
+            crew_name="test",
+            composite_score=0.7,
+            grade="B",
+            recommendation="HOLD",
+            rationale="placeholder rationale long enough",
+            risk_details={},
+            fundamental_score=0.7,
+            technical_score=0.7,
+            risk_score=2.0,
+            fundamental_details={},
+            technical_details={},
+            data_freshness_hours=0.5,
+            confidence_level=0.9,
+            warnings=[],
+            data_quality=None,
+            lineage=None,
+            cached=False,
+        )
+
+
+def test_quantify_attaches_price_targets_when_history_available(mocker: Any) -> None:
+    """When raw_data carries price_history + current_price, quantify attaches PriceTargets."""
+    mocker.patch(
+        "finwiz.scoring.deep_analysis_scorer.DeepAnalysisScorer",
+        _FakeScorer,
+    )
+    end = pd.Timestamp.now().normalize()
+    idx = pd.bdate_range(end=end, periods=250)
+    prices = pd.Series(np.linspace(100.0, 130.0, 250), index=idx, dtype=float)
+    raw = {"current_price": 130.0, "price_history": prices}
+    ctx = AnalysisContext(ticker="AAPL", asset_class="stock", company_name="Apple")
+    _result, quant = calculate_quantitative(ctx, raw)
+    assert quant.price_targets is not None
+    assert quant.price_targets.buy_target_primary > 130.0
+    assert quant.price_targets.sell_target_primary < 130.0
+
+
+def test_quantify_no_price_targets_when_history_missing(mocker: Any) -> None:
+    """When raw_data has no price_history, price_targets remains None — never crashes."""
+    mocker.patch(
+        "finwiz.scoring.deep_analysis_scorer.DeepAnalysisScorer",
+        _FakeScorer,
+    )
+    raw = {"current_price": 130.0}  # no price_history key
+    ctx = AnalysisContext(ticker="AAPL", asset_class="stock", company_name="Apple")
+    _result, quant = calculate_quantitative(ctx, raw)
+    assert quant.price_targets is None
+
+
+def test_quantify_no_price_targets_when_current_price_missing(mocker: Any) -> None:
+    """Without current_price the helper returns None — quantify must not crash."""
+    mocker.patch(
+        "finwiz.scoring.deep_analysis_scorer.DeepAnalysisScorer",
+        _FakeScorer,
+    )
+    end = pd.Timestamp.now().normalize()
+    idx = pd.bdate_range(end=end, periods=250)
+    prices = pd.Series(np.linspace(100.0, 130.0, 250), index=idx, dtype=float)
+    raw = {"price_history": prices}  # no current_price
+    ctx = AnalysisContext(ticker="AAPL", asset_class="stock", company_name="Apple")
+    _result, quant = calculate_quantitative(ctx, raw)
+    assert quant.price_targets is None
+
+
+def test_quantify_swallows_tactical_pricing_failures(mocker: Any) -> None:
+    """If tactical_pricing raises (any reason), quantify continues with price_targets=None."""
+    mocker.patch(
+        "finwiz.scoring.deep_analysis_scorer.DeepAnalysisScorer",
+        _FakeScorer,
+    )
+    mocker.patch(
+        "finwiz.quantitative.tactical_pricing.compute_tactical_pricing",
+        side_effect=RuntimeError("simulated pricing crash"),
+    )
+    end = pd.Timestamp.now().normalize()
+    idx = pd.bdate_range(end=end, periods=250)
+    prices = pd.Series(np.linspace(100.0, 130.0, 250), index=idx, dtype=float)
+    raw = {"current_price": 130.0, "price_history": prices}
+    ctx = AnalysisContext(ticker="AAPL", asset_class="stock", company_name="Apple")
+    _result, quant = calculate_quantitative(ctx, raw)
+    assert quant.price_targets is None  # graceful degradation, no exception

--- a/tests/unit/orchestrators/test_merge.py
+++ b/tests/unit/orchestrators/test_merge.py
@@ -1,0 +1,188 @@
+"""Unit tests for merge.py — ADR-011 price_targets propagation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from finwiz.orchestrators.portfolio_review.merge import merge_deep_analysis_from_flow_state
+from finwiz.schemas.common import RiskAssessmentStandardized
+from finwiz.schemas.portfolio_review import HoldingDecision, PriceTargets
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _stub_decision(ticker: str = "ASML") -> HoldingDecision:
+    """Return a minimal, valid HoldingDecision with defaults for all required fields."""
+    return HoldingDecision(
+        asset_class="stock",
+        name="ASML Holding NV",
+        ticker=ticker,
+        currency="EUR",
+        decision="KEEP",
+        composite_score=0.6,
+        grade="D",
+        grade_description="Placeholder",
+        recommended_action="Analyse en attente",
+        risk=RiskAssessmentStandardized(
+            score=3.0,
+            level="Medium",
+        ),
+    )
+
+
+class _FakeFlowState:
+    """Minimal flow-state stub accepted by merge_deep_analysis_from_flow_state."""
+
+    def __init__(self, deep_analysis_results: dict[str, Any], portfolio_alternatives: dict[str, Any] | None = None) -> None:
+        self.deep_analysis_results = deep_analysis_results
+        self.portfolio_alternatives = portfolio_alternatives or {}
+
+
+# ---------------------------------------------------------------------------
+# Tests: basic merge (smoke tests)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_returns_decisions_unchanged_when_no_results() -> None:
+    """When deep_analysis_results is empty, decisions come back unmodified."""
+    decisions = [_stub_decision()]
+    flow_state = _FakeFlowState({})
+    merged = merge_deep_analysis_from_flow_state(decisions, flow_state)
+    assert len(merged) == 1
+    assert merged[0].ticker == "ASML"
+
+
+def test_merge_sets_grade_na_when_ticker_missing() -> None:
+    """A ticker absent from deep_analysis_results gets grade='N/A' (DELL-panic fix).
+
+    The map must be non-empty (otherwise merge returns early); ASML is missing
+    while a different ticker (MSFT) is present so the else-branch runs for ASML.
+    """
+    from finwiz.flow_state_models import DeepAnalysisResult
+
+    decisions = [_stub_decision()]
+    other = DeepAnalysisResult.model_construct(
+        ticker="MSFT",
+        asset_class="stock",
+        crew_name="stock_crew",
+        composite_score=0.9,
+        grade="A+",
+        recommendation="BUY",
+        rationale="great",
+        confidence="high",
+        cached=False,
+    )
+    # MSFT result present, but ASML is absent — should trigger N/A branch
+    flow_state = _FakeFlowState({"MSFT": other})
+    merged = merge_deep_analysis_from_flow_state(decisions, flow_state)
+    assert merged[0].grade == "N/A"
+    assert merged[0].composite_score == 0.0
+
+
+def test_merge_sets_grade_from_deep_result() -> None:
+    """When deep result exists, grade and composite_score are copied through."""
+    from finwiz.flow_state_models import DeepAnalysisResult
+
+    decisions = [_stub_decision()]
+    good = DeepAnalysisResult.model_construct(
+        ticker="ASML",
+        asset_class="stock",
+        crew_name="stock_crew",
+        composite_score=0.85,
+        grade="A",
+        recommendation="BUY",
+        rationale="ok",
+        confidence="high",
+        cached=False,
+    )
+    flow_state = _FakeFlowState({"ASML": good})
+    merged = merge_deep_analysis_from_flow_state(decisions, flow_state)
+    assert merged[0].grade == "A"
+    assert merged[0].composite_score == pytest.approx(0.85)
+
+
+# ---------------------------------------------------------------------------
+# Tests: ADR-011 price_targets propagation
+# ---------------------------------------------------------------------------
+
+
+def test_merge_propagates_price_targets() -> None:
+    """ADR-011: merge.py copies deep_result.price_targets onto decision.price_targets."""
+    from finwiz.flow_state_models import DeepAnalysisResult
+
+    decisions = [_stub_decision()]
+    pt = PriceTargets(
+        current_price=100.0,
+        currency="USD",
+        buy_target_primary=120.0,
+        sell_target_primary=85.0,
+        buy_rationale="r1",
+        sell_rationale="r2",
+        data_as_of=datetime.now(tz=UTC),
+    )
+    good = DeepAnalysisResult.model_construct(
+        ticker="ASML",
+        asset_class="stock",
+        crew_name="test",
+        composite_score=0.85,
+        grade="A",
+        recommendation="BUY",
+        rationale="ok",
+        confidence="high",
+        cached=False,
+        price_targets=pt,
+    )
+    flow_state = _FakeFlowState({"ASML": good})
+    merged = merge_deep_analysis_from_flow_state(decisions, flow_state)
+    assert merged[0].price_targets is not None
+    assert merged[0].price_targets.buy_target_primary == 120.0
+    assert merged[0].price_targets.sell_target_primary == 85.0
+
+
+def test_merge_handles_missing_price_targets_gracefully() -> None:
+    """If deep_result has no price_targets, decision.price_targets stays None — no crash."""
+    from finwiz.flow_state_models import DeepAnalysisResult
+
+    decisions = [_stub_decision()]
+    good = DeepAnalysisResult.model_construct(
+        ticker="ASML",
+        asset_class="stock",
+        crew_name="test",
+        composite_score=0.85,
+        grade="A",
+        recommendation="BUY",
+        rationale="ok",
+        confidence="high",
+        cached=False,
+        # NOTE: no price_targets attribute set
+    )
+    flow_state = _FakeFlowState({"ASML": good})
+    merged = merge_deep_analysis_from_flow_state(decisions, flow_state)
+    assert merged[0].price_targets is None  # default from HoldingDecision
+
+
+def test_merge_propagates_price_targets_with_none_explicitly() -> None:
+    """If deep_result.price_targets is explicitly None, decision.price_targets stays None."""
+    from finwiz.flow_state_models import DeepAnalysisResult
+
+    decisions = [_stub_decision()]
+    good = DeepAnalysisResult.model_construct(
+        ticker="ASML",
+        asset_class="stock",
+        crew_name="test",
+        composite_score=0.85,
+        grade="A",
+        recommendation="BUY",
+        rationale="ok",
+        confidence="high",
+        cached=False,
+        price_targets=None,
+    )
+    flow_state = _FakeFlowState({"ASML": good})
+    merged = merge_deep_analysis_from_flow_state(decisions, flow_state)
+    assert merged[0].price_targets is None

--- a/tests/unit/quantitative/test_tactical_pricing.py
+++ b/tests/unit/quantitative/test_tactical_pricing.py
@@ -1,0 +1,248 @@
+# tests/unit/quantitative/test_tactical_pricing.py
+"""Tests for tactical_pricing.compute_tactical_pricing helper."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from finwiz.quantitative.tactical_pricing import compute_tactical_pricing
+from finwiz.schemas.portfolio_review import PriceTargets
+
+
+def _series(values: list[float], freq: str = "B") -> pd.Series:
+    """Build a business-day-indexed price series ending today."""
+    end = pd.Timestamp.now().normalize()
+    idx = pd.bdate_range(end=end, periods=len(values))
+    return pd.Series(values, index=idx, dtype=float)
+
+
+class TestStockTactical:
+    def test_returns_pricetargets_for_stock(self) -> None:
+        rng = np.random.default_rng(seed=42)
+        base = np.linspace(100.0, 130.0, 250)
+        noise = rng.normal(0.0, 1.0, 250)
+        prices = _series((base + noise).tolist())
+        result = compute_tactical_pricing(
+            ticker="AAPL",
+            asset_class="stock",
+            price_history=prices,
+            current_price=130.0,
+        )
+        assert isinstance(result, PriceTargets)
+        assert result.current_price == pytest.approx(130.0)
+        assert result.currency == "USD"
+        assert result.sell_target_primary is not None
+        assert result.buy_target_primary is not None
+        assert result.buy_target_primary > 130.0
+        assert result.sell_target_primary < 130.0
+
+    def test_target_capped_at_25pct_for_stock(self) -> None:
+        prices = _series([10.0] * 50 + list(np.linspace(10.0, 100.0, 200)))
+        result = compute_tactical_pricing(
+            ticker="MEME",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.0,
+        )
+        assert result is not None
+        assert result.buy_target_primary is not None
+        assert result.buy_target_primary <= 100.0 * 1.25 + 1e-6
+
+    def test_sell_level_uses_higher_of_support_or_atr_floor(self) -> None:
+        prices = _series([100.0, 99.0, 101.0, 100.5, 99.5, 100.2, 100.8] * 30)
+        result = compute_tactical_pricing(
+            ticker="STABLE",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.8,
+        )
+        assert result is not None
+        assert result.sell_target_primary is not None
+        assert result.sell_target_primary >= 95.0
+        assert result.sell_target_primary <= 100.8
+
+
+class TestETFTactical:
+    def test_returns_pricetargets_for_etf(self) -> None:
+        prices = _series(list(np.linspace(50.0, 60.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="VOO",
+            asset_class="etf",
+            price_history=prices,
+            current_price=60.0,
+        )
+        assert result is not None
+        assert result.buy_rationale.lower().startswith("objectif")
+
+    def test_etf_uses_same_25pct_cap(self) -> None:
+        prices = _series(list(np.linspace(10.0, 100.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="HYPE",
+            asset_class="etf",
+            price_history=prices,
+            current_price=100.0,
+        )
+        assert result is not None
+        assert result.buy_target_primary <= 100.0 * 1.25 + 1e-6
+
+
+class TestCryptoTactical:
+    def test_crypto_uses_40pct_cap(self) -> None:
+        prices = _series(list(np.linspace(1000.0, 10000.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="BTC-USD",
+            asset_class="crypto",
+            price_history=prices,
+            current_price=10000.0,
+        )
+        assert result is not None
+        assert result.buy_target_primary <= 10000.0 * 1.40 + 1e-6
+        assert result.buy_target_primary > 10000.0 * 1.25
+
+
+class TestEdgeCases:
+    def test_short_history_returns_none(self) -> None:
+        prices = _series([100.0] * 30)
+        result = compute_tactical_pricing(
+            ticker="NEW",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.0,
+        )
+        assert result is None
+
+    def test_stale_history_returns_none(self) -> None:
+        end = pd.Timestamp.now().normalize() - pd.Timedelta(days=10)
+        idx = pd.bdate_range(end=end, periods=120)
+        prices = pd.Series([100.0] * 120, index=idx, dtype=float)
+        result = compute_tactical_pricing(
+            ticker="STALE",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.0,
+        )
+        assert result is None
+
+    def test_zero_current_price_returns_none(self) -> None:
+        prices = _series([100.0] * 120)
+        result = compute_tactical_pricing(
+            ticker="ZERO",
+            asset_class="stock",
+            price_history=prices,
+            current_price=0.0,
+        )
+        assert result is None
+
+    def test_breakout_target_uses_drift_only(self) -> None:
+        prices = _series(list(np.linspace(80.0, 100.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="BRK",
+            asset_class="stock",
+            price_history=prices,
+            current_price=110.0,
+        )
+        assert result is not None
+        assert "cassure" in result.buy_rationale.lower() or "dérive" in result.buy_rationale.lower()
+
+    def test_exactly_60_days_passes_min_history_check(self) -> None:
+        """Boundary: spec says 'fewer than 60 days' → None; exactly 60 should pass."""
+        prices = _series(list(np.linspace(100.0, 110.0, 60)))
+        result = compute_tactical_pricing(
+            ticker="EDGE60",
+            asset_class="stock",
+            price_history=prices,
+            current_price=110.0,
+        )
+        # 60 days passes the >= guard; result should be non-None (low confidence).
+        assert result is not None
+
+    def test_nan_heavy_history_returns_none(self) -> None:
+        """A series that drops to <60 clean bars after NaN filter must return None."""
+        values = [100.0, np.nan] * 60 + [np.nan] * 30  # ~60 valid bars
+        # Only ~60 valid bars survives the NaN filter from 150 total — borderline.
+        prices = _series(values)
+        result = compute_tactical_pricing(
+            ticker="NANSY",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.0,
+        )
+        # Either returns None (preferred) or a valid PriceTargets — but must not crash.
+        if result is not None:
+            assert result.buy_target_primary > 0
+            assert result.sell_target_primary > 0
+
+    def test_all_zero_history_returns_none(self) -> None:
+        """All-zero history is degenerate — return None with a logged warning."""
+        prices = _series([0.0] * 150)
+        result = compute_tactical_pricing(
+            ticker="ZEROS",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.0,
+        )
+        assert result is None
+
+    def test_flat_price_series_uses_default_atr_floor(self) -> None:
+        """Flat (zero-volatility) series must NOT produce sell_level == current_price.
+
+        Regression: ATR is 0.0 for an all-identical series, which previously made
+        atr_floor = current - 0 = current, triggering immediate stop-loss exit.
+        """
+        prices = _series([100.0] * 150)
+        result = compute_tactical_pricing(
+            ticker="FLAT",
+            asset_class="stock",
+            price_history=prices,
+            current_price=100.0,
+        )
+        # When this is a degenerate input, the function may return None
+        # (per all-zero / non-positive guard). If it returns a result, sell_level
+        # must be strictly below current_price.
+        if result is not None:
+            assert result.sell_target_primary < 100.0
+
+
+class TestTimezone:
+    def test_tz_aware_history_does_not_crash(self) -> None:
+        """yfinance returns tz-aware indexes; the helper must not crash on them."""
+        end = pd.Timestamp.now(tz="America/New_York").normalize()
+        idx = pd.bdate_range(end=end, periods=150, tz="America/New_York")
+        prices = pd.Series(np.linspace(100.0, 130.0, 150), index=idx)
+        result = compute_tactical_pricing(
+            ticker="AAPL",
+            asset_class="stock",
+            price_history=prices,
+            current_price=130.0,
+        )
+        # Must not raise; should produce a valid result.
+        assert result is not None
+        assert result.buy_target_primary > 130.0
+
+
+class TestConfidence:
+    def test_high_confidence_when_signals_agree(self) -> None:
+        prices = _series(list(np.linspace(100.0, 130.0, 250)))
+        result = compute_tactical_pricing(
+            ticker="AGREE",
+            asset_class="stock",
+            price_history=prices,
+            current_price=130.0,
+        )
+        assert result is not None
+        rationale = (result.buy_rationale + result.sell_rationale).lower()
+        assert "high" in rationale or "élevée" in rationale
+
+    def test_low_confidence_when_history_short(self) -> None:
+        prices = _series(list(np.linspace(100.0, 110.0, 80)))
+        result = compute_tactical_pricing(
+            ticker="THIN",
+            asset_class="stock",
+            price_history=prices,
+            current_price=110.0,
+        )
+        assert result is not None
+        rationale = (result.buy_rationale + result.sell_rationale).lower()
+        assert "low" in rationale or "faible" in rationale

--- a/tests/unit/reporting/test_section_generators.py
+++ b/tests/unit/reporting/test_section_generators.py
@@ -136,3 +136,51 @@ def test_holding_decision_accepts_typical_ticker_formats() -> None:
             confidence="high",
         )
         assert h.ticker == ticker
+
+
+# ---------------------------------------------------------------------------
+# ADR-011: compact target/sell columns
+# ---------------------------------------------------------------------------
+
+
+def test_holding_row_renders_target_and_sell_columns_when_present() -> None:
+    """ADR-011: holdings with price_targets show two extra columns."""
+    from datetime import UTC, datetime
+
+    from finwiz.schemas.portfolio_review import PriceTargets
+
+    holding = _build_holding(grade="A", confidence="high")
+    holding.price_targets = PriceTargets(
+        current_price=100.0,
+        currency="USD",
+        buy_target_primary=120.0,
+        sell_target_primary=85.0,
+        buy_rationale="rationale-up",
+        sell_rationale="rationale-down",
+        data_as_of=datetime.now(tz=UTC),
+    )
+    html = _render_holding_row(holding)
+    # The two values appear in the row.
+    assert "120.00" in html or "$120" in html
+    assert "85.00" in html or "$85" in html
+    # Delta annotations appear (target +20%, sell -15%).
+    assert "+20" in html or "20.0%" in html
+    assert "-15" in html or "−15" in html or "15.0%" in html
+
+
+def test_holding_row_renders_dash_when_price_targets_missing() -> None:
+    """No price_targets -> both ADR-011 cells render the muted em-dash placeholder."""
+    holding = _build_holding(grade="A", confidence="high")
+    holding.price_targets = None
+    html = _render_holding_row(holding)
+    # Em-dash appears at least twice (once per ADR-011 column).
+    assert html.count("—") >= 2
+
+
+def test_pending_row_includes_price_target_placeholders() -> None:
+    """Pending rows must keep the table grid aligned with em-dashes for the new columns."""
+    holding = _build_holding(grade="N/A", confidence="low")
+    holding.price_targets = None  # pending rows never have price_targets
+    html = _render_holding_row(holding)
+    # Pending row already has em-dashes for grade/score; ADR-011 columns add 2 more.
+    assert html.count("—") >= 4

--- a/tests/unit/schemas/test_quantitative_schema.py
+++ b/tests/unit/schemas/test_quantitative_schema.py
@@ -1,0 +1,51 @@
+"""Schema tests for QuantitativeAnalysis.price_targets (ADR-011)."""
+
+from datetime import UTC, datetime
+
+from finwiz.schemas.hybrid_analysis.metadata import DataQualityMetrics
+from finwiz.schemas.hybrid_analysis.quantitative import QuantitativeAnalysis
+from finwiz.schemas.portfolio_review import PriceTargets
+
+
+def _build_quant(price_targets: PriceTargets | None = None) -> QuantitativeAnalysis:
+    return QuantitativeAnalysis(
+        composite_score=0.7,
+        fundamental_score=0.7,
+        technical_score=0.7,
+        risk_score=2.0,
+        grade="B",
+        preliminary_recommendation="HOLD",
+        fundamental_metrics={},
+        technical_indicators={},
+        risk_metrics={},
+        calculation_timestamp=datetime.now(),
+        data_quality=DataQualityMetrics(
+            completeness_score=0.9,
+            freshness_score=1.0,
+            accuracy_confidence=0.9,
+            source_reliability=0.85,
+        ),
+        confidence_level=0.9,
+        python_rationale="placeholder rationale",
+        price_targets=price_targets,
+    )
+
+
+def test_quantitative_analysis_accepts_none_price_targets() -> None:
+    quant = _build_quant(price_targets=None)
+    assert quant.price_targets is None
+
+
+def test_quantitative_analysis_accepts_pricetargets_instance() -> None:
+    pt = PriceTargets(
+        current_price=100.0,
+        currency="USD",
+        buy_target_primary=120.0,
+        sell_target_primary=85.0,
+        buy_rationale="r1",
+        sell_rationale="r2",
+        data_as_of=datetime.now(tz=UTC),
+    )
+    quant = _build_quant(price_targets=pt)
+    assert quant.price_targets is not None
+    assert quant.price_targets.buy_target_primary == 120.0


### PR DESCRIPTION
## Summary
Implements [ADR-011](docs/adr/ADR-011-tactical-price-targets-and-sell-levels.md). Adds two deterministic, AI-free price levels to every holding in the deep-analysis report:

- **Objectif de cours** (3-6 month tactical target) = `max(next major technical resistance, drift-projected price)`, capped at ±25% (stocks/ETFs) or ±40% (crypto). Uses log-return drift over the trailing 12 months.
- **Niveau de vente** (stop-loss floor) = `max(nearest technical support, current_price − 2 × ATR(14))`. Always strictly below current_price; ATR-only fallback when support is above current.

Pure Python — AI Minimalism (ADR-003) preserved. Reuses existing primitives in \`quantitative/price_targets.py\` + a close-only ATR proxy.

## What you'll see
- **Two new columns** in the consolidated holdings table: \`Objectif (3-6 mo)\` and \`Niveau de vente\`. Each shows \`\$value\` plus a ±%delta vs current price. Pending rows render em-dashes so the grid stays aligned.
- **🎯 Objectifs Tactiques (3-6 mois)** detail panel in the per-ticker enriched HTML report with three metric cards: target, sell-level, current price.
- **Confidence label** baked into every rationale string: élevée / moyenne / faible based on history depth (≥120 trading days for high) and signal agreement (≤10% divergence).
- **Graceful degradation**: returns \`None\` for short (<60d) or stale (>7d lag) or degenerate (NaN-heavy / all-zero / non-positive) history; the report shows em-dashes instead of garbage.

## Architecture
Thin orchestration: new \`quantitative/tactical_pricing.py\` (single \`compute_tactical_pricing\` entry point) returning the existing \`PriceTargets\` Pydantic model. Wiring path:
\`quantify stage → QuantitativeAnalysis.price_targets (new field) → DeepAnalysisResult.price_targets (new field, mirrors fact_pack pattern) → merge.py → HoldingDecision.price_targets (existing field) → renderer (compact columns + detail panel)\`.

## Test plan
- [x] Unit tests for \`tactical_pricing\` across stocks/ETFs/crypto + edge cases — **17 tests** including tz-aware indexes, all-zero series, NaN-heavy interior, exact 60-day boundary, breakout detection, confidence labelling
- [x] Schema tests for \`QuantitativeAnalysis.price_targets\` — **2 tests** (None and populated)
- [x] Quantify stage integration — **4 tests** (history available, missing history, missing current_price, helper raises)
- [x] Merge propagation — **3 tests** (propagation, missing field, explicit None)
- [x] Holdings table compact columns — **3 tests** (values + deltas, em-dashes, pending alignment)
- [x] Per-ticker detail panel — **3 tests** (renders, omitted on None, omitted on missing key)
- [x] Lint clean (\`make lint\`)
- [x] **296/298 passing** in the broader regression sweep — the 2 failures are pre-existing flaky property tests (\`test_property_result_structure_validation\`, \`test_property_pipeline_integration\`) that hit FRED rate limits + use banned \`unittest.mock\`; they fail on main too
- [ ] End-to-end: replay the family portfolio with \`crewai flow kickoff\` and verify each holding shows two numbers in the table + the detail panel in the per-ticker page

## Notes for reviewers
- **AI Minimalism preserved**: zero AI calls, zero new external API calls (price history is reused from the data manager's existing fetch path through its 15-minute disk cache).
- **No schema breaking changes**: \`QuantitativeAnalysis.price_targets\` and \`DeepAnalysisResult.price_targets\` are both optional with default \`None\`. Existing callers continue to work.
- **No regressions**: every code-quality reviewer round was \`APPROVED\`. Two CRITICAL bugs caught + fixed in T1 review (tz-aware crash + ATR=0 degenerate sell-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tactical price targets: 3–6 month buy objectives and stop-loss sell levels derived from technical support/resistance and volatility analysis.
  * Holdings table now displays two new columns: target price (with percentage delta) and sell level.
  * Enriched analysis reports include a new "Targets" section with buy/sell targets, current price, and confidence metrics.

* **Documentation**
  * Introduced architectural design and implementation plan for tactical price-target computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->