### PR TITLE
feat(reporting): surface costly AI research as report quintessence

### DIFF
--- a/src/finwiz/orchestrators/reporting/enrichment.py
+++ b/src/finwiz/orchestrators/reporting/enrichment.py
@@ -70,6 +70,15 @@ class ReportEnrichmentMixin:
         # Synthesize portfolio-level strategic posture from per-holding strategic analyses (best-effort).
         portfolio_strategic_posture = self._synthesize_portfolio_strategic(deep_analysis_results)
 
+        # Distill per-holding "quintessence" cards from the costly enriched JSON (best-effort).
+        holdings_insights = self._extract_holdings_insights(deep_analysis_results)
+
+        # Gap-fill opportunity shortlist: prefer state, fall back to the on-disk file.
+        opportunity_shortlist = self._load_opportunity_shortlist()
+
+        # Real LLM cost read live from the token monitor (state.llm_* is populated after report()).
+        cost_summary = self._read_live_cost_summary()
+
         report_path = generate_python_report(
             portfolio_review=portfolio_review,
             deep_analysis_results=deep_analysis_results,
@@ -82,9 +91,150 @@ class ReportEnrichmentMixin:
             portfolio_strategic_posture=portfolio_strategic_posture,
             run_ledger=getattr(self.state, "run_ledger", None),
             deep_analysis_coverage=getattr(self.state, "deep_analysis_coverage", None),
+            holdings_insights=holdings_insights,
+            opportunity_shortlist=opportunity_shortlist,
+            cost_summary=cost_summary,
         )
 
         return report_path
+
+    def _load_opportunity_shortlist(self) -> Any:
+        """Return the gap-fill opportunity shortlist (state preferred, file fallback).
+
+        Best-effort: returns None on any failure so the report still renders.
+        """
+        shortlist = getattr(self.state, "opportunity_shortlist", None)
+        if shortlist:
+            return shortlist
+        try:
+            shortlist_path = Path("output/discovery/opportunity_shortlist.json")
+            if shortlist_path.exists():
+                return json.loads(shortlist_path.read_text())
+        except Exception as e:
+            self.logger.debug(f"Could not load opportunity shortlist file: {e}")
+        return None
+
+    def _read_live_cost_summary(self) -> dict[str, Any] | None:
+        """Read the live LLM cost summary from the token monitor (best-effort).
+
+        ``state.llm_total_cost`` / ``llm_cost_summary`` are populated only *after*
+        report generation, so we read the monitor directly at report time.
+        """
+        try:
+            from finwiz.infrastructure.monitoring.litellm_callback import get_token_monitor
+
+            monitor = get_token_monitor()
+            if monitor is None:
+                return None
+            return monitor.get_cost_summary()
+        except Exception as e:
+            self.logger.debug(f"Live cost summary unavailable: {e}")
+            return None
+
+    def _extract_holdings_insights(self, deep_analysis_results: dict[str, Any] | None) -> dict[str, dict] | None:
+        """Distill per-holding "quintessence" insight cards from enriched JSON files.
+
+        Mirrors :meth:`_extract_holdings_strategic` (session-preferred walk). For
+        each ticker, distills the most decision-relevant fields from
+        ``data["qualitative"]`` into a flat dict consumed by
+        :func:`finwiz.reporting.sections.insights.generate_holdings_insight_cards`.
+
+        Returns ``{ticker: distilled_dict}`` or ``None`` when no holding carries
+        qualitative data (ETF/crypto-only or unanalyzed portfolios).
+        """
+        if not deep_analysis_results:
+            return None
+
+        insights: dict[str, dict] = {}
+        session_id = self.state.session_id or "default"
+
+        for asset_class in ["stock", "etf", "crypto"]:
+            for base_dir in [f"output/enriched/{session_id}/{asset_class}", f"output/enriched/{asset_class}"]:
+                enriched_dir = Path(base_dir)
+                if not enriched_dir.exists():
+                    continue
+                for json_file in enriched_dir.glob("*_enriched.json"):
+                    try:
+                        data = json.loads(json_file.read_text())
+                        ticker = data.get("ticker")
+                        qual = data.get("qualitative")
+                        if not ticker or not isinstance(qual, dict):
+                            continue
+                        distilled = self._distill_qualitative(qual)
+                        if distilled:
+                            distilled["report_link"] = f"{asset_class}/{ticker}_report.html"
+                            distilled["grade"] = data.get("final_grade", "")
+                            insights[ticker] = distilled
+                    except Exception as e:
+                        self.logger.debug(f"Could not extract insights from {json_file}: {e}")
+                # Prefer the session-scoped dir exclusively (see _extract_holdings_strategic).
+                break
+
+        return insights if insights else None
+
+    @staticmethod
+    def _distill_qualitative(qual: dict[str, Any]) -> dict[str, Any]:
+        """Flatten the most decision-relevant qualitative fields into a card dict.
+
+        Pure dict access (fail-soft): any absent sub-object simply omits its keys.
+        """
+
+        def _section(name: str) -> dict[str, Any]:
+            val = qual.get(name)
+            return val if isinstance(val, dict) else {}
+
+        def _first(items: Any) -> str:
+            return str(items[0]) if isinstance(items, list) and items else ""
+
+        synth = _section("investment_synthesis")
+        sec = _section("sec_insights")
+        fund = _section("fundamental_context")
+        risks = _section("contextual_risks")
+        tech = _section("technical_strategy")
+        fact = _section("fact_pack")
+
+        # Key risks: first of regulatory / competitive / operational (best signal, no flood).
+        key_risks = [
+            r
+            for r in (
+                _first(risks.get("regulatory_risks")),
+                _first(risks.get("competitive_risks")),
+                _first(risks.get("operational_risks")),
+            )
+            if r
+        ]
+
+        action_plan = synth.get("action_plan") if isinstance(synth.get("action_plan"), dict) else {}
+        immediate_actions = action_plan.get("immediate_actions") if isinstance(action_plan, dict) else None
+
+        distilled: dict[str, Any] = {
+            "thesis": synth.get("investment_thesis", ""),
+            "bull_case": synth.get("bull_case", ""),
+            "bear_case": synth.get("bear_case", ""),
+            "scenario_probabilities": synth.get("scenario_probabilities"),
+            "final_recommendation": synth.get("final_recommendation", "HOLD"),
+            "recommendation_confidence": synth.get("recommendation_confidence", ""),
+            "immediate_actions": (immediate_actions or [])[:2],
+            "moat": _first(sec.get("competitive_advantages")),
+            "top_sec_risk": _first(sec.get("risk_factors")),
+            "growth_drivers": (fund.get("growth_drivers") or [])[:2],
+            "competitive_positioning": fund.get("competitive_positioning", ""),
+            "key_risks": key_risks,
+            "price_target_rationale": tech.get("entry_exit_strategy", ""),
+        }
+
+        if fact:
+            distilled["fact_pack"] = {
+                "corporate_structure": fact.get("corporate_structure", ""),
+                "recent_events": (fact.get("recent_events") or [])[:3],
+                "leadership": fact.get("leadership", ""),
+                "freshness": fact.get("freshness", ""),
+                "source_citations": (fact.get("source_citations") or [])[:5],
+            }
+
+        # Drop a card that distilled to nothing meaningful (no thesis, no facts, no recommendation signal).
+        has_signal = any(distilled.get(k) for k in ("thesis", "bull_case", "bear_case", "moat", "top_sec_risk", "competitive_positioning")) or "fact_pack" in distilled
+        return distilled if has_signal else {}
 
     def _extract_holdings_strategic(self, deep_analysis_results: dict[str, Any] | None) -> dict[str, dict] | None:
         """Walk enriched JSON files and pull each holding's StrategicAnalysis dict.

--- a/src/finwiz/orchestrators/reporting/enrichment.py
+++ b/src/finwiz/orchestrators/reporting/enrichment.py
@@ -148,8 +148,15 @@ class ReportEnrichmentMixin:
         insights: dict[str, dict] = {}
         session_id = self.state.session_id or "default"
 
+        # `_store_enriched_analysis` writes the canonical files to `output/{asset_class}`;
+        # the `output/enriched/...` dirs are session-scoped overrides when present.
+        # Probe in priority order and use the first that exists (data_loading.py:57).
         for asset_class in ["stock", "etf", "crypto"]:
-            for base_dir in [f"output/enriched/{session_id}/{asset_class}", f"output/enriched/{asset_class}"]:
+            for base_dir in [
+                f"output/enriched/{session_id}/{asset_class}",
+                f"output/enriched/{asset_class}",
+                f"output/{asset_class}",
+            ]:
                 enriched_dir = Path(base_dir)
                 if not enriched_dir.exists():
                     continue
@@ -167,7 +174,8 @@ class ReportEnrichmentMixin:
                             insights[ticker] = distilled
                     except Exception as e:
                         self.logger.debug(f"Could not extract insights from {json_file}: {e}")
-                # Prefer the session-scoped dir exclusively (see _extract_holdings_strategic).
+                # Use the first existing dir exclusively, so a prior run's enriched
+                # files in a lower-priority dir don't leak into this report.
                 break
 
         return insights if insights else None

--- a/src/finwiz/reporting/python_report_generator.py
+++ b/src/finwiz/reporting/python_report_generator.py
@@ -65,6 +65,9 @@ class PythonReportGenerator:
         portfolio_strategic_posture: dict | None = None,
         run_ledger: Any = None,
         deep_analysis_coverage: tuple[int, int] | None = None,
+        holdings_insights: dict[str, dict] | None = None,
+        opportunity_shortlist: Any = None,
+        cost_summary: dict[str, Any] | None = None,
     ) -> str:
         """
         Generate comprehensive family financial plan HTML report.
@@ -110,6 +113,9 @@ class PythonReportGenerator:
             portfolio_strategic_posture=portfolio_strategic_posture,
             run_ledger=run_ledger,
             deep_analysis_coverage=deep_analysis_coverage,
+            holdings_insights=holdings_insights,
+            opportunity_shortlist=opportunity_shortlist,
+            cost_summary=cost_summary,
         )
 
         # Write to file
@@ -229,6 +235,9 @@ class PythonReportGenerator:
         portfolio_strategic_posture: dict | None = None,
         run_ledger: Any = None,
         deep_analysis_coverage: tuple[int, int] | None = None,
+        holdings_insights: dict[str, dict] | None = None,
+        opportunity_shortlist: Any = None,
+        cost_summary: dict[str, Any] | None = None,
     ) -> str:
         """Generate complete HTML report."""
         # Generate timestamp
@@ -249,6 +258,11 @@ class PythonReportGenerator:
             )
             trust_banner_html = render_trust_banner(TrustBanner.from_coverage(summary))
 
+        # Header cost line: real LLM spend when available, neutral text otherwise.
+        # The deterministic Python scoring + HTML rendering remain $0 regardless.
+        cost_header = self._format_cost_header(cost_summary)
+        cost_footer = self._format_cost_footer(cost_summary)
+
         # Build HTML content
         html = f"""<!doctype html>
 <html lang="fr">
@@ -264,7 +278,7 @@ class PythonReportGenerator:
   <header>
     <h1>Plan financier familial -- Rapport FinWiz</h1>
     <div class="muted">Genere le {timestamp} -- Session: {session_id}</div>
-    <div class="muted">Analyse Python ultra-rapide -- 0 appels LLM -- Cout: $0</div>
+    <div class="muted">{cost_header}</div>
   </header>
 
   {self._generate_executive_summary(portfolio_stats, trust_banner_html=trust_banner_html)}
@@ -277,9 +291,13 @@ class PythonReportGenerator:
 
   {self._generate_holdings_analysis(portfolio_review.holdings)}
 
+  {self._generate_holdings_insight_cards(holdings_insights, portfolio_review.holdings)}
+
   {self._generate_sentiment_section(holdings_sentiment)}
 
   {self._generate_recommendations(portfolio_stats, discovery_results)}
+
+  {self._generate_gap_fill_shortlist_section(opportunity_shortlist)}
 
   {self._generate_discovery_section(discovery_results)}
 
@@ -287,13 +305,15 @@ class PythonReportGenerator:
 
   {self._generate_performance_metrics(deep_analysis_results)}
 
+  {self._generate_cost_summary_section(cost_summary)}
+
   {self._generate_stress_test_section(stress_test_results)}
 
   {self._generate_economic_calendar_section(economic_calendar)}
 
   <footer>
     <p>Rapport genere par FinWiz -- Analyse Python deterministe</p>
-    <p class="small">Performance: Analyse complete en quelques secondes -- 100% reduction des couts LLM</p>
+    <p class="small">{cost_footer}</p>
   </footer>
 </body>
 </html>"""
@@ -358,6 +378,61 @@ class PythonReportGenerator:
 
         return generate_discovery_section(discovery_results)
 
+    def _generate_holdings_insight_cards(self, holdings_insights: dict[str, dict] | None, holdings: list[HoldingDecision]) -> str:
+        """Generate per-holding quintessence cards (delegates to module)."""
+        from finwiz.reporting.section_generators import generate_holdings_insight_cards
+
+        return generate_holdings_insight_cards(holdings_insights, holdings)
+
+    def _generate_gap_fill_shortlist_section(self, opportunity_shortlist: Any) -> str:
+        """Generate the gap-fill shortlist block (delegates to module)."""
+        from finwiz.reporting.section_generators import generate_gap_fill_shortlist_section
+
+        return generate_gap_fill_shortlist_section(opportunity_shortlist)
+
+    def _generate_cost_summary_section(self, cost_summary: dict[str, Any] | None) -> str:
+        """Generate the real LLM cost summary section (delegates to module)."""
+        from finwiz.reporting.section_generators import generate_cost_summary_section
+
+        return generate_cost_summary_section(cost_summary)
+
+    @staticmethod
+    def _cost_total_and_calls(cost_summary: dict[str, Any] | None) -> tuple[float, int] | None:
+        """Best-effort (total_cost, call_count) from a token-monitor summary, or None."""
+        if not isinstance(cost_summary, dict):
+            return None
+        try:
+            total = float(cost_summary.get("total_cost", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            return None
+        try:
+            calls = int(cost_summary.get("call_count", 0) or 0)
+        except (TypeError, ValueError):
+            calls = 0
+        if calls <= 0:
+            per_crew = cost_summary.get("per_crew")
+            if isinstance(per_crew, dict):
+                calls = sum(int(d.get("calls", 0) or 0) for d in per_crew.values() if isinstance(d, dict))
+        if total <= 0 and calls <= 0:
+            return None
+        return total, calls
+
+    def _format_cost_header(self, cost_summary: dict[str, Any] | None) -> str:
+        """Header cost line: real LLM spend when available, neutral text otherwise."""
+        parsed = self._cost_total_and_calls(cost_summary)
+        if parsed is None:
+            return "Scoring quantitatif Python -- $0 -- recherche IA qualitative séparée"
+        total, calls = parsed
+        return f"Scoring Python: $0 -- Recherche IA qualitative: ${total:.2f} sur {calls} appels LLM"
+
+    def _format_cost_footer(self, cost_summary: dict[str, Any] | None) -> str:
+        """Footer cost line: replace the misleading '100% reduction' claim with the truth."""
+        parsed = self._cost_total_and_calls(cost_summary)
+        if parsed is None:
+            return "Performance: Analyse complete en quelques secondes -- scoring et rendu 100% Python"
+        total, _calls = parsed
+        return f"Performance: scoring et rendu 100% Python ($0) -- recherche IA qualitative: ${total:.2f}"
+
     def _generate_stress_test_section(self, stress_test_results: list[dict[str, Any]] | None) -> str:
         """Generate stress test analysis section (delegates to module)."""
         from finwiz.reporting.section_generators import (
@@ -407,6 +482,9 @@ def generate_python_report(
     portfolio_strategic_posture: dict | None = None,
     run_ledger: Any = None,
     deep_analysis_coverage: tuple[int, int] | None = None,
+    holdings_insights: dict[str, dict] | None = None,
+    opportunity_shortlist: Any = None,
+    cost_summary: dict[str, Any] | None = None,
 ) -> str:
     """
     Convenience function to generate Python-based report.
@@ -426,4 +504,7 @@ def generate_python_report(
         portfolio_strategic_posture=portfolio_strategic_posture,
         run_ledger=run_ledger,
         deep_analysis_coverage=deep_analysis_coverage,
+        holdings_insights=holdings_insights,
+        opportunity_shortlist=opportunity_shortlist,
+        cost_summary=cost_summary,
     )

--- a/src/finwiz/reporting/section_generators.py
+++ b/src/finwiz/reporting/section_generators.py
@@ -15,7 +15,10 @@ from finwiz.reporting.sections.analysis import (
     generate_performance_metrics,
     generate_stress_test_section,
 )
-from finwiz.reporting.sections.discovery import generate_discovery_section
+from finwiz.reporting.sections.discovery import (
+    generate_discovery_section,
+    generate_gap_fill_shortlist_section,
+)
 from finwiz.reporting.sections.factpack import _fact_pack_provenance_footer
 from finwiz.reporting.sections.holdings import (
     _confidence_badge,
@@ -23,6 +26,10 @@ from finwiz.reporting.sections.holdings import (
     _render_holding_row,
     generate_holdings_analysis,
     generate_recommendations,
+)
+from finwiz.reporting.sections.insights import (
+    generate_cost_summary_section,
+    generate_holdings_insight_cards,
 )
 from finwiz.reporting.sections.macro import (
     generate_economic_calendar_section,
@@ -40,11 +47,14 @@ __all__ = [
     "_fact_pack_provenance_footer",
     "_get_recommendation_badge",
     "_render_holding_row",
+    "generate_cost_summary_section",
     "generate_deep_analysis_section",
     "generate_discovery_section",
     "generate_economic_calendar_section",
     "generate_executive_summary",
+    "generate_gap_fill_shortlist_section",
     "generate_holdings_analysis",
+    "generate_holdings_insight_cards",
     "generate_macro_dashboard_section",
     "generate_performance_metrics",
     "generate_portfolio_overview",

--- a/src/finwiz/reporting/sections/discovery.py
+++ b/src/finwiz/reporting/sections/discovery.py
@@ -8,6 +8,98 @@ from typing import Any
 _CONVICTION_GRADES: frozenset[str] = frozenset({"A+", "A"})
 
 
+def _format_fit(opp: dict[str, Any]) -> str:
+    """Format a 0..1 portfolio_fit_score as a percentage, or '—' when absent."""
+    fit = opp.get("portfolio_fit_score")
+    if fit is None:
+        return "—"
+    try:
+        return f"{float(fit):.0%}"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _format_gap(opp: dict[str, Any]) -> str:
+    """Format the gap_filled sector label (HTML-escaped), or '—' when absent."""
+    gap = opp.get("gap_filled")
+    if gap is None or not str(gap).strip():
+        return "—"
+    return escape(str(gap))
+
+
+def _shortlist_opps(shortlist: Any) -> list[dict[str, Any]]:
+    """Normalize the opportunity shortlist input to a list of opp dicts.
+
+    Accepts either the raw list or the on-disk ``{"shortlist": [...], "size": N}``
+    wrapper. Returns ``[]`` for anything unparseable.
+    """
+    if isinstance(shortlist, dict):
+        shortlist = shortlist.get("shortlist")
+    if not isinstance(shortlist, list):
+        return []
+    return [o for o in shortlist if isinstance(o, dict)]
+
+
+def generate_gap_fill_shortlist_section(shortlist: Any) -> str:
+    """Render a highlighted "Top Gap-Fill Opportunities" block.
+
+    Surfaces the portfolio-aware cascade's marginal-fit ranking (which gaps each
+    candidate fills) that is otherwise dark in the consolidated report.
+
+    Returns "" when there is nothing to show.
+    """
+    opps = _shortlist_opps(shortlist)
+    if not opps:
+        return ""
+
+    opps = sorted(opps, key=lambda o: o.get("composite_score", 0) or 0, reverse=True)
+
+    rows: list[str] = []
+    for rank, opp in enumerate(opps, start=1):
+        ticker = escape(str(opp.get("ticker", "N/A")))
+        grade = str(opp.get("grade", "?"))
+        grade_safe = escape(grade)
+        grade_class = escape(f"grade-{grade.lower().replace('+', '-plus')}", quote=True)
+        score = opp.get("composite_score", 0) or 0
+        try:
+            score_str = f"{float(score):.3f}"
+        except (TypeError, ValueError):
+            score_str = "—"
+        rows.append(f"""
+        <tr>
+          <td>{rank}</td>
+          <td><strong>{ticker}</strong></td>
+          <td class="{grade_class}"><strong>{grade_safe}</strong></td>
+          <td>{score_str}</td>
+          <td>{_format_fit(opp)}</td>
+          <td>{_format_gap(opp)}</td>
+        </tr>""")
+
+    return f"""
+  <div class="section">
+    <div class="highlight success">
+      <h3>🎯 Top Opportunités Comblant des Lacunes</h3>
+      <p>Classement par adéquation marginale au portefeuille — chaque candidat comble une lacune sectorielle identifiée.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Rang</th>
+            <th>Ticker</th>
+            <th>Grade</th>
+            <th>Score</th>
+            <th>Adéquation</th>
+            <th>Comble la lacune</th>
+          </tr>
+        </thead>
+        <tbody>
+          {"".join(rows)}
+        </tbody>
+      </table>
+    </div>
+  </div>
+    """
+
+
 def _render_conviction_picks(opportunities: list[dict[str, Any]]) -> str:
     """Render a short A/A+ "Conviction Picks" callout, or empty if none qualify.
 
@@ -110,6 +202,8 @@ def generate_discovery_section(discovery_results: dict[str, Any] | None) -> str:
           <td><strong>{ticker}</strong><br><small>{name}</small></td>
           <td class="{grade_class}"><strong>{grade_safe}</strong></td>
           <td>{score:.3f}</td>
+          <td>{_format_fit(opp)}</td>
+          <td>{_format_gap(opp)}</td>
           <td>{rec_badge}</td>
           <td><small>{rationale}...</small></td>
         </tr>""")
@@ -137,6 +231,8 @@ def generate_discovery_section(discovery_results: dict[str, Any] | None) -> str:
           <th>Ticker / Name</th>
           <th>Grade</th>
           <th>Score</th>
+          <th>Portfolio Fit</th>
+          <th>Fills Gap</th>
           <th>Recommendation</th>
           <th>Rationale</th>
         </tr>

--- a/src/finwiz/reporting/sections/insights.py
+++ b/src/finwiz/reporting/sections/insights.py
@@ -1,0 +1,245 @@
+"""Per-holding "quintessence" insight cards + LLM cost summary for the consolidated report.
+
+These two sections surface the most expensive AI research — distilled per-holding
+investment synthesis, SEC moat/risks, fundamentals, contextual risks and verified
+fact-pack facts — into the single consolidated report, plus the real LLM spend.
+
+AI Minimalism: pure-Python rendering. Every input is HTML-escaped at the boundary
+and every sub-block is omitted (never errors) when its data is absent.
+"""
+
+from __future__ import annotations
+
+from html import escape
+from typing import Any
+
+from finwiz.reporting.sections.factpack import _is_safe_url
+
+_REC_BADGE: dict[str, str] = {
+    "BUY": '<span class="badge badge-buy">BUY</span>',
+    "SELL": '<span class="badge badge-sell">SELL</span>',
+    "HOLD": '<span class="badge badge-hold">HOLD</span>',
+}
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Trim whitespace and cap at ``limit`` chars with an ellipsis."""
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _rec_badge(recommendation: str) -> str:
+    """Recommendation badge, defaulting to a neutral HOLD pill."""
+    return _REC_BADGE.get(str(recommendation).upper(), _REC_BADGE["HOLD"])
+
+
+def _scenario_bar(probs: dict[str, Any] | None) -> str:
+    """Render a bull/base/bear stacked mini-bar from probabilities (0..1 each).
+
+    Returns "" when probabilities are missing or unparseable.
+    """
+    if not isinstance(probs, dict):
+        return ""
+    try:
+        bull = max(0.0, float(probs.get("bull", 0.0)))
+        base = max(0.0, float(probs.get("base", 0.0)))
+        bear = max(0.0, float(probs.get("bear", 0.0)))
+    except (TypeError, ValueError):
+        return ""
+    total = bull + base + bear
+    if total <= 0:
+        return ""
+    bull_pct, base_pct, bear_pct = (100 * bull / total, 100 * base / total, 100 * bear / total)
+    return (
+        '<div style="display:flex;height:14px;border-radius:7px;overflow:hidden;'
+        'margin:6px 0;font-size:0;width:100%">'
+        f'<div title="Haussier {bull_pct:.0f}%" style="width:{bull_pct:.1f}%;background:#22c55e"></div>'
+        f'<div title="Neutre {base_pct:.0f}%" style="width:{base_pct:.1f}%;background:#9ca3af"></div>'
+        f'<div title="Baissier {bear_pct:.0f}%" style="width:{bear_pct:.1f}%;background:#ef4444"></div>'
+        "</div>"
+        '<div class="small muted">'
+        f"Haussier {bull_pct:.0f}% · Neutre {base_pct:.0f}% · Baissier {bear_pct:.0f}%"
+        "</div>"
+    )
+
+
+def _prose_block(label: str, value: str, limit: int) -> str:
+    """Render a labeled prose paragraph, or "" when empty."""
+    text = _truncate(str(value or ""), limit)
+    if not text:
+        return ""
+    return f"<p><strong>{escape(label)} :</strong> {escape(text)}</p>"
+
+
+def _list_block(label: str, items: list[Any] | None, limit: int) -> str:
+    """Render a labeled <ul> from a list of strings, or "" when empty."""
+    if not items:
+        return ""
+    li = [f"<li>{escape(_truncate(str(it), limit))}</li>" for it in items if str(it).strip()]
+    if not li:
+        return ""
+    return f"<p><strong>{escape(label)} :</strong></p><ul>{''.join(li)}</ul>"
+
+
+def _fact_pack_block(fact_pack: dict[str, Any] | None) -> str:
+    """Render distilled fact-pack facts (structure, events, leadership, citations)."""
+    if not isinstance(fact_pack, dict):
+        return ""
+    rows: list[str] = []
+    rows.append(_prose_block("Structure", fact_pack.get("corporate_structure", ""), 400))
+    rows.append(_prose_block("Direction", fact_pack.get("leadership", ""), 300))
+    rows.append(_list_block("Événements récents", (fact_pack.get("recent_events") or [])[:3], 240))
+    body = "".join(r for r in rows if r)
+    if not body:
+        return ""
+
+    freshness = str(fact_pack.get("freshness", "")).strip()
+    fresh_note = f'<div class="small muted">Faits vérifiés (Perplexity) — fraîcheur : {escape(freshness)}.</div>' if freshness else ""
+
+    safe = [u for u in (fact_pack.get("source_citations") or []) if _is_safe_url(str(u))][:5]
+    citations = ""
+    if safe:
+        links = " ".join(f'<a href="{escape(str(u), quote=True)}" rel="noopener" target="_blank">[{i + 1}]</a>' for i, u in enumerate(safe))
+        citations = f'<div class="small muted">Sources : {links}</div>'
+
+    return f"<h4>Faits vérifiés</h4>{body}{fresh_note}{citations}"
+
+
+def _render_card(ticker: str, grade: str, data: dict[str, Any], report_link: str | None) -> str:
+    """Render one collapsible <details> quintessence card for a holding."""
+    rec = str(data.get("final_recommendation", "HOLD"))
+    confidence = str(data.get("recommendation_confidence", "")).strip()
+    conf_note = f" · Confiance {escape(confidence)}" if confidence else ""
+    grade_safe = escape(str(grade or "?"))
+    grade_class = escape(f"grade-{str(grade or '').lower().replace('+', '-plus')}", quote=True)
+
+    summary = f'<summary><strong>{escape(ticker)}</strong> <span class="{grade_class}">{grade_safe}</span> {_rec_badge(rec)}{conf_note}</summary>'
+
+    parts: list[str] = [_scenario_bar(data.get("scenario_probabilities"))]
+    parts.append(_prose_block("Thèse d'investissement", data.get("thesis", ""), 600))
+    parts.append(_prose_block("Scénario haussier", data.get("bull_case", ""), 400))
+    parts.append(_prose_block("Scénario baissier", data.get("bear_case", ""), 400))
+    parts.append(_prose_block("Avantage concurrentiel (moat)", data.get("moat", ""), 300))
+    parts.append(_prose_block("Risque SEC principal", data.get("top_sec_risk", ""), 300))
+    parts.append(_list_block("Moteurs de croissance", (data.get("growth_drivers") or [])[:2], 240))
+    parts.append(_prose_block("Positionnement concurrentiel", data.get("competitive_positioning", ""), 300))
+    parts.append(_list_block("Risques clés", (data.get("key_risks") or [])[:3], 240))
+    parts.append(_prose_block("Justification de l'objectif de cours", data.get("price_target_rationale", ""), 300))
+    parts.append(_list_block("Actions immédiates", (data.get("immediate_actions") or [])[:2], 240))
+    parts.append(_fact_pack_block(data.get("fact_pack")))
+
+    if report_link:
+        parts.append(f'<p><a class="ticker-link" href="{escape(report_link, quote=True)}">Analyse complète →</a></p>')
+
+    body = "".join(p for p in parts if p)
+    return f'<details class="highlight">{summary}{body}</details>'
+
+
+def generate_holdings_insight_cards(insights: dict[str, dict] | None, holdings: list[Any] | None) -> str:
+    """Render distilled per-holding "quintessence" cards for the consolidated report.
+
+    Args:
+        insights: ticker -> distilled insight dict (from ReportEnrichmentMixin
+            ._extract_holdings_insights). Tickers without qualitative data are absent.
+        holdings: portfolio holdings (HoldingDecision-like) used for authoritative
+            per-ticker grade. Optional; falls back to the grade carried in ``insights``.
+
+    Returns:
+        HTML for the section, or "" when there are no insights to render.
+    """
+    if not insights:
+        return ""
+
+    grade_by_ticker: dict[str, str] = {}
+    for h in holdings or []:
+        t = getattr(h, "ticker", None)
+        if t:
+            grade_by_ticker[str(t)] = str(getattr(h, "grade", "") or "")
+
+    cards: list[str] = []
+    for ticker, data in insights.items():
+        if not isinstance(data, dict):
+            continue
+        grade = grade_by_ticker.get(ticker) or str(data.get("grade", "") or "")
+        report_link = data.get("report_link")
+        cards.append(_render_card(ticker, grade, data, report_link if isinstance(report_link, str) else None))
+
+    if not cards:
+        return ""
+
+    return f"""
+  <div class="section">
+    <h2>Quintessence par position</h2>
+    <p class="muted">Synthèse distillée de la recherche IA approfondie (thèse, scénarios, moat, risques, faits vérifiés). Cliquez pour déplier ; l'analyse complète reste dans le rapport détaillé de chaque position.</p>
+    {"".join(cards)}
+  </div>
+    """
+
+
+def generate_cost_summary_section(cost_summary: dict[str, Any] | None) -> str:
+    """Render the real LLM cost summary (total, calls, per-crew breakdown).
+
+    Args:
+        cost_summary: output of ``get_token_monitor().get_cost_summary()`` —
+            ``{"total_cost": float, "call_count": int, "per_crew": {...}}``.
+
+    Returns:
+        HTML for the section, or "" when no usable cost data is available.
+    """
+    if not isinstance(cost_summary, dict):
+        return ""
+
+    per_crew = cost_summary.get("per_crew") or {}
+    try:
+        total_cost = float(cost_summary.get("total_cost", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        total_cost = 0.0
+
+    # call_count can be unreliable; derive from per-crew calls when it reads zero.
+    try:
+        call_count = int(cost_summary.get("call_count", 0) or 0)
+    except (TypeError, ValueError):
+        call_count = 0
+    if call_count <= 0 and isinstance(per_crew, dict):
+        call_count = sum(int(d.get("calls", 0) or 0) for d in per_crew.values() if isinstance(d, dict))
+
+    if total_cost <= 0 and call_count <= 0:
+        return ""
+
+    rows: list[str] = []
+    if isinstance(per_crew, dict):
+        ordered = sorted(per_crew.items(), key=lambda kv: float(kv[1].get("cost", 0.0) or 0.0) if isinstance(kv[1], dict) else 0.0, reverse=True)
+        for crew_name, data in ordered:
+            if not isinstance(data, dict):
+                continue
+            try:
+                cost = float(data.get("cost", 0.0) or 0.0)
+                calls = int(data.get("calls", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            tokens = data.get("tokens") or {}
+            total_tokens = int(tokens.get("prompt", 0) or 0) + int(tokens.get("completion", 0) or 0) if isinstance(tokens, dict) else 0
+            rows.append(f"<tr><td>{escape(str(crew_name))}</td><td>${cost:.4f}</td><td>{calls}</td><td>{total_tokens:,}</td></tr>")
+
+    table = ""
+    if rows:
+        table = f"""
+    <table>
+      <thead>
+        <tr><th>Crew</th><th>Coût</th><th>Appels</th><th>Tokens</th></tr>
+      </thead>
+      <tbody>
+        {"".join(rows)}
+      </tbody>
+    </table>"""
+
+    return f"""
+  <div class="section">
+    <h2>Coût réel de l'analyse IA</h2>
+    <div class="highlight">
+      <p>L'analyse qualitative approfondie a engagé <strong>${total_cost:.2f}</strong> de coûts LLM sur <strong>{call_count}</strong> appels. Le scoring quantitatif et le rendu des rapports restent 100% Python ($0).</p>
+    </div>{table}
+  </div>
+    """

--- a/tests/unit/orchestrators/test_reporting_orchestrator.py
+++ b/tests/unit/orchestrators/test_reporting_orchestrator.py
@@ -487,6 +487,74 @@ class TestReportingOrchestrator:
         assert result["consolidated_data"]["total_reports"] == 0
 
 
+class TestHoldingsInsightsExtraction:
+    """Tests for _extract_holdings_insights (quintessence card distillation)."""
+
+    @pytest.fixture
+    def orchestrator(self):
+        return ReportingOrchestrator(FinwizState())
+
+    @staticmethod
+    def _write_enriched(base, ticker: str, qualitative: dict, final_grade: str = "A") -> None:
+        base.mkdir(parents=True, exist_ok=True)
+        (base / f"{ticker}_enriched.json").write_text(json.dumps({"ticker": ticker, "final_grade": final_grade, "qualitative": qualitative}))
+
+    def test_distills_from_session_enriched_json(self, orchestrator, tmp_path, monkeypatch):
+        # Arrange — session-scoped dir is preferred over the generic dir.
+        monkeypatch.chdir(tmp_path)
+        qualitative = {
+            "investment_synthesis": {
+                "investment_thesis": "Strong compounder.",
+                "bull_case": "Upside scenario.",
+                "bear_case": "Downside scenario.",
+                "scenario_probabilities": {"bull": 0.3, "base": 0.5, "bear": 0.2},
+                "final_recommendation": "BUY",
+                "recommendation_confidence": "HIGH",
+                "action_plan": {"immediate_actions": ["Buy now", "Watch earnings", "Ignore me"]},
+            },
+            "sec_insights": {"competitive_advantages": ["Network effects"], "risk_factors": ["Key risk A"]},
+            "fundamental_context": {"growth_drivers": ["Driver 1", "Driver 2", "Driver 3"], "competitive_positioning": "Leader"},
+            "contextual_risks": {"regulatory_risks": ["Reg risk"], "competitive_risks": ["Comp risk"], "operational_risks": []},
+            "fact_pack": {
+                "corporate_structure": "Single entity.",
+                "recent_events": ["E1", "E2", "E3", "E4"],
+                "leadership": "CEO X.",
+                "freshness": "fresh",
+                "source_citations": ["https://a.com"],
+            },
+        }
+        self._write_enriched(tmp_path / "output" / "enriched" / "default" / "stock", "AAPL", qualitative)
+
+        # Act
+        result = orchestrator._extract_holdings_insights({"AAPL": {}})
+
+        # Assert
+        assert result is not None
+        card = result["AAPL"]
+        assert card["thesis"] == "Strong compounder."
+        assert card["moat"] == "Network effects"
+        assert card["top_sec_risk"] == "Key risk A"
+        assert card["growth_drivers"] == ["Driver 1", "Driver 2"]  # capped at 2
+        assert card["immediate_actions"] == ["Buy now", "Watch earnings"]  # capped at 2
+        assert card["key_risks"] == ["Reg risk", "Comp risk"]  # operational empty → omitted
+        assert card["fact_pack"]["recent_events"] == ["E1", "E2", "E3"]  # capped at 3
+        assert card["report_link"] == "stock/AAPL_report.html"
+        assert card["grade"] == "A"
+
+    def test_returns_none_when_no_qualitative(self, orchestrator, tmp_path, monkeypatch):
+        # Arrange — enriched file with no qualitative section (ETF/crypto-only).
+        monkeypatch.chdir(tmp_path)
+        base = tmp_path / "output" / "enriched" / "default" / "etf"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "SPY_enriched.json").write_text(json.dumps({"ticker": "SPY", "qualitative": None}))
+
+        # Act / Assert
+        assert orchestrator._extract_holdings_insights({"SPY": {}}) is None
+
+    def test_returns_none_when_no_deep_analysis(self, orchestrator):
+        assert orchestrator._extract_holdings_insights(None) is None
+
+
 class TestHTMLAutoGeneration:
     """Tests for HTML auto-generation functionality."""
 

--- a/tests/unit/orchestrators/test_reporting_orchestrator.py
+++ b/tests/unit/orchestrators/test_reporting_orchestrator.py
@@ -551,6 +551,38 @@ class TestHoldingsInsightsExtraction:
         # Act / Assert
         assert orchestrator._extract_holdings_insights({"SPY": {}}) is None
 
+    def test_distills_from_canonical_asset_dir(self, orchestrator, tmp_path, monkeypatch):
+        # Regression: a real kickoff writes to output/{asset_class} (not output/enriched/...).
+        # The extractor must find files there or the Quintessence section silently vanishes.
+        monkeypatch.chdir(tmp_path)
+        qualitative = {"investment_synthesis": {"investment_thesis": "Real layout thesis.", "final_recommendation": "BUY"}}
+        self._write_enriched(tmp_path / "output" / "crypto", "BTC-USD", qualitative, final_grade="B")
+
+        result = orchestrator._extract_holdings_insights({"BTC-USD": {}})
+
+        assert result is not None
+        assert result["BTC-USD"]["thesis"] == "Real layout thesis."
+        assert result["BTC-USD"]["report_link"] == "crypto/BTC-USD_report.html"
+
+    def test_session_dir_takes_precedence_over_asset_dir(self, orchestrator, tmp_path, monkeypatch):
+        # Both dirs exist; the session-scoped dir wins (no stale leakage from output/{asset}).
+        monkeypatch.chdir(tmp_path)
+        self._write_enriched(
+            tmp_path / "output" / "enriched" / "default" / "stock",
+            "AAPL",
+            {"investment_synthesis": {"investment_thesis": "Session thesis.", "final_recommendation": "BUY"}},
+        )
+        self._write_enriched(
+            tmp_path / "output" / "stock",
+            "AAPL",
+            {"investment_synthesis": {"investment_thesis": "Stale asset-dir thesis.", "final_recommendation": "SELL"}},
+        )
+
+        result = orchestrator._extract_holdings_insights({"AAPL": {}})
+
+        assert result is not None
+        assert result["AAPL"]["thesis"] == "Session thesis."
+
     def test_returns_none_when_no_deep_analysis(self, orchestrator):
         assert orchestrator._extract_holdings_insights(None) is None
 

--- a/tests/unit/reporting/test_insights.py
+++ b/tests/unit/reporting/test_insights.py
@@ -1,0 +1,139 @@
+"""Tests for the consolidated-report quintessence cards and LLM cost summary.
+
+Deterministic Python rendering only — no coverage on the LLM that produced the
+distilled data. Covers escaping, fail-soft omission, and sub-block rendering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from finwiz.reporting.sections.insights import (
+    generate_cost_summary_section,
+    generate_holdings_insight_cards,
+)
+
+
+@dataclass
+class _Holding:
+    ticker: str
+    grade: str
+
+
+def _full_insight() -> dict:
+    return {
+        "thesis": "Durable compounder with widening moat.",
+        "bull_case": "AI demand re-rates multiple.",
+        "bear_case": "Regulation compresses margins.",
+        "scenario_probabilities": {"bull": 0.3, "base": 0.5, "bear": 0.2},
+        "final_recommendation": "BUY",
+        "recommendation_confidence": "HIGH",
+        "immediate_actions": ["Initiate 2% position", "Set stop at -15%"],
+        "moat": "Switching costs across the install base.",
+        "top_sec_risk": "Customer concentration in top 3 accounts.",
+        "growth_drivers": ["Cloud migration", "New silicon cycle"],
+        "competitive_positioning": "Clear category leader.",
+        "key_risks": ["Antitrust scrutiny", "Pricing pressure"],
+        "price_target_rationale": "Accumulate below $150; trim above $220.",
+        "fact_pack": {
+            "corporate_structure": "Single operating entity, no recent divestitures.",
+            "recent_events": ["Q4 beat", "New CFO appointed"],
+            "leadership": "CEO Jane Doe since 2019.",
+            "freshness": "fresh",
+            "source_citations": ["https://example.com/a", "javascript:alert(1)"],
+        },
+        "report_link": "stock/AAPL_report.html",
+    }
+
+
+def test_cards_render_core_quintessence() -> None:
+    html = generate_holdings_insight_cards({"AAPL": _full_insight()}, [_Holding("AAPL", "A")])
+    assert "Durable compounder" in html
+    assert "AI demand re-rates" in html  # bull
+    assert "Regulation compresses" in html  # bear
+    assert "Switching costs" in html  # moat
+    assert "Customer concentration" in html  # SEC risk
+    assert "Antitrust scrutiny" in html  # key risks
+    assert "Single operating entity" in html  # fact-pack fact
+    assert "Initiate 2% position" in html  # action item
+    assert "stock/AAPL_report.html" in html  # full deep-dive link
+    assert "<details" in html and "<summary>" in html
+
+
+def test_cards_render_scenario_probability_bar() -> None:
+    html = generate_holdings_insight_cards({"AAPL": _full_insight()}, [_Holding("AAPL", "A")])
+    # Bar widths normalized from probabilities; labels expose the percentages.
+    assert "Haussier 30%" in html
+    assert "Neutre 50%" in html
+    assert "Baissier 20%" in html
+
+
+def test_cards_only_safe_citations_rendered() -> None:
+    html = generate_holdings_insight_cards({"AAPL": _full_insight()}, [_Holding("AAPL", "A")])
+    assert "https://example.com/a" in html
+    assert "javascript:alert(1)" not in html
+
+
+def test_cards_escape_injection() -> None:
+    malicious = {
+        "thesis": "<script>alert('xss')</script>",
+        "final_recommendation": "BUY",
+        "moat": "<img src=x onerror=alert(1)>",
+    }
+    html = generate_holdings_insight_cards({"<b>EVIL</b>": malicious}, [])
+    assert "<script>alert('xss')</script>" not in html
+    assert "&lt;script&gt;" in html
+    assert "<img src=x" not in html
+    assert "<b>EVIL</b>" not in html  # ticker escaped
+
+
+def test_cards_empty_returns_empty_string() -> None:
+    assert generate_holdings_insight_cards(None, []) == ""
+    assert generate_holdings_insight_cards({}, []) == ""
+
+
+def test_cards_omit_absent_subblocks() -> None:
+    minimal = {"thesis": "Only a thesis here.", "final_recommendation": "HOLD"}
+    html = generate_holdings_insight_cards({"XYZ": minimal}, [_Holding("XYZ", "B")])
+    assert "Only a thesis here." in html
+    assert "Faits vérifiés" not in html  # no fact pack
+    assert "Scénario haussier" not in html  # no bull case
+    assert "Actions immédiates" not in html  # no actions
+
+
+def test_cards_grade_from_holdings_takes_precedence() -> None:
+    insight = {"thesis": "t", "final_recommendation": "BUY", "grade": "C"}
+    html = generate_holdings_insight_cards({"AAPL": insight}, [_Holding("AAPL", "A+")])
+    assert "grade-a-plus" in html  # holding grade wins over insight grade
+
+
+def test_cost_summary_renders_real_figures() -> None:
+    summary = {
+        "total_cost": 1.2345,
+        "call_count": 42,
+        "per_crew": {
+            "deep_analysis": {"cost": 1.0, "calls": 30, "tokens": {"prompt": 1000, "completion": 500}},
+            "stock_crew": {"cost": 0.2345, "calls": 12, "tokens": {"prompt": 200, "completion": 100}},
+        },
+    }
+    html = generate_cost_summary_section(summary)
+    assert "$1.23" in html
+    assert "42" in html
+    assert "deep_analysis" in html
+    assert "1,500" in html  # token total formatted
+
+
+def test_cost_summary_derives_call_count_when_zero() -> None:
+    summary = {
+        "total_cost": 0.5,
+        "call_count": 0,  # buggy monitor; derive from per-crew
+        "per_crew": {"deep_analysis": {"cost": 0.5, "calls": 7, "tokens": {"prompt": 1, "completion": 1}}},
+    }
+    html = generate_cost_summary_section(summary)
+    assert "7" in html
+
+
+def test_cost_summary_degrades_to_empty() -> None:
+    assert generate_cost_summary_section(None) == ""
+    assert generate_cost_summary_section({}) == ""
+    assert generate_cost_summary_section({"total_cost": 0.0, "call_count": 0, "per_crew": {}}) == ""

--- a/tests/unit/reporting/test_section_hardening.py
+++ b/tests/unit/reporting/test_section_hardening.py
@@ -7,8 +7,12 @@ tolerance, asset-class bucketing, and cascade-aware discovery counts.
 from __future__ import annotations
 
 from finwiz.reporting.sections.analysis import generate_deep_analysis_section
-from finwiz.reporting.sections.discovery import generate_discovery_section
+from finwiz.reporting.sections.discovery import (
+    generate_discovery_section,
+    generate_gap_fill_shortlist_section,
+)
 from finwiz.reporting.sections.holdings import generate_recommendations
+from finwiz.reporting.sections.insights import generate_cost_summary_section
 from finwiz.reporting.sections.macro import _format_macro_value, generate_economic_calendar_section
 
 
@@ -56,3 +60,56 @@ def test_recommendations_counts_opportunity_shortlist() -> None:
     }
     html = generate_recommendations(stats, {"opportunity_shortlist": [{"ticker": "X"}, {"ticker": "Y"}]})
     assert "2 actionable candidates" in html
+
+
+def test_discovery_table_has_fit_and_gap_columns() -> None:
+    html = generate_discovery_section(
+        {
+            "opportunities": [
+                {"ticker": "NVDA", "name": "Nvidia", "grade": "A", "composite_score": 0.9, "portfolio_fit_score": 0.72, "gap_filled": "Semiconductors"},
+                {"ticker": "VWO", "name": "Emerging", "grade": "B", "composite_score": 0.7},  # no fit/gap → —
+            ]
+        }
+    )
+    assert "Portfolio Fit" in html
+    assert "Fills Gap" in html
+    assert "72%" in html
+    assert "Semiconductors" in html
+    assert "—" in html  # missing fit/gap rendered as em dash
+
+
+def test_discovery_gap_column_escapes_injection() -> None:
+    html = generate_discovery_section({"opportunities": [{"ticker": "X", "name": "n", "grade": "A", "composite_score": 0.9, "gap_filled": "<script>x</script>"}]})
+    assert "<script>x</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_gap_fill_shortlist_renders_and_ranks() -> None:
+    shortlist = {
+        "shortlist": [
+            {"ticker": "AAA", "grade": "B", "composite_score": 0.6, "portfolio_fit_score": 0.5, "gap_filled": "Energy"},
+            {"ticker": "BBB", "grade": "A", "composite_score": 0.9, "portfolio_fit_score": 0.8, "gap_filled": "Healthcare"},
+        ],
+        "size": 2,
+    }
+    html = generate_gap_fill_shortlist_section(shortlist)
+    # Highest composite score ranked first.
+    assert html.index("BBB") < html.index("AAA")
+    assert "Healthcare" in html
+    assert "80%" in html
+    assert "🎯" in html
+
+
+def test_gap_fill_shortlist_accepts_bare_list() -> None:
+    html = generate_gap_fill_shortlist_section([{"ticker": "Z", "grade": "A", "composite_score": 0.9}])
+    assert "Z" in html
+
+
+def test_gap_fill_shortlist_empty_returns_empty() -> None:
+    assert generate_gap_fill_shortlist_section(None) == ""
+    assert generate_gap_fill_shortlist_section({"shortlist": []}) == ""
+    assert generate_gap_fill_shortlist_section([]) == ""
+
+
+def test_cost_summary_section_degrades_when_unavailable() -> None:
+    assert generate_cost_summary_section(None) == ""


### PR DESCRIPTION
## Summary

The pipeline spends real money on per-holding AI research (deep-analysis, Perplexity fact-packs + strategic synthesis, sentiment, fundamentals), but the **consolidated** report (`output/finwiz_family_financial_plan.html`) surfaced only a thin slice — the most expensive output was *dark*, visible only by clicking into each per-holding `enriched_analysis_report.html`. The header also claimed `0 appels LLM -- Cout: $0`.

This makes the consolidated report the executive **quintessence** — a distilled, high-signal view of the costly research — while individual reports stay the full detail.

## What changed

**1. Per-holding "quintessence cards"** (new `reporting/sections/insights.py`)
- One collapsible `<details>`/`<summary>` card per analyzed holding (native collapse, no JS).
- Distilled: investment thesis, bull/bear, scenario-probability mini-bar, moat (`competitive_advantages[0]`), #1 SEC risk, growth drivers, key risks (first regulatory/competitive/operational), verified fact-pack facts (structure, recent events, leadership, citations), action items, price-target rationale.
- Links to the holding's full deep-dive report.
- New extractor `ReportEnrichmentMixin._extract_holdings_insights` walks enriched JSON (session-preferred, mirroring `_extract_holdings_sentiment`).

**2. Gap-fill surfacing** (`reporting/sections/discovery.py`)
- New `generate_gap_fill_shortlist_section` — "🎯 Top Gap-Fill Opportunities" block (rank · ticker · grade · score · Portfolio Fit % · Fills Gap).
- Added **Portfolio Fit** + **Fills Gap** columns to the opportunities table (data already on each opp dict from the cascade; `None` → `—`).

**3. Real LLM cost summary**
- New `generate_cost_summary_section` (total cost, calls, per-crew breakdown).
- Cost read **live** from the token monitor at report time (`state.llm_*` is only populated after `report()`). Replaces the hard-coded `$0` header + "100% reduction des couts LLM" footer with the real figure (neutral fallback when unavailable).

## Safety / design
- Pure-Python rendering (AI Minimalism); **no new LLM calls, no schema changes**.
- All inputs HTML-escaped at the render boundary; citations restricted to http/https.
- Fail-soft everywhere: missing data → omit, never error. Cards render only for holdings that carry insights.

## Testing
- `tests/unit/reporting/test_insights.py` (new): card rendering, scenario bar, injection escaping, safe-citation filtering, empty/absent-subblock omission, cost-summary figures + degradation.
- `tests/unit/reporting/test_section_hardening.py`: gap-fill block + ranking, the two new discovery columns (`—` when absent), gap-column escaping.
- `tests/unit/orchestrators/test_reporting_orchestrator.py`: `_extract_holdings_insights` distillation (session-dir preferred), `None` when no qualitative data.
- `make lint` + `mypy` clean; targeted reporting + orchestrator suites green (262 passed); semgrep 0 findings.

## Remaining manual verification
End-to-end `crewai flow kickoff` (real-money run) to eyeball the rendered cards, gap-fill columns, and real cost figure in a live report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Financial reports now include per-holding insights distilled from qualitative analysis
* Discovery opportunities display portfolio fit percentages and gap-fill indicators
* Reports feature live LLM cost summaries with detailed per-crew token usage breakdowns
* Enhanced opportunity shortlist automatically highlights top gap-filling candidates ranked by composite score

<!-- end of auto-generated comment: release notes by coderabbit.ai -->