### PR TITLE
fix(reporting): unify enriched-JSON dir resolution + dedup/efficiency cleanups

### DIFF
--- a/src/finwiz/infrastructure/monitoring/litellm_callback.py
+++ b/src/finwiz/infrastructure/monitoring/litellm_callback.py
@@ -46,6 +46,7 @@ class TokenMonitorCallback(CustomLogger):
 
     def log_success_event(self, kwargs: dict, response_obj: Any, start_time: float, end_time: float) -> None:
         """Called after successful LLM call. Tracks cost and crew attribution."""
+        self.call_count += 1
         usage = getattr(response_obj, "usage", None)
         prompt_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
         completion_tokens = getattr(usage, "completion_tokens", 0) if usage else 0

--- a/src/finwiz/orchestrators/reporting/enrichment.py
+++ b/src/finwiz/orchestrators/reporting/enrichment.py
@@ -64,7 +64,10 @@ class ReportEnrichmentMixin:
 
         # Read every enriched JSON file once; the three extractors below all
         # distill from this single parsed set (avoids re-globbing + re-parsing 3x).
-        enriched_records = list(self._iter_enriched_records())
+        # Filter to the current portfolio's tickers so leftover *_enriched.json from
+        # a prior run (the non-session-scoped output/{asset_class} dir is never
+        # cleared) can't surface stale holdings in sentiment/strategic/insights.
+        enriched_records = self._filter_records_to_holdings(self._iter_enriched_records(), portfolio_review)
 
         # Extract holdings sentiment from enriched JSON files
         holdings_sentiment = self._extract_holdings_sentiment(deep_analysis_results, records=enriched_records)
@@ -170,6 +173,22 @@ class ReportEnrichmentMixin:
                         yield asset_class, data
                 # First existing dir wins (highest priority); stop probing fallbacks.
                 break
+
+    @staticmethod
+    def _filter_records_to_holdings(
+        records: Iterator[tuple[str, dict[str, Any]]] | list[tuple[str, dict[str, Any]]],
+        portfolio_review: PortfolioReview,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Keep only enriched records whose ticker is in the current portfolio.
+
+        Guards against stale ``*_enriched.json`` from a prior run leaking in via the
+        non-session-scoped ``output/{asset_class}`` dir. When the portfolio carries
+        no tickers, no filter is applied (degrades to the unfiltered set).
+        """
+        tickers = {h.ticker for h in portfolio_review.holdings if getattr(h, "ticker", None)}
+        if not tickers:
+            return list(records)
+        return [(asset_class, data) for asset_class, data in records if data.get("ticker") in tickers]
 
     def _extract_holdings_insights(
         self,

--- a/src/finwiz/orchestrators/reporting/enrichment.py
+++ b/src/finwiz/orchestrators/reporting/enrichment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -131,26 +132,21 @@ class ReportEnrichmentMixin:
             self.logger.debug(f"Live cost summary unavailable: {e}")
             return None
 
-    def _extract_holdings_insights(self, deep_analysis_results: dict[str, Any] | None) -> dict[str, dict] | None:
-        """Distill per-holding "quintessence" insight cards from enriched JSON files.
+    def _iter_enriched_records(self) -> Iterator[tuple[str, dict[str, Any]]]:
+        """Yield ``(asset_class, enriched_json)`` for the current run's enriched files.
 
-        Mirrors :meth:`_extract_holdings_strategic` (session-preferred walk). For
-        each ticker, distills the most decision-relevant fields from
-        ``data["qualitative"]`` into a flat dict consumed by
-        :func:`finwiz.reporting.sections.insights.generate_holdings_insight_cards`.
+        Single source of truth for locating per-holding enriched JSON, shared by
+        every extractor below so the directory list cannot drift between them.
 
-        Returns ``{ticker: distilled_dict}`` or ``None`` when no holding carries
-        qualitative data (ETF/crypto-only or unanalyzed portfolios).
+        ``DeepAnalysisOrchestrator._store_enriched_analysis`` writes the canonical
+        files to ``output/{asset_class}/{ticker}_enriched.json``; the
+        ``output/enriched/...`` dirs are session-scoped overrides used by some
+        pipelines. Per asset class, probe in priority order and read **only** the
+        first directory that exists, so a prior run's files in a lower-priority
+        directory don't leak into this report. Fail-soft: unreadable/invalid
+        files are skipped with a debug log.
         """
-        if not deep_analysis_results:
-            return None
-
-        insights: dict[str, dict] = {}
         session_id = self.state.session_id or "default"
-
-        # `_store_enriched_analysis` writes the canonical files to `output/{asset_class}`;
-        # the `output/enriched/...` dirs are session-scoped overrides when present.
-        # Probe in priority order and use the first that exists (data_loading.py:57).
         for asset_class in ["stock", "etf", "crypto"]:
             for base_dir in [
                 f"output/enriched/{session_id}/{asset_class}",
@@ -163,20 +159,38 @@ class ReportEnrichmentMixin:
                 for json_file in enriched_dir.glob("*_enriched.json"):
                     try:
                         data = json.loads(json_file.read_text())
-                        ticker = data.get("ticker")
-                        qual = data.get("qualitative")
-                        if not ticker or not isinstance(qual, dict):
-                            continue
-                        distilled = self._distill_qualitative(qual)
-                        if distilled:
-                            distilled["report_link"] = f"{asset_class}/{ticker}_report.html"
-                            distilled["grade"] = data.get("final_grade", "")
-                            insights[ticker] = distilled
                     except Exception as e:
-                        self.logger.debug(f"Could not extract insights from {json_file}: {e}")
-                # Use the first existing dir exclusively, so a prior run's enriched
-                # files in a lower-priority dir don't leak into this report.
+                        self.logger.debug(f"Could not read enriched file {json_file}: {e}")
+                        continue
+                    if isinstance(data, dict):
+                        yield asset_class, data
+                # First existing dir wins (highest priority); stop probing fallbacks.
                 break
+
+    def _extract_holdings_insights(self, deep_analysis_results: dict[str, Any] | None) -> dict[str, dict] | None:
+        """Distill per-holding "quintessence" insight cards from enriched JSON files.
+
+        For each ticker, distills the most decision-relevant fields from
+        ``data["qualitative"]`` into a flat dict consumed by
+        :func:`finwiz.reporting.sections.insights.generate_holdings_insight_cards`.
+
+        Returns ``{ticker: distilled_dict}`` or ``None`` when no holding carries
+        qualitative data (ETF/crypto-only or unanalyzed portfolios).
+        """
+        if not deep_analysis_results:
+            return None
+
+        insights: dict[str, dict] = {}
+        for asset_class, data in self._iter_enriched_records():
+            ticker = data.get("ticker")
+            qual = data.get("qualitative")
+            if not ticker or not isinstance(qual, dict):
+                continue
+            distilled = self._distill_qualitative(qual)
+            if distilled:
+                distilled["report_link"] = f"{asset_class}/{ticker}_report.html"
+                distilled["grade"] = data.get("final_grade", "")
+                insights[ticker] = distilled
 
         return insights if insights else None
 
@@ -254,26 +268,12 @@ class ReportEnrichmentMixin:
         if not deep_analysis_results:
             return None
         strategic: dict[str, dict] = {}
-        session_id = self.state.session_id or "default"
-        for asset_class in ["stock", "etf", "crypto"]:
-            for base_dir in [f"output/enriched/{session_id}/{asset_class}", f"output/enriched/{asset_class}"]:
-                enriched_dir = Path(base_dir)
-                if not enriched_dir.exists():
-                    continue
-                for json_file in enriched_dir.glob("*_enriched.json"):
-                    try:
-                        data = json.loads(json_file.read_text())
-                        ticker = data.get("ticker")
-                        qual = data.get("qualitative") or {}
-                        sa = qual.get("strategic_analysis") if isinstance(qual, dict) else None
-                        if ticker and sa:
-                            strategic[ticker] = sa
-                    except Exception as e:
-                        self.logger.debug(f"Could not extract strategic from {json_file}: {e}")
-                # Prefer the session-scoped dir exclusively; only fall back to the
-                # generic dir when the session dir is absent, so a prior run's
-                # enriched files don't leak into this report.
-                break
+        for _asset_class, data in self._iter_enriched_records():
+            ticker = data.get("ticker")
+            qual = data.get("qualitative") or {}
+            sa = qual.get("strategic_analysis") if isinstance(qual, dict) else None
+            if ticker and sa:
+                strategic[ticker] = sa
         return strategic if strategic else None
 
     def _synthesize_portfolio_strategic(self, deep_analysis_results: dict[str, Any] | None) -> dict | None:
@@ -321,24 +321,11 @@ class ReportEnrichmentMixin:
             return None
 
         sentiment_data: dict[str, dict] = {}
-        session_id = self.state.session_id or "default"
-
-        for asset_class in ["stock", "etf", "crypto"]:
-            for base_dir in [f"output/enriched/{session_id}/{asset_class}", f"output/enriched/{asset_class}"]:
-                enriched_dir = Path(base_dir)
-                if not enriched_dir.exists():
-                    continue
-                for json_file in enriched_dir.glob("*_enriched.json"):
-                    try:
-                        data = json.loads(json_file.read_text())
-                        ticker = data.get("ticker")
-                        summary = data.get("sentiment_summary")
-                        if ticker and summary and isinstance(summary, dict):
-                            sentiment_data[ticker] = summary
-                    except Exception as e:
-                        self.logger.debug(f"Could not extract sentiment from {json_file}: {e}")
-                # Prefer the session-scoped dir exclusively (see _extract_holdings_strategic).
-                break
+        for _asset_class, data in self._iter_enriched_records():
+            ticker = data.get("ticker")
+            summary = data.get("sentiment_summary")
+            if ticker and summary and isinstance(summary, dict):
+                sentiment_data[ticker] = summary
 
         return sentiment_data if sentiment_data else None
 

--- a/src/finwiz/orchestrators/reporting/enrichment.py
+++ b/src/finwiz/orchestrators/reporting/enrichment.py
@@ -62,17 +62,21 @@ class ReportEnrichmentMixin:
         # Load macro snapshot from state (set by DeepAnalysisOrchestrator in Plan 16-01)
         macro_snapshot: dict | None = getattr(self.state, "macro_snapshot", None) or None
 
+        # Read every enriched JSON file once; the three extractors below all
+        # distill from this single parsed set (avoids re-globbing + re-parsing 3x).
+        enriched_records = list(self._iter_enriched_records())
+
         # Extract holdings sentiment from enriched JSON files
-        holdings_sentiment = self._extract_holdings_sentiment(deep_analysis_results)
+        holdings_sentiment = self._extract_holdings_sentiment(deep_analysis_results, records=enriched_records)
 
         # Collect economic calendar data
         economic_calendar = self._collect_economic_calendar(portfolio_review)
 
         # Synthesize portfolio-level strategic posture from per-holding strategic analyses (best-effort).
-        portfolio_strategic_posture = self._synthesize_portfolio_strategic(deep_analysis_results)
+        portfolio_strategic_posture = self._synthesize_portfolio_strategic(deep_analysis_results, records=enriched_records)
 
         # Distill per-holding "quintessence" cards from the costly enriched JSON (best-effort).
-        holdings_insights = self._extract_holdings_insights(deep_analysis_results)
+        holdings_insights = self._extract_holdings_insights(deep_analysis_results, records=enriched_records)
 
         # Gap-fill opportunity shortlist: prefer state, fall back to the on-disk file.
         opportunity_shortlist = self._load_opportunity_shortlist()
@@ -167,12 +171,19 @@ class ReportEnrichmentMixin:
                 # First existing dir wins (highest priority); stop probing fallbacks.
                 break
 
-    def _extract_holdings_insights(self, deep_analysis_results: dict[str, Any] | None) -> dict[str, dict] | None:
+    def _extract_holdings_insights(
+        self,
+        deep_analysis_results: dict[str, Any] | None,
+        records: list[tuple[str, dict[str, Any]]] | None = None,
+    ) -> dict[str, dict] | None:
         """Distill per-holding "quintessence" insight cards from enriched JSON files.
 
         For each ticker, distills the most decision-relevant fields from
         ``data["qualitative"]`` into a flat dict consumed by
         :func:`finwiz.reporting.sections.insights.generate_holdings_insight_cards`.
+
+        ``records`` is the shared parsed output of :meth:`_iter_enriched_records`;
+        when omitted (e.g. direct/test calls) it is read on demand.
 
         Returns ``{ticker: distilled_dict}`` or ``None`` when no holding carries
         qualitative data (ETF/crypto-only or unanalyzed portfolios).
@@ -181,7 +192,7 @@ class ReportEnrichmentMixin:
             return None
 
         insights: dict[str, dict] = {}
-        for asset_class, data in self._iter_enriched_records():
+        for asset_class, data in self._iter_enriched_records() if records is None else records:
             ticker = data.get("ticker")
             qual = data.get("qualitative")
             if not ticker or not isinstance(qual, dict):
@@ -226,8 +237,9 @@ class ReportEnrichmentMixin:
             if r
         ]
 
-        action_plan = synth.get("action_plan") if isinstance(synth.get("action_plan"), dict) else {}
-        immediate_actions = action_plan.get("immediate_actions") if isinstance(action_plan, dict) else None
+        action_plan = synth.get("action_plan")
+        action_plan = action_plan if isinstance(action_plan, dict) else {}
+        immediate_actions = action_plan.get("immediate_actions")
 
         distilled: dict[str, Any] = {
             "thesis": synth.get("investment_thesis", ""),
@@ -258,17 +270,22 @@ class ReportEnrichmentMixin:
         has_signal = any(distilled.get(k) for k in ("thesis", "bull_case", "bear_case", "moat", "top_sec_risk", "competitive_positioning")) or "fact_pack" in distilled
         return distilled if has_signal else {}
 
-    def _extract_holdings_strategic(self, deep_analysis_results: dict[str, Any] | None) -> dict[str, dict] | None:
+    def _extract_holdings_strategic(
+        self,
+        deep_analysis_results: dict[str, Any] | None,
+        records: list[tuple[str, dict[str, Any]]] | None = None,
+    ) -> dict[str, dict] | None:
         """Walk enriched JSON files and pull each holding's StrategicAnalysis dict.
 
-        Mirrors :meth:`_extract_holdings_sentiment`. Returns ``{ticker: dict}`` where
-        each value is the raw :class:`StrategicAnalysis` model_dump (or None if no
+        ``records`` is the shared parsed output of :meth:`_iter_enriched_records`;
+        when omitted it is read on demand. Returns ``{ticker: dict}`` where each
+        value is the raw :class:`StrategicAnalysis` model_dump (or None if no
         strategic analyses were generated, e.g. ETF/crypto-only portfolios).
         """
         if not deep_analysis_results:
             return None
         strategic: dict[str, dict] = {}
-        for _asset_class, data in self._iter_enriched_records():
+        for _asset_class, data in self._iter_enriched_records() if records is None else records:
             ticker = data.get("ticker")
             qual = data.get("qualitative") or {}
             sa = qual.get("strategic_analysis") if isinstance(qual, dict) else None
@@ -276,14 +293,18 @@ class ReportEnrichmentMixin:
                 strategic[ticker] = sa
         return strategic if strategic else None
 
-    def _synthesize_portfolio_strategic(self, deep_analysis_results: dict[str, Any] | None) -> dict | None:
+    def _synthesize_portfolio_strategic(
+        self,
+        deep_analysis_results: dict[str, Any] | None,
+        records: list[tuple[str, dict[str, Any]]] | None = None,
+    ) -> dict | None:
         """Synthesize a portfolio-level :class:`PortfolioStrategicPosture` via Perplexity.
 
         Best-effort: any failure (no strategic data, API down, parse error) returns
         None so the rest of the report still renders.
         """
         try:
-            holdings_strategic_dicts = self._extract_holdings_strategic(deep_analysis_results)
+            holdings_strategic_dicts = self._extract_holdings_strategic(deep_analysis_results, records=records)
             if not holdings_strategic_dicts:
                 return None
 
@@ -309,10 +330,16 @@ class ReportEnrichmentMixin:
             self.logger.warning(f"Portfolio strategic synthesis failed (non-fatal): {e}")
             return None
 
-    def _extract_holdings_sentiment(self, deep_analysis_results: dict[str, Any] | None) -> dict[str, dict] | None:
+    def _extract_holdings_sentiment(
+        self,
+        deep_analysis_results: dict[str, Any] | None,
+        records: list[tuple[str, dict[str, Any]]] | None = None,
+    ) -> dict[str, dict] | None:
         """Extract sentiment_summary from enriched JSON files for all holdings.
 
         Scans enriched JSON files for sentiment_summary data added by Plan 16-01.
+        ``records`` is the shared parsed output of :meth:`_iter_enriched_records`;
+        when omitted it is read on demand.
 
         Returns:
             Dict mapping ticker -> sentiment_summary dict, or None if no data found.
@@ -321,7 +348,7 @@ class ReportEnrichmentMixin:
             return None
 
         sentiment_data: dict[str, dict] = {}
-        for _asset_class, data in self._iter_enriched_records():
+        for _asset_class, data in self._iter_enriched_records() if records is None else records:
             ticker = data.get("ticker")
             summary = data.get("sentiment_summary")
             if ticker and summary and isinstance(summary, dict):

--- a/src/finwiz/reporting/python_report_generator.py
+++ b/src/finwiz/reporting/python_report_generator.py
@@ -396,30 +396,11 @@ class PythonReportGenerator:
 
         return generate_cost_summary_section(cost_summary)
 
-    @staticmethod
-    def _cost_total_and_calls(cost_summary: dict[str, Any] | None) -> tuple[float, int] | None:
-        """Best-effort (total_cost, call_count) from a token-monitor summary, or None."""
-        if not isinstance(cost_summary, dict):
-            return None
-        try:
-            total = float(cost_summary.get("total_cost", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            return None
-        try:
-            calls = int(cost_summary.get("call_count", 0) or 0)
-        except (TypeError, ValueError):
-            calls = 0
-        if calls <= 0:
-            per_crew = cost_summary.get("per_crew")
-            if isinstance(per_crew, dict):
-                calls = sum(int(d.get("calls", 0) or 0) for d in per_crew.values() if isinstance(d, dict))
-        if total <= 0 and calls <= 0:
-            return None
-        return total, calls
-
     def _format_cost_header(self, cost_summary: dict[str, Any] | None) -> str:
         """Header cost line: real LLM spend when available, neutral text otherwise."""
-        parsed = self._cost_total_and_calls(cost_summary)
+        from finwiz.reporting.sections.insights import cost_total_and_calls
+
+        parsed = cost_total_and_calls(cost_summary)
         if parsed is None:
             return "Scoring quantitatif Python -- $0 -- recherche IA qualitative séparée"
         total, calls = parsed
@@ -427,7 +408,9 @@ class PythonReportGenerator:
 
     def _format_cost_footer(self, cost_summary: dict[str, Any] | None) -> str:
         """Footer cost line: replace the misleading '100% reduction' claim with the truth."""
-        parsed = self._cost_total_and_calls(cost_summary)
+        from finwiz.reporting.sections.insights import cost_total_and_calls
+
+        parsed = cost_total_and_calls(cost_summary)
         if parsed is None:
             return "Performance: Analyse complete en quelques secondes -- scoring et rendu 100% Python"
         total, _calls = parsed

--- a/src/finwiz/reporting/sections/common.py
+++ b/src/finwiz/reporting/sections/common.py
@@ -1,0 +1,15 @@
+"""Small cross-cutting helpers shared across report sections."""
+
+from __future__ import annotations
+
+from html import escape
+
+
+def grade_css_class(grade: object) -> str:
+    """Map a letter grade to its CSS class, HTML-attribute-safe.
+
+    ``"A+"`` → ``"grade-a-plus"``, ``"B"`` → ``"grade-b"``. Empty/None → ``"grade-"``.
+    Centralizes the grade→class expression that several sections render.
+    """
+    slug = str(grade or "").lower().replace("+", "-plus")
+    return escape(f"grade-{slug}", quote=True)

--- a/src/finwiz/reporting/sections/discovery.py
+++ b/src/finwiz/reporting/sections/discovery.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from html import escape
 from typing import Any
 
+from finwiz.reporting.sections.common import grade_css_class
+
 _CONVICTION_GRADES: frozenset[str] = frozenset({"A+", "A"})
 
 
@@ -59,7 +61,7 @@ def generate_gap_fill_shortlist_section(shortlist: Any) -> str:
         ticker = escape(str(opp.get("ticker", "N/A")))
         grade = str(opp.get("grade", "?"))
         grade_safe = escape(grade)
-        grade_class = escape(f"grade-{grade.lower().replace('+', '-plus')}", quote=True)
+        grade_class = grade_css_class(grade)
         score = opp.get("composite_score", 0) or 0
         try:
             score_str = f"{float(score):.3f}"
@@ -118,7 +120,7 @@ def _render_conviction_picks(opportunities: list[dict[str, Any]]) -> str:
         name = escape(str(p.get("name", "N/A")))
         grade = str(p.get("grade", "?"))
         grade_safe = escape(grade)
-        grade_class = escape(f"grade-{grade.lower().replace('+', '-plus')}", quote=True)
+        grade_class = grade_css_class(grade)
         score = p.get("composite_score", 0)
         rationale = escape(str(p.get("rationale", "")))[:120]
         rows.append(f"""
@@ -190,7 +192,7 @@ def generate_discovery_section(discovery_results: dict[str, Any] | None) -> str:
         name = escape(str(opp.get("name", "N/A")))
         grade = str(opp.get("grade", "?"))
         grade_safe = escape(grade)
-        grade_class = escape(f"grade-{grade.lower().replace('+', '-plus')}", quote=True)
+        grade_class = grade_css_class(grade)
         score = opp.get("composite_score", 0)
         recommendation = opp.get("recommendation", "BUY")
         rationale = escape(str(opp.get("rationale", "Promising opportunity identified by Python analysis")))[:100]

--- a/src/finwiz/reporting/sections/insights.py
+++ b/src/finwiz/reporting/sections/insights.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from html import escape
 from typing import Any
 
+from finwiz.reporting.sections.common import grade_css_class
 from finwiz.reporting.sections.factpack import _is_safe_url
 
 _REC_BADGE: dict[str, str] = {
@@ -113,7 +114,7 @@ def _render_card(ticker: str, grade: str, data: dict[str, Any], report_link: str
     confidence = str(data.get("recommendation_confidence", "")).strip()
     conf_note = f" · Confiance {escape(confidence)}" if confidence else ""
     grade_safe = escape(str(grade or "?"))
-    grade_class = escape(f"grade-{str(grade or '').lower().replace('+', '-plus')}", quote=True)
+    grade_class = grade_css_class(grade)
 
     summary = f'<summary><strong>{escape(ticker)}</strong> <span class="{grade_class}">{grade_safe}</span> {_rec_badge(rec)}{conf_note}</summary>'
 
@@ -178,6 +179,33 @@ def generate_holdings_insight_cards(insights: dict[str, dict] | None, holdings: 
     """
 
 
+def cost_total_and_calls(cost_summary: dict[str, Any] | None) -> tuple[float, int] | None:
+    """Best-effort ``(total_cost, call_count)`` from a token-monitor summary, or ``None``.
+
+    Single source of truth for parsing ``get_token_monitor().get_cost_summary()`` —
+    shared by :func:`generate_cost_summary_section` and the report header/footer.
+    Derives the call count from per-crew calls when the top-level count is absent.
+    Returns ``None`` when no usable cost data is present.
+    """
+    if not isinstance(cost_summary, dict):
+        return None
+    try:
+        total = float(cost_summary.get("total_cost", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        total = 0.0
+    try:
+        calls = int(cost_summary.get("call_count", 0) or 0)
+    except (TypeError, ValueError):
+        calls = 0
+    if calls <= 0:
+        per_crew = cost_summary.get("per_crew")
+        if isinstance(per_crew, dict):
+            calls = sum(int(d.get("calls", 0) or 0) for d in per_crew.values() if isinstance(d, dict))
+    if total <= 0 and calls <= 0:
+        return None
+    return total, calls
+
+
 def generate_cost_summary_section(cost_summary: dict[str, Any] | None) -> str:
     """Render the real LLM cost summary (total, calls, per-crew breakdown).
 
@@ -188,27 +216,13 @@ def generate_cost_summary_section(cost_summary: dict[str, Any] | None) -> str:
     Returns:
         HTML for the section, or "" when no usable cost data is available.
     """
-    if not isinstance(cost_summary, dict):
+    parsed = cost_total_and_calls(cost_summary)
+    if parsed is None or not isinstance(cost_summary, dict):
         return ""
-
-    per_crew = cost_summary.get("per_crew") or {}
-    try:
-        total_cost = float(cost_summary.get("total_cost", 0.0) or 0.0)
-    except (TypeError, ValueError):
-        total_cost = 0.0
-
-    # call_count can be unreliable; derive from per-crew calls when it reads zero.
-    try:
-        call_count = int(cost_summary.get("call_count", 0) or 0)
-    except (TypeError, ValueError):
-        call_count = 0
-    if call_count <= 0 and isinstance(per_crew, dict):
-        call_count = sum(int(d.get("calls", 0) or 0) for d in per_crew.values() if isinstance(d, dict))
-
-    if total_cost <= 0 and call_count <= 0:
-        return ""
+    total_cost, call_count = parsed
 
     rows: list[str] = []
+    per_crew = cost_summary.get("per_crew")
     if isinstance(per_crew, dict):
         ordered = sorted(per_crew.items(), key=lambda kv: float(kv[1].get("cost", 0.0) or 0.0) if isinstance(kv[1], dict) else 0.0, reverse=True)
         for crew_name, data in ordered:

--- a/tests/unit/infrastructure/monitoring/test_litellm_callback_cost.py
+++ b/tests/unit/infrastructure/monitoring/test_litellm_callback_cost.py
@@ -89,6 +89,19 @@ class TestTokenMonitorCostTracking:
         cb = TokenMonitorCallback()
         cb.log_cost_summary()  # Should not raise with no calls
 
+    def test_call_count_increments_per_event(self, mocker):
+        # Regression: call_count was never incremented, so get_cost_summary()
+        # always reported 0 calls and the per-call log printed "#0".
+        mocker.patch("litellm.completion_cost", return_value=0.005)
+        cb = TokenMonitorCallback()
+        assert cb.call_count == 0
+
+        cb.log_success_event({"model": "gpt-4"}, self._make_response(mocker), 0.0, 1.0)
+        cb.log_success_event({"model": "gpt-4"}, self._make_response(mocker), 0.0, 1.0)
+
+        assert cb.call_count == 2
+        assert cb.get_cost_summary()["call_count"] == 2
+
     def test_token_tracking_per_crew(self, mocker):
         mocker.patch("litellm.completion_cost", return_value=0.0)
         cb = TokenMonitorCallback()

--- a/tests/unit/orchestrators/test_reporting_orchestrator.py
+++ b/tests/unit/orchestrators/test_reporting_orchestrator.py
@@ -587,6 +587,77 @@ class TestHoldingsInsightsExtraction:
         assert orchestrator._extract_holdings_insights(None) is None
 
 
+class TestSentimentAndStrategicExtraction:
+    """Regression: sentiment + strategic extractors must read the canonical output/{asset_class}.
+
+    Both previously scanned only output/enriched/... (never created on a real
+    kickoff), so the Sentiment and Strategic Posture sections silently vanished.
+    They now share _iter_enriched_records with the insights extractor.
+    """
+
+    @pytest.fixture
+    def orchestrator(self):
+        return ReportingOrchestrator(FinwizState())
+
+    @staticmethod
+    def _write(base, ticker: str, payload: dict) -> None:
+        base.mkdir(parents=True, exist_ok=True)
+        (base / f"{ticker}_enriched.json").write_text(json.dumps({"ticker": ticker, **payload}))
+
+    def test_sentiment_reads_canonical_asset_dir(self, orchestrator, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._write(
+            tmp_path / "output" / "stock",
+            "AAPL",
+            {"sentiment_summary": {"score": 0.4, "confidence": 0.8, "article_count": 5}},
+        )
+
+        result = orchestrator._extract_holdings_sentiment({"AAPL": {}})
+
+        assert result is not None
+        assert result["AAPL"]["score"] == 0.4
+
+    def test_strategic_reads_canonical_asset_dir(self, orchestrator, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._write(
+            tmp_path / "output" / "etf",
+            "SPY",
+            {"qualitative": {"strategic_analysis": {"swot": {"strengths": ["Liquidity"]}}}},
+        )
+
+        result = orchestrator._extract_holdings_strategic({"SPY": {}})
+
+        assert result is not None
+        assert result["SPY"]["swot"]["strengths"] == ["Liquidity"]
+
+    def test_session_dir_preferred_for_sentiment(self, orchestrator, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._write(tmp_path / "output" / "enriched" / "default" / "stock", "AAPL", {"sentiment_summary": {"score": 0.9}})
+        self._write(tmp_path / "output" / "stock", "AAPL", {"sentiment_summary": {"score": -0.9}})
+
+        result = orchestrator._extract_holdings_sentiment({"AAPL": {}})
+
+        assert result is not None
+        assert result["AAPL"]["score"] == 0.9  # session dir wins, no stale leakage
+
+    def test_both_return_none_without_deep_analysis(self, orchestrator):
+        assert orchestrator._extract_holdings_sentiment(None) is None
+        assert orchestrator._extract_holdings_strategic(None) is None
+
+    def test_iter_enriched_records_skips_unreadable_files(self, orchestrator, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        base = tmp_path / "output" / "crypto"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "BTC-USD_enriched.json").write_text("{not valid json")
+        (base / "ETH-USD_enriched.json").write_text(json.dumps({"ticker": "ETH-USD", "sentiment_summary": {"score": 0.1}}))
+
+        result = orchestrator._extract_holdings_sentiment({"BTC-USD": {}, "ETH-USD": {}})
+
+        # Bad file skipped (fail-soft); good file still surfaced.
+        assert result is not None
+        assert set(result.keys()) == {"ETH-USD"}
+
+
 class TestHTMLAutoGeneration:
     """Tests for HTML auto-generation functionality."""
 

--- a/tests/unit/orchestrators/test_reporting_orchestrator.py
+++ b/tests/unit/orchestrators/test_reporting_orchestrator.py
@@ -587,6 +587,49 @@ class TestHoldingsInsightsExtraction:
         assert orchestrator._extract_holdings_insights(None) is None
 
 
+class TestRecordFilteringToHoldings:
+    """_filter_records_to_holdings drops stale tickers left in output/{asset_class}."""
+
+    @staticmethod
+    def _review(*tickers: str) -> PortfolioReview:
+        from datetime import datetime
+
+        from finwiz.schemas.common import RiskAssessmentStandardized
+
+        holdings = [
+            HoldingDecision(
+                ticker=t,
+                name=t,
+                asset_class="stock",
+                currency="USD",
+                decision="KEEP",
+                grade="A",
+                composite_score=0.8,
+                grade_description="x",
+                recommended_action="Keep",
+                risk=RiskAssessmentStandardized(score=2.0, level="Low"),
+                rationale_bullets=["x"],
+            )
+            for t in tickers
+        ]
+        return PortfolioReview(as_of=datetime.now(), holdings=holdings)
+
+    def test_drops_records_not_in_portfolio(self):
+        records = [("stock", {"ticker": "AAPL"}), ("stock", {"ticker": "STALE"}), ("stock", {"ticker": "MSFT"})]
+        kept = ReportingOrchestrator._filter_records_to_holdings(records, self._review("AAPL", "MSFT"))
+        assert [d["ticker"] for _ac, d in kept] == ["AAPL", "MSFT"]
+
+    def test_no_filter_when_portfolio_has_no_tickers(self):
+        records = [("stock", {"ticker": "AAPL"}), ("stock", {"ticker": "STALE"})]
+        kept = ReportingOrchestrator._filter_records_to_holdings(records, self._review())
+        assert len(kept) == 2
+
+    def test_accepts_iterator_input(self):
+        records = iter([("stock", {"ticker": "AAPL"}), ("stock", {"ticker": "GONE"})])
+        kept = ReportingOrchestrator._filter_records_to_holdings(records, self._review("AAPL"))
+        assert [d["ticker"] for _ac, d in kept] == ["AAPL"]
+
+
 class TestSentimentAndStrategicExtraction:
     """Regression: sentiment + strategic extractors must read the canonical output/{asset_class}.
 


### PR DESCRIPTION
Re-targets to `main` after #47 merged (the original #48 was auto-closed when its base branch `feat/report-quintessence` was deleted on merge). Same three commits, unchanged.

## What's here

**1. Unify enriched-JSON dir resolution across all three extractors** (the core fix)
`_extract_holdings_sentiment` and `_extract_holdings_strategic` had the same latent path bug fixed for insights in #47: they scanned only `output/enriched/...` while a real kickoff writes to `output/{asset_class}/{ticker}_enriched.json`. On a fresh run `output/enriched/` is never created, so the Sentiment and Strategic Posture sections silently vanished. Introduced a single shared `_iter_enriched_records()` helper (session-scoped → generic enriched → canonical `output/{asset_class}`, first existing dir wins, fail-soft) that all three extractors route through, so the directory list can't drift again.

**2. Simplify pass** (parallel reuse/simplify/efficiency/altitude review)
- Extracted the duplicated grade→CSS-class expression into `sections/common.py::grade_css_class` (was copy-pasted in insights.py + 3 sites in discovery.py).
- Collapsed the duplicated total-cost/call-count derivation into one shared `insights.cost_total_and_calls()`.
- Fixed the root cause the renderer patched around: `TokenMonitorCallback.call_count` was never incremented (so `get_cost_summary()` always reported 0 calls, the per-call log printed `#0`, and `log_cost_summary()` short-circuited). One-line increment + regression test.
- Read enriched JSON once and pass to all three extractors (was globbed+parsed 3×).
- Removed a dead `isinstance()` re-check.

**3. Filter enriched records to current portfolio tickers** (Codex P2 on old #48)
The non-session-scoped `output/{asset_class}` fallback is never cleared between runs, so a prior run's `*_enriched.json` (for tickers no longer held) could surface stale holdings. Added `_filter_records_to_holdings` (no-op when the portfolio has no tickers).

## Testing
- All affected suites green (~272 reporting + orchestrator, + 9 token-monitor); ruff + mypy clean; semgrep 0 findings.
- Regression tests: canonical asset-dir reads, session-dir precedence, fail-soft skip of unreadable files, stale-ticker filtering, call_count increment.

## Note / out of scope
`crew_html.py::generate_enriched_html_reports` shares the same probe pattern but is lower-impact (those HTMLs are also generated on-the-fly by `_store_enriched_analysis`). Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)