### PR TITLE
refactor(reporting): route crew_html through shared enriched-dir resolver

### DIFF
--- a/src/finwiz/orchestrators/reporting/crew_html.py
+++ b/src/finwiz/orchestrators/reporting/crew_html.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -23,6 +24,10 @@ class CrewHtmlMixin:
     # Provided by ReportingOrchestrator.__init__
     state: FinwizState
     logger: Any
+
+    def _iter_enriched_files(self) -> Iterator[tuple[str, Path]]:  # pragma: no cover - provided by ReportEnrichmentMixin
+        """Declared for type-checking; implemented by ReportEnrichmentMixin."""
+        raise NotImplementedError
 
     def generate_html_from_export(
         self,
@@ -196,8 +201,10 @@ class CrewHtmlMixin:
         """
         Generate HTML reports from all enriched JSON files.
 
-        Scans output/enriched/{asset_class}/ directories for *_enriched.json files
-        and generates corresponding HTML reports using EnrichedAnalysisReportGenerator.
+        Locates ``*_enriched.json`` via the shared
+        :meth:`ReportEnrichmentMixin._iter_enriched_files` resolver (session-scoped →
+        generic enriched → canonical ``output/{asset_class}``, first existing dir wins)
+        and generates corresponding HTML using EnrichedAnalysisReportGenerator.
 
         Returns:
             Dictionary mapping asset classes to lists of generated HTML paths
@@ -212,39 +219,19 @@ class CrewHtmlMixin:
         generator = EnrichedAnalysisReportGenerator()
         self.logger.info("🔄 Generating HTML reports from enriched JSON files...")
 
-        # Scan enriched directories for each asset class
-        for asset_class in ["stock", "etf", "crypto"]:
-            generated_for_asset: list[Path] = []
+        for asset_class, json_file in self._iter_enriched_files():
+            try:
+                data = json.loads(json_file.read_text())
+                html_path = json_file.with_suffix(".html")
+                generator.generate_and_save_report(data, str(html_path))
 
-            # Check both session-specific and direct asset class directories
-            session_id = self.state.session_id or "default"
-            for base_dir in [f"output/enriched/{session_id}/{asset_class}", f"output/enriched/{asset_class}"]:
-                enriched_dir = Path(base_dir)
-                if not enriched_dir.exists():
-                    continue
+                generated_reports.setdefault(asset_class, []).append(html_path)
+                total_generated += 1
+                self.logger.debug(f"✅ Generated HTML: {html_path}")
 
-                for json_file in enriched_dir.glob("*_enriched.json"):
-                    try:
-                        # Load enriched data
-                        data = json.loads(json_file.read_text())
-                        ticker = data.get("ticker", json_file.stem.replace("_enriched", ""))
-
-                        # Generate HTML path
-                        html_path = json_file.with_suffix(".html")
-
-                        # Generate HTML report
-                        generator.generate_and_save_report(data, str(html_path))
-
-                        generated_for_asset.append(html_path)
-                        total_generated += 1
-                        self.logger.debug(f"✅ Generated HTML: {html_path}")
-
-                    except Exception as e:
-                        total_failed += 1
-                        self.logger.warning(f"Failed to generate HTML for {json_file}: {e}")
-
-            if generated_for_asset:
-                generated_reports[asset_class] = generated_for_asset
+            except Exception as e:
+                total_failed += 1
+                self.logger.warning(f"Failed to generate HTML for {json_file}: {e}")
 
         self.logger.info(f"📊 HTML report generation complete: {total_generated} generated, {total_failed} failed")
 

--- a/src/finwiz/orchestrators/reporting/enrichment.py
+++ b/src/finwiz/orchestrators/reporting/enrichment.py
@@ -139,19 +139,19 @@ class ReportEnrichmentMixin:
             self.logger.debug(f"Live cost summary unavailable: {e}")
             return None
 
-    def _iter_enriched_records(self) -> Iterator[tuple[str, dict[str, Any]]]:
-        """Yield ``(asset_class, enriched_json)`` for the current run's enriched files.
+    def _iter_enriched_files(self) -> Iterator[tuple[str, Path]]:
+        """Yield ``(asset_class, json_file_path)`` for the current run's enriched files.
 
-        Single source of truth for locating per-holding enriched JSON, shared by
-        every extractor below so the directory list cannot drift between them.
+        Single source of truth for *locating* per-holding enriched JSON, shared by
+        :meth:`_iter_enriched_records` and by ``CrewHtmlMixin.generate_enriched_html_reports``
+        so the directory list cannot drift between them.
 
         ``DeepAnalysisOrchestrator._store_enriched_analysis`` writes the canonical
         files to ``output/{asset_class}/{ticker}_enriched.json``; the
         ``output/enriched/...`` dirs are session-scoped overrides used by some
-        pipelines. Per asset class, probe in priority order and read **only** the
+        pipelines. Per asset class, probe in priority order and use **only** the
         first directory that exists, so a prior run's files in a lower-priority
-        directory don't leak into this report. Fail-soft: unreadable/invalid
-        files are skipped with a debug log.
+        directory don't leak in.
         """
         session_id = self.state.session_id or "default"
         for asset_class in ["stock", "etf", "crypto"]:
@@ -163,16 +163,24 @@ class ReportEnrichmentMixin:
                 enriched_dir = Path(base_dir)
                 if not enriched_dir.exists():
                     continue
-                for json_file in enriched_dir.glob("*_enriched.json"):
-                    try:
-                        data = json.loads(json_file.read_text())
-                    except Exception as e:
-                        self.logger.debug(f"Could not read enriched file {json_file}: {e}")
-                        continue
-                    if isinstance(data, dict):
-                        yield asset_class, data
+                yield from ((asset_class, json_file) for json_file in enriched_dir.glob("*_enriched.json"))
                 # First existing dir wins (highest priority); stop probing fallbacks.
                 break
+
+    def _iter_enriched_records(self) -> Iterator[tuple[str, dict[str, Any]]]:
+        """Yield ``(asset_class, enriched_json)`` for the current run's enriched files.
+
+        Parses each file located by :meth:`_iter_enriched_files`. Fail-soft:
+        unreadable/invalid files are skipped with a debug log.
+        """
+        for asset_class, json_file in self._iter_enriched_files():
+            try:
+                data = json.loads(json_file.read_text())
+            except Exception as e:
+                self.logger.debug(f"Could not read enriched file {json_file}: {e}")
+                continue
+            if isinstance(data, dict):
+                yield asset_class, data
 
     @staticmethod
     def _filter_records_to_holdings(

--- a/tests/unit/orchestrators/test_reporting_orchestrator.py
+++ b/tests/unit/orchestrators/test_reporting_orchestrator.py
@@ -701,6 +701,90 @@ class TestSentimentAndStrategicExtraction:
         assert set(result.keys()) == {"ETH-USD"}
 
 
+class TestIterEnrichedFiles:
+    """_iter_enriched_files is the shared directory resolver (paths, not parsed dicts)."""
+
+    @pytest.fixture
+    def orchestrator(self):
+        return ReportingOrchestrator(FinwizState())
+
+    @staticmethod
+    def _touch(base, ticker: str) -> None:
+        base.mkdir(parents=True, exist_ok=True)
+        (base / f"{ticker}_enriched.json").write_text(json.dumps({"ticker": ticker}))
+
+    def test_yields_paths_from_canonical_asset_dir(self, orchestrator, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._touch(tmp_path / "output" / "crypto", "BTC-USD")
+
+        results = list(orchestrator._iter_enriched_files())
+
+        assert len(results) == 1
+        asset_class, path = results[0]
+        assert asset_class == "crypto"
+        assert path.name == "BTC-USD_enriched.json"
+        # Records iterator (built on top) still parses the same file.
+        assert orchestrator._extract_holdings_insights({"BTC-USD": {}}) is None  # no qualitative payload
+
+    def test_first_existing_dir_wins(self, orchestrator, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._touch(tmp_path / "output" / "enriched" / "default" / "stock", "AAPL")
+        self._touch(tmp_path / "output" / "stock", "STALE")  # lower priority, ignored
+
+        tickers = {p.name for _ac, p in orchestrator._iter_enriched_files()}
+
+        assert tickers == {"AAPL_enriched.json"}
+
+    def test_empty_when_no_dirs(self, orchestrator, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert list(orchestrator._iter_enriched_files()) == []
+
+
+class TestGenerateEnrichedHtmlReports:
+    """generate_enriched_html_reports now resolves files via _iter_enriched_files.
+
+    Regression: it previously scanned only output/enriched/... so a real kickoff
+    (which writes to output/{asset_class}) produced nothing.
+    """
+
+    @pytest.fixture
+    def orchestrator(self):
+        return ReportingOrchestrator(FinwizState())
+
+    def test_generates_from_canonical_asset_dir(self, orchestrator, tmp_path, monkeypatch, mocker):
+        monkeypatch.chdir(tmp_path)
+        base = tmp_path / "output" / "stock"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "AAPL_enriched.json").write_text(json.dumps({"ticker": "AAPL"}))
+
+        # Stub the report generator so we don't depend on Jinja templates.
+        mock_gen = mocker.Mock()
+        mocker.patch(
+            "finwiz.reporting.enriched_analysis_report_generator.EnrichedAnalysisReportGenerator",
+            return_value=mock_gen,
+        )
+
+        result = orchestrator.generate_enriched_html_reports()
+
+        assert "stock" in result
+        assert [p.name for p in result["stock"]] == ["AAPL_enriched.html"]
+        mock_gen.generate_and_save_report.assert_called_once()
+
+    def test_counts_failures_fail_soft(self, orchestrator, tmp_path, monkeypatch, mocker):
+        monkeypatch.chdir(tmp_path)
+        base = tmp_path / "output" / "etf"
+        base.mkdir(parents=True, exist_ok=True)
+        (base / "SPY_enriched.json").write_text("{not valid json")
+
+        mocker.patch(
+            "finwiz.reporting.enriched_analysis_report_generator.EnrichedAnalysisReportGenerator",
+            return_value=mocker.Mock(),
+        )
+
+        # Bad JSON is caught per-file; no asset entry, no raise.
+        assert orchestrator.generate_enriched_html_reports() == {}
+
+
 class TestHTMLAutoGeneration:
     """Tests for HTML auto-generation functionality."""
 


### PR DESCRIPTION
## Summary

Cleans up the last item from the report-quintessence work: `CrewHtmlMixin.generate_enriched_html_reports` was the **4th and final copy** of the enriched-JSON directory probe that #47/#49 unified everywhere else. It still scanned only `output/enriched/{session}/{asset_class}` and `output/enriched/{asset_class}` — missing the canonical `output/{asset_class}` dir (where `DeepAnalysisOrchestrator._store_enriched_analysis` actually writes `*_enriched.json`) and the "first existing dir wins" break — so on a real kickoff the batch pass found nothing. It undercut the shared helper's "single source of truth, cannot drift" guarantee.

## What changed

`generate_enriched_html_reports` needs each file's **`Path`** (`json_file.with_suffix(".html")`), which the existing `_iter_enriched_records` (yields `(asset_class, dict)`) can't provide. Rather than widen that signature (would touch all 3 extractor consumers), I split the resolver into two layers:

- **New** `ReportEnrichmentMixin._iter_enriched_files() -> Iterator[tuple[str, Path]]` — owns the single priority list (session-scoped → generic enriched → canonical `output/{asset_class}`), the first-existing-dir break, and the glob. Yields paths.
- **`_iter_enriched_records`** now just parses each path from `_iter_enriched_files` — behavior unchanged, directory list no longer duplicated inside it.
- **`generate_enriched_html_reports`** consumes `_iter_enriched_files` instead of its own nested scan, fixing the canonical-dir bug and removing the duplicate. Also drops a dead `ticker` local.

The probe list now lives in exactly one place.

### Behavior note
With first-existing-dir-wins, the batch pass regenerates from a single dir per asset class (highest priority) instead of both `output/enriched/...` dirs — more correct (no duplicate regeneration) and now includes the previously-ignored canonical dir. This method is an idempotent catch-all (per-holding `{ticker}_report.html` are already written on-the-fly by `_store_enriched_analysis`), so no stale-ticker filter is needed here — that guard stays scoped to the consolidated report.

## Testing
- New `TestIterEnrichedFiles` (canonical-dir paths, first-dir-wins, empty) and `TestGenerateEnrichedHtmlReports` (generates from `output/{asset_class}`, fail-soft on bad JSON) — neither had tests before.
- Existing `_iter_enriched_records` / extractor tests unchanged and green.
- 277 passed across `tests/unit/orchestrators/test_reporting_orchestrator.py` + `tests/unit/reporting`; ruff + mypy clean; semgrep introduces 0 new findings (the lone jinja2 warning is pre-existing in the untouched `generate_html_from_export`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized enriched HTML report discovery with session-scoped, priority-based directory resolution for improved reliability and consistency.

* **Bug Fixes**
  * Enhanced error handling to gracefully skip invalid enriched files instead of interrupting report generation.

* **Tests**
  * Added comprehensive test coverage for enriched file discovery and HTML report generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->