### PR TITLE
fix(deep-analysis): enforce provider JSON mode (keep Mistral, stop dropped qualitative sections)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,13 @@ LLM_MODEL_PLANNING=openrouter/anthropic/claude-opus-4.5     # Planning and strat
 LLM_MODEL_BASELINE=openrouter/deepseek/deepseek-v3.2       # Baseline/comparison/fallback
 LLM_MODEL_THINKING=openrouter/anthropic/claude-opus-4.5     # High-value reasoning tasks
 
+# Deep-analysis qualitative crew — emits the pipeline's largest strict-schema JSON.
+# Optional override; unset = falls back to LLM_MODEL_MINI / LLM_MODEL_STANDARD.
+# This crew always runs in provider JSON mode (response_format=json_object), so JSON
+# validity is enforced regardless of model. Mistral is strong in French (the report
+# language); bump to mistral-large-2512 for deeper analysis.
+# LLM_MODEL_DEEP_ANALYSIS=openrouter/mistralai/mistral-small-2603
+
 # Thinking budget control: off | low | medium | high
 LLM_THINKING_LEVEL=medium                        # Thinking token budget (default: medium)
 

--- a/src/finwiz/config/llm/llm_config.py
+++ b/src/finwiz/config/llm/llm_config.py
@@ -251,7 +251,12 @@ def _validate_api_key_for_model(model: str) -> None:
         raise OSError(f"{required_key} not found in environment variables. Required for model: {model}. Please set your API key in the .env file.")
 
 
-def get_configured_llm(model_override: str | None = None, model_type: str = "standard", max_tokens: int | None = None) -> LLM:
+def get_configured_llm(
+    model_override: str | None = None,
+    model_type: str = "standard",
+    max_tokens: int | None = None,
+    force_json_object: bool = False,
+) -> LLM:
     """
     Get a properly configured LLM instance for CrewAI.
 
@@ -262,6 +267,13 @@ def get_configured_llm(model_override: str | None = None, model_type: str = "sta
         model_override: Optional model name to override environment configuration
         model_type: Type of model to use ("standard", "mini", "manager", "planning", "baseline")
                    Only used if model_override is None
+        force_json_object: When True, request provider-enforced JSON output via
+                   ``extra_body.response_format = {"type": "json_object"}``. Use only for
+                   crews whose every turn is a JSON emission (no tool calls / prose), e.g.
+                   the deep-analysis qualitative crew. Routed through ``extra_body`` rather
+                   than CrewAI's native ``response_format`` param because CrewAI raises for
+                   providers (OpenRouter) that litellm doesn't flag as schema-capable, even
+                   though OpenRouter honors response_format at the request level.
 
     Returns:
         LLM: Configured LLM instance ready for CrewAI use
@@ -298,8 +310,8 @@ def get_configured_llm(model_override: str | None = None, model_type: str = "sta
         fallback = "openai/gpt-4o" if model_type == "baseline" else "openai/gpt-4o-mini"
         model = _get_model_from_env(env_var, fallback)
 
-    # Check cache first (include max_tokens so callers with different limits get distinct instances)
-    cache_key = f"{model}:{model_type}:{max_tokens}"
+    # Check cache first (include max_tokens + json mode so callers with different needs get distinct instances)
+    cache_key = f"{model}:{model_type}:{max_tokens}:json={force_json_object}"
     if cache_key in _llm_cache:
         logger.debug(f"Returning cached LLM instance for {cache_key}")
         return _llm_cache[cache_key]
@@ -347,6 +359,14 @@ def get_configured_llm(model_override: str | None = None, model_type: str = "sta
                 extra_body["parallel_tool_calls"] = False
                 extra_body["tool_choice"] = "auto"
             logger.info("OpenRouter middle-out transform enabled for automatic context compression")
+
+        # Provider-enforced JSON output: eliminates markdown-fenced / malformed JSON at the
+        # source. Injected via extra_body (request-level) so CrewAI's response_format guard
+        # is bypassed; OpenRouter and OpenAI-compatible providers honor it. Validated live
+        # against openrouter/mistralai/mistral-small-2603.
+        if force_json_object:
+            extra_body["response_format"] = {"type": "json_object"}
+            logger.info("Provider JSON mode enabled (response_format=json_object via extra_body)")
 
         # Create LLM with proper configuration.
         # Note: retry on transient errors is handled at the litellm module level

--- a/src/finwiz/crews/deep_analysis/deep_analysis.py
+++ b/src/finwiz/crews/deep_analysis/deep_analysis.py
@@ -58,6 +58,7 @@ FRESHNESS THRESHOLDS:
 - SEC filings: 7 days maximum (static data)
 """
 
+import os
 import time
 from typing import Any
 
@@ -225,16 +226,23 @@ class DeepAnalysisCrew:
         """
         Get configured LLM instance for this crew based on optimization mode.
 
-        Uses environment variables:
-            - LLM_MODEL_MINI for performance-optimized operations
-            - LLM_MODEL_STANDARD for standard operations
+        This crew emits the largest strict-schema JSON in the pipeline (the full
+        QualitativeInsights payload). A weak model produces malformed/invalid JSON
+        that the repair layer can't always fix, dropping that holding's qualitative
+        section. ``LLM_MODEL_DEEP_ANALYSIS`` lets this one crew pin a JSON-reliable,
+        structured-output-capable model (e.g. ``openrouter/google/gemini-3-flash-preview``)
+        independently of the global mini/standard slot. Unset → existing behavior.
         """
         # Deep analysis needs high max_tokens regardless of model — full JSON output
         # requires 1500-2000 words across 5 sections. Mini default (1024) is far too low.
+        # force_json_object: this crew is tool-less and single-task, so every turn is a JSON
+        # emission — provider JSON mode kills the markdown-fenced / malformed output that
+        # otherwise drops a holding's qualitative section. Coercion validators on
+        # _QualitativeInsightsRaw + the json-repair patch handle any residual shape variance.
+        deep_model = os.getenv("LLM_MODEL_DEEP_ANALYSIS", "").strip() or None
         if self.perf_config.should_use_mini_model():
-            return get_configured_llm(model_type="mini", max_tokens=40960)
-        else:
-            return get_configured_llm(model_type="standard", max_tokens=61440)
+            return get_configured_llm(model_override=deep_model, model_type="mini", max_tokens=40960, force_json_object=True)
+        return get_configured_llm(model_override=deep_model, model_type="standard", max_tokens=61440, force_json_object=True)
 
     @agent
     def asset_analyst(self) -> Agent:

--- a/tests/unit/config/test_llm_config_json_mode.py
+++ b/tests/unit/config/test_llm_config_json_mode.py
@@ -1,0 +1,50 @@
+"""Tests for provider-enforced JSON mode in get_configured_llm (force_json_object).
+
+The deep-analysis qualitative crew emits the pipeline's largest strict-schema JSON;
+provider JSON mode (response_format=json_object, injected via extra_body to bypass
+CrewAI's response_format guard for OpenRouter) eliminates markdown-fenced / malformed
+output at the source. Validated live against openrouter/mistralai/mistral-small-2603.
+"""
+
+from __future__ import annotations
+
+import finwiz.config.llm.llm_config as llm_config
+
+
+def _capture_llm_kwargs(mocker):
+    """Patch the LLM ctor + API-key validation; return a Mock capturing LLM() kwargs."""
+    mock_llm = mocker.patch.object(llm_config, "LLM")
+    mocker.patch.object(llm_config, "_validate_api_key_for_model")
+    llm_config._llm_cache.clear()
+    return mock_llm
+
+
+def test_force_json_object_injects_response_format(mocker):
+    mock_llm = _capture_llm_kwargs(mocker)
+
+    llm_config.get_configured_llm(model_override="openrouter/mistralai/mistral-small-2603", force_json_object=True)
+
+    kwargs = mock_llm.call_args.kwargs
+    assert kwargs["extra_body"]["response_format"] == {"type": "json_object"}
+
+
+def test_default_does_not_force_json(mocker):
+    mock_llm = _capture_llm_kwargs(mocker)
+
+    llm_config.get_configured_llm(model_override="openrouter/mistralai/mistral-small-2603")
+
+    extra_body = mock_llm.call_args.kwargs.get("extra_body") or {}
+    assert "response_format" not in extra_body
+
+
+def test_json_mode_is_cache_distinct(mocker):
+    mock_llm = _capture_llm_kwargs(mocker)
+    mock_llm.side_effect = lambda **kw: mocker.Mock(name="llm")  # distinct instance per build
+    model = "openrouter/mistralai/mistral-small-2603"
+
+    plain = llm_config.get_configured_llm(model_override=model)
+    forced = llm_config.get_configured_llm(model_override=model, force_json_object=True)
+
+    # Different cache entries -> two distinct LLM constructions, not a shared instance.
+    assert plain is not forced
+    assert mock_llm.call_count == 2

--- a/tests/unit/crews/test_deep_analysis_crew.py
+++ b/tests/unit/crews/test_deep_analysis_crew.py
@@ -57,6 +57,39 @@ class TestDeepAnalysisCrew:
 
         assert hasattr(DeepAnalysisCrew, "get_tools_for_asset_class")
 
+    def test_configured_llm_forces_json_and_honors_model_override(self, mocker, monkeypatch):
+        """_get_configured_llm requests provider JSON mode and respects LLM_MODEL_DEEP_ANALYSIS."""
+        import finwiz.crews.deep_analysis.deep_analysis as da
+
+        # Bypass the heavy @CrewBase __init__; only perf_config is needed by the method.
+        crew = da.DeepAnalysisCrew.__new__(da.DeepAnalysisCrew)
+        crew.perf_config = mocker.Mock()
+        crew.perf_config.should_use_mini_model.return_value = False
+        mock_get = mocker.patch.object(da, "get_configured_llm", return_value="LLM")
+        monkeypatch.setenv("LLM_MODEL_DEEP_ANALYSIS", "openrouter/mistralai/mistral-large-2512")
+
+        crew._get_configured_llm()
+
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["force_json_object"] is True
+        assert kwargs["model_override"] == "openrouter/mistralai/mistral-large-2512"
+
+    def test_configured_llm_override_unset_falls_back(self, mocker, monkeypatch):
+        """With LLM_MODEL_DEEP_ANALYSIS unset, model_override is None (global slot used)."""
+        import finwiz.crews.deep_analysis.deep_analysis as da
+
+        crew = da.DeepAnalysisCrew.__new__(da.DeepAnalysisCrew)
+        crew.perf_config = mocker.Mock()
+        crew.perf_config.should_use_mini_model.return_value = False
+        mock_get = mocker.patch.object(da, "get_configured_llm", return_value="LLM")
+        monkeypatch.delenv("LLM_MODEL_DEEP_ANALYSIS", raising=False)
+
+        crew._get_configured_llm()
+
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["model_override"] is None
+        assert kwargs["force_json_object"] is True
+
     def test_should_validate_asset_class_parameter(self):
         """Test that get_tools_for_asset_class validates asset_class parameter."""
         # We test the logic without instantiating the crew


### PR DESCRIPTION
## Summary

The logs showed ~4/63 holdings losing their qualitative section to `JSON repair failed for _QualitativeInsightsRaw`. Investigation (and live testing) showed the **model was never the problem — the missing structured-output enforcement was.**

The deep-analysis qualitative crew emits the pipeline's largest strict-schema JSON, but ran with no provider-side JSON enforcement: the model returned ` ```json `-fenced or occasionally malformed output that the repair layer couldn't always recover.

## Why this approach (Mistral kept)

Mistral is strong in French (the report language) and the content was already good — 59/63 holdings produced rich multi-thousand-word analysis; only the JSON *envelope* failed. So the fix preserves Mistral and cost, and just turns on JSON enforcement.

Live-validated on the actual `openrouter/mistralai/mistral-small-2603` setup:
| Mechanism | Result |
|---|---|
| baseline (no enforcement) | ` ```json `-fenced → raw parse fails ✗ |
| `response_format={"type":"json_object"}` | clean valid JSON ✓ |
| CrewAI native `response_format` param on `openrouter/*` | **raises** (litellm doesn't flag OpenRouter models schema-capable) ✗ |
| `json_object` via **`extra_body`** | works through CrewAI end-to-end ✓ |

## Changes
- `get_configured_llm(..., force_json_object=True)` → injects `extra_body.response_format = {"type":"json_object"}` (bypasses CrewAI's guard; OpenRouter honors it at the request level). Cache key includes the flag.
- Deep-analysis crew opts in — safe because it's **tool-less and single-task**, so every turn is a JSON emission (no tool-call conflict). `_QualitativeInsightsRaw`'s coercion validators + the json-repair patch stay as backstop.
- Optional `LLM_MODEL_DEEP_ANALYSIS` override so this one crew can pin a model (e.g. `mistral-large-2512` for deeper analysis) independently of the global slot; unset = existing behavior. Documented in `.env.example`.

## Testing
- New `tests/unit/config/test_llm_config_json_mode.py` (force_json_object injects response_format; default doesn't; cache-distinct) + crew tests (forces JSON mode, honors/falls-back the override).
- 257 passed across config + crew suites; ruff + mypy clean; semgrep 0 findings.
- **Live end-to-end through the production `get_configured_llm` path**: returns unfenced valid JSON that validates into `_QualitativeInsightsRaw` (rec=BUY, 520-char thesis).

## Note
The repair backstop (`crewai_json_patch`) is retained — provider JSON mode guarantees valid *syntax*; the existing coercion/repair handles residual *shape* variance. A full `crewai flow kickoff` is the final real-world confirmation (your call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)