### PR TITLE
Log triage: honest discovery, AI retry, ticker hygiene, cost summary (5.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.0] - 2026-06-07
+
+### Fixed
+
+- **Discovery no longer emits weak (D/F) opportunities** -- the
+  portfolio-aware discovery path skipped the actionable-grade filter, so the
+  `a_plus_*`/`consolidated_discovery` outputs filled with F/D candidates (and
+  zero A+). `NewcomerDiscoveryPipeline.discover()` now applies
+  `_filter_actionable()` on both the portfolio-aware and legacy paths; wide
+  recall still happens inside scoring, but the surfaced list excludes noise.
+  See `src/finwiz/scoring/discovery/pipeline.py`.
+- **AI qualitative analysis no longer silently falls back to Python-only** --
+  `validate_ai_output_with_retry` was called with no `retry_callback`, so any
+  crew output that failed structured parsing logged a misleading double-ERROR
+  and dropped to Python-only (32 holdings last run). A real `retry_callback`
+  now re-runs the deep-analysis crew once with explicit JSON format
+  instructions (`{retry_guidance}`) before falling back. The no-callback path
+  logs a single WARNING instead of two ERRORs.
+- **Stale/renamed crypto tickers no longer spam yfinance errors** -- new
+  `discovery/ticker_hygiene.py` centralizes renames (`MATIC`->`POL`,
+  `FTM`->`S`) and non-tradable exclusions (`XTSLA`), applied at
+  `to_yfinance_symbol` and the `get_returns`/`get_sectors` fetch boundaries.
+
+### Changed
+
+- **Honest LLM cost summary** -- the end-of-run summary reported "No LLM calls
+  made" even when the deep-analysis crew ran (CrewAI clobbers
+  `litellm.callbacks`, so our callback never fired). Cost/tokens are now
+  recorded from CrewAI's authoritative `CrewOutput.token_usage` at the
+  `execute_crew_with_timeout` chokepoint via `record_usage()`. An unmeasured
+  run says so plainly; dollar amounts are labelled estimates; unpriced models
+  show "cost n/a" instead of a false $0.
+- **Reduced log noise** -- downgraded ~500 by-design fallback WARNINGs to
+  DEBUG (fact-pack truncation, defaulted-field metrics, news-source waterfall,
+  SEC CIK misses for non-US tickers).
+
 ## [5.3.0] - 2026-05-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "finwiz"
-version = "5.3.0"
+version = "5.4.0"
 description = "finwiz using crewAI"
 authors = [{ name = "Frederic Jacquet", email = "fred.jacquet@gmail.com" }]
 requires-python = ">=3.12,<3.13"

--- a/src/finwiz/analysis/_helpers.py
+++ b/src/finwiz/analysis/_helpers.py
@@ -213,6 +213,11 @@ def _build_crew_inputs(ctx: AnalysisContext, quant: QuantitativeAnalysis, raw_da
         inputs["fact_pack_freshness"] = "unknown"
         inputs["fact_pack_confidence"] = "unknown"
 
+    # Retry guidance is empty on the first attempt. The qualify-stage retry
+    # callback overrides this with explicit JSON format instructions when the
+    # first crew output fails structured parsing (see qualify._try_ai_qualify).
+    inputs["retry_guidance"] = ""
+
     # DIAGNOSTIC: Log sizes of each input field for debugging
     total_chars = sum(len(str(v)) for v in inputs.values() if v is not None)
     estimated_tokens = total_chars // 4

--- a/src/finwiz/analysis/fact_pack_research.py
+++ b/src/finwiz/analysis/fact_pack_research.py
@@ -78,7 +78,7 @@ class _FactPackRaw(BaseModel):
                 if not stripped:
                     continue
                 if len(stripped) > _EVENT_MAX_CHARS:
-                    logger.warning(
+                    logger.debug(
                         f"recent_events[{i}] truncated from {len(stripped)} to {_EVENT_MAX_CHARS} chars",
                     )
                     stripped = stripped[:_EVENT_MAX_CHARS].rstrip()

--- a/src/finwiz/analysis/stages/qualify.py
+++ b/src/finwiz/analysis/stages/qualify.py
@@ -88,6 +88,30 @@ def _promote_to_qualitative(
     )
 
 
+def _run_deep_analysis_crew(asset_class: str, crew: Any, crew_inputs: dict[str, Any]) -> Any:
+    """Execute the deep-analysis crew, loop-aware, re-raising hard failures.
+
+    Shared by the initial qualitative attempt and the retry callback so both use
+    the same event-loop handling and timeout wrapper.
+    """
+    import asyncio
+    import concurrent.futures
+
+    from finwiz.infrastructure.resilience.crew_execution import execute_crew_with_timeout
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    name = f"deep_analysis_{asset_class}"
+    if loop and loop.is_running():
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            future = pool.submit(asyncio.run, execute_crew_with_timeout(name, crew, crew_inputs))
+            return future.result()
+    return asyncio.run(execute_crew_with_timeout(name, crew, crew_inputs))
+
+
 def _try_ai_qualify(
     ctx: AnalysisContext,
     quant: QuantitativeAnalysis,
@@ -110,24 +134,10 @@ def _try_ai_qualify(
     crew = _get_analysis_crew(ctx.asset_class)
     crew_inputs = _build_crew_inputs(ctx, quant, raw_data, fact_pack=fact_pack)
 
-    import asyncio
-    import concurrent.futures
     import traceback
 
-    from finwiz.infrastructure.resilience.crew_execution import execute_crew_with_timeout
-
     try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
-
-    try:
-        if loop and loop.is_running():
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                future = pool.submit(asyncio.run, execute_crew_with_timeout(f"deep_analysis_{ctx.asset_class}", crew, crew_inputs))
-                crew_result = future.result()
-        else:
-            crew_result = asyncio.run(execute_crew_with_timeout(f"deep_analysis_{ctx.asset_class}", crew, crew_inputs))
+        crew_result = _run_deep_analysis_crew(ctx.asset_class, crew, crew_inputs)
     except (OSError, TimeoutError):
         # Transient I/O or timeout — let @stage decorator retry then record FAILED.
         raise
@@ -136,9 +146,33 @@ def _try_ai_qualify(
         # re-raise so the @stage decorator captures it as FAILED, not DEGRADED.
         raise
 
+    def _retry_crew(format_instructions: str, retry_context: str) -> Any:
+        """Re-run the crew with explicit JSON format instructions.
+
+        Wired into ``validate_ai_output_with_retry`` so a first output that fails
+        structured parsing gets one real corrected attempt before the Python-only
+        fallback — instead of the old dead no-callback path that always degraded.
+        Returns a canonical dict on success, or the raw output on failure so the
+        validator cleanly exhausts its retries and falls back to Python-only.
+        """
+        retry_inputs = dict(crew_inputs)
+        retry_inputs["retry_guidance"] = (
+            "⚠️ RETRY — la sortie précédente n'a pas pu être parsée en JSON "
+            f"structuré. {retry_context}\n"
+            "Réémets UNIQUEMENT un objet JSON valide conforme au schéma, sans "
+            "aucun texte ni balise markdown autour.\n"
+            f"{format_instructions}"
+        )
+        logger.info(f"Retrying qualitative crew for {ctx.ticker} with explicit format instructions")
+        retry_result = _run_deep_analysis_crew(ctx.asset_class, crew, retry_inputs)
+        retry_qual = _extract_qualitative(retry_result, quant, fact_pack=fact_pack)
+        if retry_qual is not None and _has_qualitative_content(retry_qual):
+            return retry_qual.model_dump()
+        return retry_result.raw if hasattr(retry_result, "raw") else str(retry_result)
+
     # Only return None when the AI call succeeded but returned empty/null content.
     # This is the one legitimate trigger for the DEGRADED branch.
-    qual = _extract_qualitative(crew_result, quant, fact_pack=fact_pack)
+    qual = _extract_qualitative(crew_result, quant, fact_pack=fact_pack, retry_callback=_retry_crew)
     if qual is not None and _has_qualitative_content(qual):
         logger.info(f"Qualitative insights generated for {ctx.ticker}")
         return qual
@@ -284,6 +318,7 @@ def _extract_qualitative(
     crew_result: CrewOutput,
     quant: QuantitativeAnalysis,
     fact_pack: FactPack | None = None,
+    retry_callback: Any = None,
 ) -> QualitativeInsights:
     """Extract QualitativeInsights from a crew result.
 
@@ -294,6 +329,11 @@ def _extract_qualitative(
 
     Older code paths that still produce :class:`QualitativeInsights` directly
     continue to work — we just hand them through.
+
+    ``retry_callback`` (optional) is forwarded to
+    :func:`validate_ai_output_with_retry` as the last-resort path: when all
+    direct extraction fails it re-runs the crew once with explicit format
+    instructions before falling back to Python-only analysis.
     """
 
     def _coerce(candidate: Any) -> QualitativeInsights | None:
@@ -368,4 +408,6 @@ def _extract_qualitative(
 
     logger.warning("All extraction methods failed, falling back to validation with retry")
     raw_output = crew_result.raw if hasattr(crew_result, "raw") else str(crew_result)
-    return validate_ai_output_with_retry(raw_output, quant, max_retries=2)
+    # One crew re-run with explicit format instructions (when a callback is
+    # wired) before Python-only fallback.
+    return validate_ai_output_with_retry(raw_output, quant, retry_callback=retry_callback, max_retries=1)

--- a/src/finwiz/crews/deep_analysis/config/tasks.yaml
+++ b/src/finwiz/crews/deep_analysis/config/tasks.yaml
@@ -96,6 +96,8 @@ deep_qualitative_analysis_task:
 
     NO trailing commas. NO text outside JSON.
 
+    {retry_guidance}
+
   expected_output: >
     QualitativeInsights JSON with sec_insights, fundamental_context,
     technical_strategy, contextual_risks, investment_synthesis.

--- a/src/finwiz/crews/helpers/llm_config.py
+++ b/src/finwiz/crews/helpers/llm_config.py
@@ -6,6 +6,8 @@ based on optimization mode. These functions are externalized from crew classes
 to make them testable and reusable.
 """
 
+import os
+
 from crewai import LLM
 
 from finwiz.config.llm.llm_config import get_configured_llm, get_mini_llm
@@ -34,3 +36,16 @@ def get_crew_llm() -> LLM:
         return get_mini_llm()
     else:
         return get_configured_llm(model_type="standard")
+
+
+def get_crew_model_string() -> str:
+    """Return the model id ``get_crew_llm()`` would use, without building an LLM.
+
+    Used by the cost tracker for litellm price lookup. Resolving the string
+    directly (rather than constructing an ``LLM``) keeps the cost path free of
+    API-key validation side effects. Mirrors ``get_crew_llm``'s mini-vs-standard
+    decision and the env fallback chain in ``config.llm.llm_config``.
+    """
+    perf_config = get_performance_config_manager()
+    env_var = "LLM_MODEL_MINI" if perf_config.should_use_mini_model() else "LLM_MODEL_STANDARD"
+    return os.getenv(env_var) or os.getenv("MODEL") or "openai/gpt-4o-mini"

--- a/src/finwiz/data/adapters/finnhub_news_adapter.py
+++ b/src/finwiz/data/adapters/finnhub_news_adapter.py
@@ -62,25 +62,27 @@ class FinnhubNewsAdapter:
         articles: list[NewsArticle] = []
 
         # Level 1: Finnhub (has pre-computed sentiment)
+        # Per-source failures are expected steps in the waterfall (the next level
+        # picks up the slack), so they log at DEBUG, not WARNING.
         if self.finnhub_key:
             try:
                 articles.extend(self._fetch_finnhub(ticker, days))
             except Exception as e:
-                logger.warning(f"Finnhub failed for {ticker}: {e}")
+                logger.debug(f"Finnhub failed for {ticker}: {e}")
 
         # Level 2: gnews (needs VADER sentiment)
         if len(articles) < _MIN_FINNHUB_ARTICLES and self.gnews_key:
             try:
                 articles.extend(self._fetch_gnews(ticker, days))
             except Exception as e:
-                logger.warning(f"gnews failed for {ticker}: {e}")
+                logger.debug(f"gnews failed for {ticker}: {e}")
 
         # Level 3: RSS (needs VADER sentiment)
         if len(articles) < _MIN_TOTAL_ARTICLES:
             try:
                 articles.extend(self._fetch_rss(ticker))
             except Exception as e:
-                logger.warning(f"RSS failed for {ticker}: {e}")
+                logger.debug(f"RSS failed for {ticker}: {e}")
 
         # Apply VADER to articles without sentiment
         articles = self._apply_vader_fallback(articles)

--- a/src/finwiz/discovery/market_data.py
+++ b/src/finwiz/discovery/market_data.py
@@ -22,6 +22,7 @@ import json
 from datetime import date
 from pathlib import Path
 
+from finwiz.discovery.ticker_hygiene import is_tradable
 from finwiz.discovery.ticker_utils import to_yfinance_symbol
 from finwiz.tools.logger import get_logger
 
@@ -81,7 +82,7 @@ def get_returns(
     if not tickers:
         return {}
 
-    wanted = sorted({t.upper() for t in tickers})
+    wanted = sorted({t.upper() for t in tickers if is_tradable(t)})
     out: dict[str, list[float]] = {}
     missing: list[str] = []
     for t in wanted:
@@ -171,7 +172,7 @@ def get_sectors(tickers: list[str], asset_class: str = "stock") -> dict[str, str
     if not tickers:
         return {}
 
-    wanted = sorted({t.upper() for t in tickers})
+    wanted = sorted({t.upper() for t in tickers if is_tradable(t)})
     out: dict[str, str | None] = {}
     missing: list[str] = []
     for t in wanted:

--- a/src/finwiz/discovery/ticker_hygiene.py
+++ b/src/finwiz/discovery/ticker_hygiene.py
@@ -1,0 +1,55 @@
+"""Centralized ticker hygiene: renames and non-tradable exclusions.
+
+Single source of truth for two classes of yfinance noise observed in runs:
+
+* **Renamed/migrated crypto** — symbols that changed ticker and now return
+  "possibly delisted" under their old name (e.g. ``MATIC`` → ``POL`` after the
+  2024 Polygon migration, ``FTM`` → ``S`` after the Sonic rebrand).
+* **Non-tradable placeholders** — instrument codes that are not quotable
+  securities (e.g. ``XTSLA``, a BlackRock cash-sweep line that leaks in from
+  ETF holdings expansion) and 404 on every yfinance lookup.
+
+Apply :func:`canonical_symbol` at the bare-ticker stage (before the ``-USD``
+suffix) and filter with :func:`is_tradable` at fetch boundaries so the old
+names never reach yfinance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# Bare-symbol renames (asset-class agnostic; applied before quote suffixing).
+CRYPTO_SYMBOL_RENAMES: dict[str, str] = {
+    "MATIC": "POL",  # Polygon migrated MATIC -> POL (2024)
+    "FTM": "S",  # Fantom rebranded to Sonic (S) (2024)
+}
+
+# Symbols that are not quotable securities and 404 on every yfinance call.
+NON_TRADABLE_SYMBOLS: frozenset[str] = frozenset(
+    {
+        "XTSLA",  # BlackRock cash-sweep placeholder, not a tradable ticker
+    }
+)
+
+
+def canonical_symbol(ticker: str) -> str:
+    """Return the current canonical bare symbol, applying known renames.
+
+    Idempotent and case-insensitive on input; returns an upper-cased symbol.
+    """
+    symbol = ticker.strip().upper()
+    return CRYPTO_SYMBOL_RENAMES.get(symbol, symbol)
+
+
+def is_tradable(ticker: str) -> bool:
+    """Return False for known non-tradable placeholder symbols."""
+    return canonical_symbol(ticker) not in NON_TRADABLE_SYMBOLS
+
+
+def sanitize_symbols(tickers: Iterable[str]) -> list[str]:
+    """Apply renames and drop non-tradable symbols, de-duplicated and sorted.
+
+    Use at fetch boundaries that batch many tickers into a single yfinance call.
+    """
+    cleaned = {canonical_symbol(t) for t in tickers if is_tradable(t)}
+    return sorted(cleaned)

--- a/src/finwiz/discovery/ticker_utils.py
+++ b/src/finwiz/discovery/ticker_utils.py
@@ -7,19 +7,26 @@ The ``-USD`` suffix for crypto is applied only at the yfinance query boundary.
 
 from __future__ import annotations
 
+from finwiz.discovery.ticker_hygiene import canonical_symbol
+
 _CRYPTO_QUOTE_SUFFIXES: tuple[str, ...] = ("-USD", "-USDT", "-USDC")
 
 
 def to_yfinance_symbol(ticker: str, asset_class: str) -> str:
     """Return the yfinance-query form of *ticker*.
 
-    Crypto tickers receive a ``-USD`` suffix; stock/ETF tickers pass through.
-    Idempotent: an already-suffixed crypto ticker (e.g. ``BTC-USD``) is
-    returned unchanged.
+    Applies known renames (e.g. ``MATIC`` → ``POL``) so migrated symbols don't
+    hit yfinance under their delisted old name. Crypto tickers then receive a
+    ``-USD`` suffix; stock/ETF tickers pass through. Idempotent: an already-
+    suffixed crypto ticker (e.g. ``BTC-USD``) is returned unchanged.
     """
     symbol = ticker.strip().upper()
+    for suffix in _CRYPTO_QUOTE_SUFFIXES:
+        if symbol.endswith(suffix):
+            # Already suffixed: rename the base part if needed, keep the suffix.
+            base = canonical_symbol(symbol[: -len(suffix)])
+            return f"{base}{suffix}"
+    symbol = canonical_symbol(symbol)
     if asset_class != "crypto":
-        return symbol
-    if symbol.endswith(_CRYPTO_QUOTE_SUFFIXES):
         return symbol
     return f"{symbol}-USD"

--- a/src/finwiz/infrastructure/monitoring/litellm_callback.py
+++ b/src/finwiz/infrastructure/monitoring/litellm_callback.py
@@ -43,6 +43,10 @@ class TokenMonitorCallback(CustomLogger):
         self.crew_costs: dict[str, float] = {}
         self.crew_tokens: dict[str, dict[str, int]] = {}
         self.crew_calls: dict[str, int] = {}
+        # Per-crew flag: False once any kickoff for that crew had tokens we could
+        # not price (unknown/unpriced model). Lets the summary show "cost n/a"
+        # instead of implying $0 — honesty over a false zero.
+        self.crew_cost_known: dict[str, bool] = {}
 
     def log_success_event(self, kwargs: dict, response_obj: Any, start_time: float, end_time: float) -> None:
         """Called after successful LLM call. Tracks cost and crew attribution."""
@@ -71,6 +75,59 @@ class TokenMonitorCallback(CustomLogger):
         model = kwargs.get("model", "unknown")
         logger.info(f"LLM call #{self.call_count} ({crew_name}): {model} cost=${cost:.4f} ({prompt_tokens}+{completion_tokens} tokens)")
 
+    def record_usage(self, crew_name: str, token_usage: Any, model: str | None = None) -> None:
+        """Record authoritative CrewAI usage metrics for one crew kickoff.
+
+        This is the source of truth for the cost summary. CrewAI populates
+        ``CrewOutput.token_usage`` directly, which survives thread boundaries and
+        CrewAI's own clobbering of ``litellm.callbacks`` (the reason
+        ``log_success_event`` never fires for crews). Cost is an ESTIMATE derived
+        from token counts and the crew's model via litellm pricing; when the
+        model is unknown/unpriced we count tokens but mark cost unknown rather
+        than recording a misleading $0.
+
+        Args:
+            crew_name: Crew attribution key (e.g. ``deep_analysis_stock``).
+            token_usage: CrewAI ``UsageMetrics`` (``prompt_tokens``,
+                ``completion_tokens``, ``successful_requests``).
+            model: litellm model id for price lookup (e.g. ``openai/gpt-4o-mini``).
+        """
+        prompt_tokens = int(getattr(token_usage, "prompt_tokens", 0) or 0)
+        completion_tokens = int(getattr(token_usage, "completion_tokens", 0) or 0)
+        requests = int(getattr(token_usage, "successful_requests", 0) or 0)
+        if prompt_tokens == 0 and completion_tokens == 0 and requests == 0:
+            return  # nothing measurable (empty/cached-only result) — don't fabricate a call
+
+        calls = requests if requests > 0 else 1
+
+        cost: float | None = None
+        if model:
+            try:
+                prompt_cost, completion_cost = litellm.cost_per_token(
+                    model=model,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                )
+                cost = float(prompt_cost) + float(completion_cost)
+            except Exception:
+                cost = None  # unpriced model: tokens stay honest, cost unknown
+
+        self.call_count += calls
+        self.crew_calls[crew_name] = self.crew_calls.get(crew_name, 0) + calls
+        if crew_name not in self.crew_tokens:
+            self.crew_tokens[crew_name] = {"prompt": 0, "completion": 0}
+        self.crew_tokens[crew_name]["prompt"] += prompt_tokens
+        self.crew_tokens[crew_name]["completion"] += completion_tokens
+
+        # A crew's cost is "known" only if every kickoff for it could be priced.
+        self.crew_cost_known[crew_name] = self.crew_cost_known.get(crew_name, True) and (cost is not None)
+        if cost is not None:
+            self.crew_costs[crew_name] = self.crew_costs.get(crew_name, 0.0) + cost
+            self.total_cost += cost
+
+        cost_str = f"${cost:.4f}" if cost is not None else "cost n/a"
+        logger.debug(f"Recorded usage ({crew_name}): {calls} calls, {prompt_tokens}+{completion_tokens} tokens, {cost_str}")
+
     def get_cost_summary(self) -> dict[str, Any]:
         """Get aggregated cost summary for all crews."""
         per_crew: dict[str, dict[str, Any]] = {}
@@ -80,6 +137,7 @@ class TokenMonitorCallback(CustomLogger):
                 "cost": self.crew_costs.get(crew_name, 0.0),
                 "calls": self.crew_calls.get(crew_name, 0),
                 "tokens": tokens,
+                "cost_known": self.crew_cost_known.get(crew_name, True),
             }
         return {
             "total_cost": self.total_cost,
@@ -88,17 +146,32 @@ class TokenMonitorCallback(CustomLogger):
         }
 
     def log_cost_summary(self) -> None:
-        """Log a formatted LLM cost summary."""
+        """Log a formatted, honest LLM cost summary.
+
+        Reports only what was actually measured. When nothing was measured it
+        says so plainly — it does NOT claim "No LLM calls made" (crews may run
+        outside the measured chokepoint, so an unmeasured run is not proof of
+        zero usage). Dollar amounts are labelled estimates; crews whose model
+        could not be priced show their tokens with "cost n/a" rather than $0.
+        """
         summary = self.get_cost_summary()
         if summary["call_count"] == 0:
-            logger.info("LLM Cost Summary: No LLM calls made")
+            logger.info("LLM Cost Summary: no crew LLM usage measured this run")
             return
 
-        lines = ["LLM Cost Summary:"]
+        lines = ["LLM Cost Summary (estimated from CrewAI usage metrics):"]
+        any_unpriced = False
         for crew_name, data in summary["per_crew"].items():
             total_tokens = data["tokens"]["prompt"] + data["tokens"]["completion"]
-            lines.append(f"  {crew_name}: ${data['cost']:.4f} ({data['calls']} calls, {total_tokens} tokens)")
-        lines.append(f"  TOTAL: ${summary['total_cost']:.4f} ({summary['call_count']} calls)")
+            if data.get("cost_known", True):
+                cost_str = f"${data['cost']:.4f}"
+            else:
+                cost_str = "cost n/a (unpriced model)"
+                any_unpriced = True
+            lines.append(f"  {crew_name}: {cost_str} ({data['calls']} calls, {total_tokens} tokens)")
+        lines.append(f"  TOTAL: ~${summary['total_cost']:.4f} estimated across {summary['call_count']} calls")
+        if any_unpriced:
+            lines.append("  (some crews used an unpriced model; their tokens are counted but cost is not)")
         logger.info("\n".join(lines))
 
 
@@ -107,7 +180,15 @@ _token_monitor: TokenMonitorCallback | None = None
 
 
 def enable_token_monitoring() -> None:
-    """Enable token monitoring for all LiteLLM calls."""
+    """Initialize the token monitor singleton.
+
+    Cost/token data is recorded from CrewAI's authoritative
+    ``CrewOutput.token_usage`` via :meth:`TokenMonitorCallback.record_usage` at
+    the crew-execution chokepoint — NOT from a litellm callback. CrewAI clobbers
+    ``litellm.callbacks`` when it lazily builds its own LLM at kickoff, so the
+    callback never fired; registering it would also risk double-counting any
+    crews where it *does* fire. We therefore only create the singleton here.
+    """
     global _token_monitor
 
     if _token_monitor is not None:
@@ -115,8 +196,7 @@ def enable_token_monitoring() -> None:
         return
 
     _token_monitor = TokenMonitorCallback()
-    litellm.callbacks = [_token_monitor]
-    logger.info("🔍 Token monitoring enabled - will log all LLM prompt sizes")
+    logger.info("🔍 Token monitoring enabled - recording CrewAI usage metrics per crew")
 
 
 def get_token_monitor() -> TokenMonitorCallback | None:

--- a/src/finwiz/infrastructure/resilience/crew_execution.py
+++ b/src/finwiz/infrastructure/resilience/crew_execution.py
@@ -57,6 +57,28 @@ class CircuitBreakerOpenError(RuntimeError):
     """Raised when a crew's circuit breaker is open due to repeated failures."""
 
 
+def _record_crew_usage(crew_name: str, result: Any) -> None:
+    """Record this kickoff's CrewAI token usage into the cost monitor.
+
+    Source of truth for the (honest) end-of-run cost summary: CrewAI's
+    ``CrewOutput.token_usage`` is populated directly and survives the thread
+    boundaries that prevent the litellm callback from firing. Best-effort —
+    never let cost accounting break crew execution.
+    """
+    try:
+        token_usage = getattr(result, "token_usage", None)
+        if token_usage is None:
+            return
+        from finwiz.crews.helpers.llm_config import get_crew_model_string
+        from finwiz.infrastructure.monitoring.litellm_callback import get_token_monitor
+
+        monitor = get_token_monitor()
+        if monitor is not None:
+            monitor.record_usage(crew_name, token_usage, model=get_crew_model_string())
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(f"Cost tracking skipped for {crew_name}: {exc}")
+
+
 async def execute_crew_with_timeout(
     crew_name: str,
     crew_instance: Any,
@@ -111,6 +133,7 @@ async def execute_crew_with_timeout(
         # Success: reset failure counter
         _crew_failures[crew_name] = 0
         logger.info(f"Crew {crew_name} completed successfully")
+        _record_crew_usage(crew_name, result)
         return result
 
     except ValidationError:

--- a/src/finwiz/scoring/discovery/pipeline.py
+++ b/src/finwiz/scoring/discovery/pipeline.py
@@ -96,7 +96,13 @@ class NewcomerDiscoveryPipeline:
             candidates = [c for c in candidates if c.ticker.upper() not in self.portfolio_tickers]
             logger.info("%d candidates remain after portfolio exclusion", len(candidates))
             candidates = self._score_candidates(candidates)
-            candidates = self._filter_actionable(candidates)
+
+        # Drop weak grades (D/D±/F) on BOTH paths. The portfolio-aware cascade
+        # un-gates *recall* (breakout/momentum become factor inputs, not filters)
+        # but must still EXCLUDE noise from the surfaced opportunity list rather
+        # than emit it low-graded — otherwise the a_plus_*/consolidated outputs
+        # fill with F/D candidates. See feedback rule: filter, don't low-grade.
+        candidates = self._filter_actionable(candidates)
 
         candidates.sort(key=lambda c: c.composite_score, reverse=True)
         candidates = candidates[: self.MAX_SURFACED_CANDIDATES]

--- a/src/finwiz/tools/screening_utils.py
+++ b/src/finwiz/tools/screening_utils.py
@@ -263,7 +263,7 @@ class ScreeningUtils:
                 "DOGE",
                 "DOT",
                 "AVAX",
-                "MATIC",
+                "POL",  # formerly MATIC (Polygon migrated to POL in 2024)
                 # DeFi and Layer 1s
                 "LINK",
                 "UNI",
@@ -280,7 +280,7 @@ class ScreeningUtils:
                 "ALGO",
                 "ATOM",
                 "NEAR",
-                "FTM",
+                "S",  # formerly FTM (Fantom rebranded to Sonic in 2024)
                 "ONE",
                 # Store of Value / Digital Gold
                 "LTC",

--- a/src/finwiz/tools/sec_filing_url_generator.py
+++ b/src/finwiz/tools/sec_filing_url_generator.py
@@ -84,8 +84,9 @@ class SECFilingURLGenerator:
                         logger.info(f"Found CIK {cik} for ticker {ticker}")
                         return cik
 
-                # Ticker not found
-                logger.warning(f"No CIK found for ticker {ticker}")
+                # Ticker not found — expected for non-US / crypto / OTC names
+                # that aren't in SEC EDGAR; downstream falls back gracefully.
+                logger.debug(f"No CIK found for ticker {ticker}")
                 self._cik_cache[ticker] = None
                 return None
 
@@ -217,7 +218,7 @@ class SECFilingURLGenerator:
 
         cik = self.get_cik(ticker)
         if not cik:
-            logger.warning(f"Cannot get direct filing URL for {ticker}: CIK not found")
+            logger.debug(f"Cannot get direct filing URL for {ticker}: CIK not found")
             return None
 
         try:
@@ -312,12 +313,12 @@ class SECFilingURLGenerator:
         # Fallback to browse URL only
         cik = self.get_cik(ticker)
         if not cik:
-            logger.warning(f"Cannot retrieve filing metadata for {ticker}: CIK not found")
+            logger.debug(f"Cannot retrieve filing metadata for {ticker}: CIK not found")
             return None
 
         browse_url = self.get_company_browse_url(cik, filing_type)
 
-        logger.warning(f"Could not get direct filing URL for {ticker} ({filing_type}), returning browse URL only")
+        logger.debug(f"Could not get direct filing URL for {ticker} ({filing_type}), returning browse URL only")
 
         return {
             "ticker": ticker,

--- a/src/finwiz/tools/sentiment_sources.py
+++ b/src/finwiz/tools/sentiment_sources.py
@@ -118,7 +118,9 @@ class SentimentDataSources:
             news = stock.news
 
             if not news:
-                self.logger.warning(f"No news data found for ticker {ticker}")
+                # Many valid tickers simply have no yfinance news (low coverage,
+                # non-US, crypto); not an error condition.
+                self.logger.debug(f"No news data found for ticker {ticker}")
                 return []
 
             # Limit to max_articles

--- a/src/finwiz/validation/ai_output.py
+++ b/src/finwiz/validation/ai_output.py
@@ -433,9 +433,11 @@ def validate_ai_output_with_retry(
                     retry_context = f"Previous attempt failed: {e!s}"
                     result = retry_callback(format_instructions=format_instructions, retry_context=retry_context)
                 else:
-                    # No retry callback - cannot retry
-                    logger.error("No retry callback provided, cannot retry validation")
-                    break
+                    # No retry callback wired: Python-only is the designed fallback
+                    # here, not an error. Single WARNING (was a misleading double
+                    # ERROR that fired once per holding).
+                    logger.warning("AI output validation failed and no retry callback provided; using Python-only analysis")
+                    return create_python_only_qualitative(quantitative)
             else:
                 # Max retries exceeded - fallback to Python-only
                 logger.error(f"AI output validation failed after {max_retries} retry attempts. Falling back to Python-only analysis (Requirement 12.4)")

--- a/src/finwiz/validation/quality_metrics.py
+++ b/src/finwiz/validation/quality_metrics.py
@@ -390,7 +390,9 @@ class DataQualityMetrics(BaseModel):
         """
         if field_name not in self.fields_defaulted:
             self.fields_defaulted.append(field_name)
-            logger.warning(f"⚠️ Field defaulted: {field_name} = {default_value}")
+            # Per-field defaulting is expected data-quality instrumentation; the
+            # aggregate is surfaced in the run summary. DEBUG to cut log noise.
+            logger.debug(f"⚠️ Field defaulted: {field_name} = {default_value}")
 
     def record_missing_field(self, field_name: str) -> None:
         """

--- a/tests/unit/analysis/test_fact_pack_research.py
+++ b/tests/unit/analysis/test_fact_pack_research.py
@@ -89,7 +89,8 @@ class TestFactPackRawTruncatingValidators:
         import logging
 
         long_event = "A" * 250
-        caplog.set_level(logging.WARNING, logger="finwiz.analysis.fact_pack_research")
+        # Truncation is logged at DEBUG (by-design normalization, not a warning).
+        caplog.set_level(logging.DEBUG, logger="finwiz.analysis.fact_pack_research")
         raw = _FactPackRaw.model_validate(
             {
                 "corporate_structure": "Independent",

--- a/tests/unit/discovery/test_ticker_hygiene.py
+++ b/tests/unit/discovery/test_ticker_hygiene.py
@@ -1,0 +1,56 @@
+"""Unit tests for centralized ticker hygiene (renames + non-tradable exclusions)."""
+
+from __future__ import annotations
+
+import pytest
+
+from finwiz.discovery.ticker_hygiene import (
+    canonical_symbol,
+    is_tradable,
+    sanitize_symbols,
+)
+
+
+class TestCanonicalSymbol:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("MATIC", "POL"),
+            ("matic", "POL"),
+            ("  FTM  ", "S"),
+            ("BTC", "BTC"),  # unchanged
+            ("aapl", "AAPL"),  # upper-cased pass-through
+        ],
+    )
+    def test_renames_and_passthrough(self, raw: str, expected: str) -> None:
+        assert canonical_symbol(raw) == expected
+
+    def test_idempotent(self) -> None:
+        assert canonical_symbol(canonical_symbol("MATIC")) == "POL"
+
+
+class TestIsTradable:
+    def test_non_tradable_excluded(self) -> None:
+        assert is_tradable("XTSLA") is False
+        assert is_tradable("xtsla") is False
+
+    def test_tradable_allowed(self) -> None:
+        assert is_tradable("AAPL") is True
+        assert is_tradable("BTC") is True
+        assert is_tradable("MATIC") is True  # renamed, still tradable
+
+
+class TestSanitizeSymbols:
+    def test_applies_rename_and_drops_non_tradable(self) -> None:
+        result = sanitize_symbols(["AAPL", "MATIC", "XTSLA", "FTM", "btc"])
+        assert "XTSLA" not in result
+        assert "MATIC" not in result and "FTM" not in result
+        assert {"AAPL", "POL", "S", "BTC"} == set(result)
+
+    def test_dedup_and_sorted(self) -> None:
+        result = sanitize_symbols(["MATIC", "POL", "btc", "BTC"])
+        # MATIC -> POL collapses with POL; btc/BTC collapse
+        assert result == ["BTC", "POL"]
+
+    def test_empty(self) -> None:
+        assert sanitize_symbols([]) == []

--- a/tests/unit/discovery/test_ticker_utils.py
+++ b/tests/unit/discovery/test_ticker_utils.py
@@ -40,11 +40,21 @@ class TestCryptoNormalization:
             ("AAVE", "AAVE-USD"),
             ("DOGE", "DOGE-USD"),
             ("SOL", "SOL-USD"),
-            ("MATIC", "MATIC-USD"),
         ],
     )
     def test_bare_crypto_gets_usd_suffix(self, bare: str, expected: str) -> None:
         assert to_yfinance_symbol(bare, "crypto") == expected
+
+    @pytest.mark.parametrize(
+        ("old", "expected"),
+        [
+            ("MATIC", "POL-USD"),  # Polygon migration
+            ("FTM", "S-USD"),  # Sonic rebrand
+            ("MATIC-USD", "POL-USD"),  # rename applies even when pre-suffixed
+        ],
+    )
+    def test_renamed_crypto_uses_current_symbol(self, old: str, expected: str) -> None:
+        assert to_yfinance_symbol(old, "crypto") == expected
 
     def test_case_normalization(self) -> None:
         assert to_yfinance_symbol("btc", "crypto") == "BTC-USD"

--- a/tests/unit/infrastructure/monitoring/test_litellm_callback_cost.py
+++ b/tests/unit/infrastructure/monitoring/test_litellm_callback_cost.py
@@ -1,5 +1,8 @@
 """Tests for LLM cost tracking in TokenMonitorCallback."""
 
+import logging
+from types import SimpleNamespace
+
 import pytest
 
 from finwiz.infrastructure.monitoring.litellm_callback import (
@@ -7,6 +10,11 @@ from finwiz.infrastructure.monitoring.litellm_callback import (
     clear_crew_context,
     set_crew_context,
 )
+
+
+def _usage(prompt: int = 100, completion: int = 50, requests: int = 1) -> SimpleNamespace:
+    """Build a CrewAI-like UsageMetrics object."""
+    return SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion, successful_requests=requests)
 
 
 class TestTokenMonitorCostTracking:
@@ -115,3 +123,72 @@ class TestTokenMonitorCostTracking:
 
         assert cb.crew_tokens["crew_a"]["prompt"] == 300
         assert cb.crew_tokens["crew_a"]["completion"] == 125
+
+
+class TestRecordUsage:
+    """The CrewAI-usage_metrics source of truth (record_usage)."""
+
+    def test_accumulates_tokens_calls_and_cost(self, mocker):
+        mocker.patch("litellm.cost_per_token", return_value=(0.001, 0.002))
+        cb = TokenMonitorCallback()
+
+        cb.record_usage("deep_analysis_stock", _usage(200, 100, requests=3), model="openai/gpt-4o-mini")
+
+        assert cb.call_count == 3
+        assert cb.crew_calls["deep_analysis_stock"] == 3
+        assert cb.crew_tokens["deep_analysis_stock"] == {"prompt": 200, "completion": 100}
+        assert cb.total_cost == pytest.approx(0.003)
+        assert cb.crew_cost_known["deep_analysis_stock"] is True
+
+    def test_calls_default_to_one_when_requests_missing(self, mocker):
+        mocker.patch("litellm.cost_per_token", return_value=(0.0, 0.0))
+        cb = TokenMonitorCallback()
+        cb.record_usage("c", _usage(10, 5, requests=0), model="openai/gpt-4o-mini")
+        assert cb.call_count == 1
+
+    def test_empty_usage_is_noop(self, mocker):
+        mocker.patch("litellm.cost_per_token", return_value=(0.0, 0.0))
+        cb = TokenMonitorCallback()
+        cb.record_usage("c", _usage(0, 0, requests=0), model="openai/gpt-4o-mini")
+        assert cb.call_count == 0
+        assert cb.crew_calls == {}
+
+    def test_unpriced_model_counts_tokens_but_marks_cost_unknown(self, mocker):
+        mocker.patch("litellm.cost_per_token", side_effect=Exception("no pricing for model"))
+        cb = TokenMonitorCallback()
+
+        cb.record_usage("weird_crew", _usage(100, 50, requests=1), model="vendor/unknown-model")
+
+        assert cb.crew_tokens["weird_crew"] == {"prompt": 100, "completion": 50}
+        assert cb.crew_calls["weird_crew"] == 1
+        assert cb.total_cost == 0.0  # no fabricated cost
+        assert cb.crew_cost_known["weird_crew"] is False
+
+    def test_summary_exposes_cost_known(self, mocker):
+        mocker.patch("litellm.cost_per_token", return_value=(0.001, 0.001))
+        cb = TokenMonitorCallback()
+        cb.record_usage("c", _usage(), model="openai/gpt-4o-mini")
+        per_crew = cb.get_cost_summary()["per_crew"]
+        assert per_crew["c"]["cost_known"] is True
+
+
+class TestHonestSummary:
+    """log_cost_summary must never claim 'No LLM calls made'."""
+
+    def test_empty_run_does_not_assert_zero_calls(self, caplog):
+        cb = TokenMonitorCallback()
+        caplog.set_level(logging.INFO)
+        cb.log_cost_summary()
+        msgs = " ".join(r.message for r in caplog.records)
+        assert "No LLM calls made" not in msgs
+        assert "no crew LLM usage measured" in msgs
+
+    def test_unpriced_crew_shows_na_not_zero(self, mocker, caplog):
+        mocker.patch("litellm.cost_per_token", side_effect=Exception("no pricing"))
+        cb = TokenMonitorCallback()
+        cb.record_usage("weird_crew", _usage(100, 50, requests=1), model="vendor/unknown")
+        caplog.set_level(logging.INFO)
+        cb.log_cost_summary()
+        msgs = " ".join(r.message for r in caplog.records)
+        assert "cost n/a" in msgs
+        assert "estimated" in msgs

--- a/tests/unit/infrastructure/resilience/test_crew_execution.py
+++ b/tests/unit/infrastructure/resilience/test_crew_execution.py
@@ -191,3 +191,53 @@ def test_emit_pending_distinguishes_breaker_open_reason() -> None:
     # Generic pending stays distinct.
     other = _emit_pending(ctx, reason="qualify timed out")
     assert "circuit breaker" not in other.rationale.lower()
+
+
+@pytest.mark.asyncio
+async def test_records_crew_usage_when_result_has_token_usage(mocker):
+    """Honest cost tracking: usage is recorded from CrewOutput.token_usage at the chokepoint."""
+    from types import SimpleNamespace
+
+    token_usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, successful_requests=1)
+    result = SimpleNamespace(token_usage=token_usage)
+    crew = mocker.MagicMock()
+    crew.kickoff.return_value = result
+
+    monitor = mocker.MagicMock()
+    mocker.patch(
+        "finwiz.infrastructure.monitoring.litellm_callback.get_token_monitor",
+        return_value=monitor,
+    )
+    mocker.patch(
+        "finwiz.crews.helpers.llm_config.get_crew_model_string",
+        return_value="openai/gpt-4o-mini",
+    )
+
+    out = await execute_crew_with_timeout("deep_analysis_stock", crew, {"ticker": "AAPL"}, timeout=10)
+
+    assert out is result
+    monitor.record_usage.assert_called_once()
+    args, kwargs = monitor.record_usage.call_args
+    assert args[0] == "deep_analysis_stock"
+    assert args[1] is token_usage
+    assert kwargs.get("model") == "openai/gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_usage_recording_failure_does_not_break_execution(mocker):
+    """Cost tracking is best-effort: a monitor error must not fail the crew run."""
+    from types import SimpleNamespace
+
+    result = SimpleNamespace(token_usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, successful_requests=1))
+    crew = mocker.MagicMock()
+    crew.kickoff.return_value = result
+
+    monitor = mocker.MagicMock()
+    monitor.record_usage.side_effect = RuntimeError("boom")
+    mocker.patch(
+        "finwiz.infrastructure.monitoring.litellm_callback.get_token_monitor",
+        return_value=monitor,
+    )
+
+    out = await execute_crew_with_timeout("deep_analysis_etf", crew, {}, timeout=10)
+    assert out is result  # execution still succeeds despite tracking error

--- a/tests/unit/scoring/discovery/test_pipeline.py
+++ b/tests/unit/scoring/discovery/test_pipeline.py
@@ -423,6 +423,37 @@ class TestPortfolioAwareDiscovery:
         # A near-zero (grade F) candidate still appears — no hard grade drop in wide stage.
         assert any(c.ticker == "TECHCO" for c in candidates)
 
+    def test_discover_excludes_weak_grades_from_surface(self, pipeline, mocker):
+        """discover() on the portfolio-aware path drops D/F candidates (feedback: filter, don't low-grade).
+
+        Wide recall happens inside _gather_portfolio_aware_candidates (scores
+        everything), but the surfaced opportunity list must exclude noise — the
+        a_plus_*/consolidated outputs should never contain F/D grades.
+        """
+        mocker.patch(
+            "finwiz.config.features.flags.is_feature_enabled",
+            side_effect=lambda name, *a, **k: name == "portfolio_aware_discovery",
+        )
+        graded = [
+            _make_candidate("STRONG", 0.90),
+            _make_candidate("MIDC", 0.66),
+            _make_candidate("WEAKD", 0.55),
+            _make_candidate("WEAKF", 0.20),
+        ]
+        graded[0].grade = "A"
+        graded[1].grade = "C"
+        graded[2].grade = "D"
+        graded[3].grade = "F"
+        mocker.patch.object(pipeline, "_gather_portfolio_aware_candidates", return_value=graded)
+        mocker.patch.object(pipeline, "_enrich_top_candidates", side_effect=lambda c: (c, 0, 0))
+        mocker.patch.object(pipeline, "_persist_result")
+
+        result = pipeline.discover("sess-filter")
+        grades = {c.grade for c in result.candidates}
+        tickers = {c.ticker for c in result.candidates}
+        assert "D" not in grades and "F" not in grades
+        assert tickers == {"STRONG", "MIDC"}
+
     def test_signal_score_used_when_present(self, pipeline, mocker):
         """When a ticker trips a signal, its richer signal composite is the standalone factor."""
         from finwiz.schemas.newcomer_discovery import PortfolioGapProfile

--- a/tests/unit/validation/test_ai_output_validator.py
+++ b/tests/unit/validation/test_ai_output_validator.py
@@ -412,6 +412,27 @@ def test_should_limit_retries_to_two(sample_quantitative):
     assert retry_count == 2
 
 
+def test_no_callback_falls_back_quietly(sample_quantitative, caplog):
+    """No retry_callback => Python-only fallback with a single WARNING, no ERRORs.
+
+    Regression: the old no-callback path logged two ERRORs per holding
+    ("No retry callback provided" + "Unexpected validation flow"). Python-only
+    is the designed behaviour here, not an error.
+    """
+    import logging
+
+    caplog.set_level(logging.WARNING)
+
+    result = validate_ai_output_with_retry("Invalid string output", sample_quantitative)
+
+    assert isinstance(result, QualitativeInsights)
+    assert result.ai_confidence == approx(0.0)  # Python-only fallback
+    # No ERROR-level records from the validation flow.
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert not any("Unexpected validation flow" in r.message for r in caplog.records)
+    assert any("no retry callback provided" in r.message.lower() for r in caplog.records)
+
+
 # ============================================================================
 # Test Complete Validation Flow
 # ============================================================================


### PR DESCRIPTION
## Summary

Triage of the last `crewai flow kickoff` run surfaced four issue clusters plus a dishonest cost summary. All fixed here; bumps to **5.4.0**.

### Fixes
- **`fix(discovery)`** — the portfolio-aware path skipped the actionable-grade filter, so `a_plus_*`/`consolidated_discovery` filled with **F/D candidates and zero A+**. `discover()` now applies `_filter_actionable()` on both paths. (Honors the "filter, don't low-grade" rule.)
- **`fix(deep-analysis)`** — `validate_ai_output_with_retry` had no `retry_callback`, so unparseable crew output logged a double-ERROR and dropped to Python-only (32 holdings last run). Wired a real callback that re-runs the crew once with explicit JSON format instructions; no-callback path logs a single WARNING.
- **`fix(data)`** — renamed crypto (`MATIC`→`POL`, `FTM`→`S`) and non-tradable (`XTSLA`) symbols spammed yfinance "possibly delisted" errors. New centralized `discovery/ticker_hygiene.py` applied at the fetch boundaries.
- **`chore(logging)`** — downgraded ~500 by-design fallback WARNINGs to DEBUG.

### Changed
- **`fix(monitoring)` — honest LLM cost summary.** It reported "No LLM calls made" while the deep-analysis crew ran (CrewAI clobbers `litellm.callbacks`, so our callback never fired). Now sourced from CrewAI's authoritative `CrewOutput.token_usage` at the `execute_crew_with_timeout` chokepoint. Unmeasured runs say so; costs are labelled estimates; unpriced models show "cost n/a" not a false $0.

## Test plan
- `make test`: **5260 passed, 23 skipped**, coverage **75.12%** (≥65% gate)
- ruff ✅ · mypy ✅ · unittest.mock ban ✅ · semgrep ✅ (0 findings)
- New/updated unit tests for each fix (discovery filter, retry callback, ticker hygiene, honest summary, chokepoint recording)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v5.4.0

* **Bug Fixes**
  * Discovery now correctly filters weak-grade candidates across all paths
  * AI analysis retries failed JSON parsing instead of silently falling back
  * Ticker hygiene prevents errors from renamed cryptocurrency assets

* **Improvements**
  * Cost summaries now accurately record LLM token usage and fees
  * Reduced log noise from expected fallback behavior
  * Updated cryptocurrency mappings for 2024 rebranding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->