### PR TITLE
perf(test): ~2.4x faster default test runs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -53,5 +53,5 @@ jobs:
             echo "No new Python files to check"
           fi
 
-      - name: Run tests
-        run: uv run pytest -m "not integration" -v
+      - name: Run tests (with coverage gate, parallel)
+        run: make coverage-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Faster default test runs (~7min → ~3min, 2.4x).** Coverage instrumentation
+  was moved out of pytest `addopts` (it added a ~7-11x tax to every run); the
+  fast default `make test` runs without it (`-q`), while coverage + the 65% gate
+  run via `make coverage` / `make coverage-check` (CI now uses the latter).
+  Four discovery "import-error" unit tests that hit the live yfinance network
+  (~135s) now mock the universe provider. Added a `make test-verbose` target.
+  (pytest-xdist parallelization is a deferred follow-up — the suite has latent
+  test-isolation issues, e.g. a `ConfigurationManager` singleton reading the
+  real environment, that must be fixed first.)
+
 ## [5.5.0] - 2026-06-07
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # FinWiz Development Makefile
 
-.PHONY: help install test test-all test-integration lint lint-check format clean setup dev check check-unittest-mock check-file-size check-stage-contract cleanup mypy coverage coverage-report coverage-check docs-build docs-build-strict docs-serve docs-deploy docs-lint docs-validate docs-clean all ci sbom audit
+.PHONY: help install test test-verbose test-all test-integration lint lint-check format clean setup dev check check-unittest-mock check-file-size check-stage-contract cleanup mypy coverage coverage-report coverage-check docs-build docs-build-strict docs-serve docs-deploy docs-lint docs-validate docs-clean all ci sbom audit
 
 # Default target
 help:
@@ -72,6 +72,9 @@ dev:
 
 # Testing
 test:
+	uv run pytest -m "not integration" -q
+
+test-verbose:
 	uv run pytest -m "not integration" -v
 
 test-all:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,11 +173,10 @@ line-ending = "auto"
 [tool.pytest.ini_options]
 
 testpaths = ["tests"]
+# NOTE: coverage is intentionally NOT in addopts — it adds a ~7-11x slowdown to
+# every run. The fast default (`make test`) runs without it; coverage + the 65%
+# gate run via `make coverage` / `make coverage-check` (used in CI).
 addopts = [
-    "--cov=src/finwiz",
-    "--cov-report=term-missing",
-    "--cov-report=html:htmlcov",
-    "--cov-fail-under=65",
     "--strict-markers",
     "--strict-config",
     "-ra",

--- a/tests/unit/scoring/discovery/test_breakout_detector.py
+++ b/tests/unit/scoring/discovery/test_breakout_detector.py
@@ -72,6 +72,8 @@ class TestBreakoutDetector:
         from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
 
         mocker.patch.object(NewcomerDiscoveryPipeline, "_load_portfolio_tickers")
+        # Avoid a live yfinance universe fetch; empty universe keeps screeners offline.
+        mocker.patch("finwiz.discovery.universe_provider.DynamicUniverseProvider.get_universe", return_value=[])
         pipeline = NewcomerDiscoveryPipeline("stock")
         pipeline.portfolio_tickers = set()
         candidates = pipeline._gather_candidates()

--- a/tests/unit/scoring/discovery/test_ipo_screener.py
+++ b/tests/unit/scoring/discovery/test_ipo_screener.py
@@ -73,6 +73,8 @@ class TestIPOScreener:
         from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
 
         mocker.patch.object(NewcomerDiscoveryPipeline, "_load_portfolio_tickers")
+        # Avoid a live yfinance universe fetch; empty universe keeps screeners offline.
+        mocker.patch("finwiz.discovery.universe_provider.DynamicUniverseProvider.get_universe", return_value=[])
         pipeline = NewcomerDiscoveryPipeline("stock")
         pipeline.portfolio_tickers = set()
         # _gather_candidates handles ImportError internally

--- a/tests/unit/scoring/discovery/test_momentum_scanner.py
+++ b/tests/unit/scoring/discovery/test_momentum_scanner.py
@@ -74,6 +74,8 @@ class TestMomentumScanner:
         from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
 
         mocker.patch.object(NewcomerDiscoveryPipeline, "_load_portfolio_tickers")
+        # Avoid a live yfinance universe fetch; empty universe keeps screeners offline.
+        mocker.patch("finwiz.discovery.universe_provider.DynamicUniverseProvider.get_universe", return_value=[])
         pipeline = NewcomerDiscoveryPipeline("stock")
         pipeline.portfolio_tickers = set()
         candidates = pipeline._gather_candidates()

--- a/tests/unit/scoring/discovery/test_universe_provider.py
+++ b/tests/unit/scoring/discovery/test_universe_provider.py
@@ -70,9 +70,11 @@ class TestDynamicUniverseProvider:
         from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
 
         mocker.patch.object(NewcomerDiscoveryPipeline, "_load_portfolio_tickers")
+        # Avoid a live yfinance universe fetch; empty universe keeps screeners offline.
+        mocker.patch("finwiz.discovery.universe_provider.DynamicUniverseProvider.get_universe", return_value=[])
         pipeline = NewcomerDiscoveryPipeline("stock")
         pipeline.portfolio_tickers = set()
 
-        # The real module doesn't exist, so _gather_candidates will handle ImportError
+        # _gather_candidates handles a missing/empty universe gracefully
         candidates = pipeline._gather_candidates()
         assert isinstance(candidates, list)


### PR DESCRIPTION
## Summary
Cuts the local `make test` loop from **~7min → ~3min (2.4x)** with zero flakiness. Answers the "why is pytest so slow" investigation.

### Changes
- **Coverage is now opt-in.** Removed `--cov*` from pytest `addopts` (it added a ~7-11x tax to *every* run). The fast default `make test` runs without coverage (`-q`). Coverage + the **65% gate** run via `make coverage` / `make coverage-check`, and **CI's test step now calls `make coverage-check`** so the gate is still enforced.
- **Mocked 4 network-bound "unit" tests.** `test_import_error_handled_*` in `tests/unit/scoring/discovery/` were calling the real `DynamicUniverseProvider` → yfinance on 8 ETFs (~135s). They now mock `get_universe` (empty universe keeps screeners offline) — **~135s → ~6s** — while keeping their "returns a list" contract.
- Added `make test-verbose` for the occasional full `-v` run.

### Deliberately NOT included: pytest-xdist
Parallelization would be the next big win (~3min → <30s), but the suite has **latent test-isolation bugs** that fail under `-n auto` reordering — e.g. a `ConfigurationManager` singleton that loads the real `.env` (and prints API keys on failure) and a resilience-config singleton. Enabling xdist now would break CI and risk leaking secrets. Tracked as a follow-up (fix isolation → then enable xdist).

## Test plan
- `make test` (new default): **5159 passed, 0 failed, ~182s** (was ~435s).
- `make coverage-check` (CI gate): **5159 passed, coverage ≥65%** ✅.
- ruff clean on changed tests; no dependency changes (`uv.lock` untouched).

No runtime/package changes — `[Unreleased]` in CHANGELOG, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reduced default test execution time (~7 min to ~3 min) by optimizing coverage configuration.
  * Isolated unit tests to prevent external network calls during test runs.

* **Chores**
  * Updated CI/CD workflow to use unified test command.
  * Added verbose test option (`make test-verbose`) for detailed test output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->