### PR TITLE
perf(test): reorder-safe isolation + pytest-xdist; deterministic ~1m53s make test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (pytest-xdist parallelization is a deferred follow-up — the suite has latent
   test-isolation issues, e.g. a `ConfigurationManager` singleton reading the
   real environment, that must be fixed first.)
+- **Parallel test runs (pytest-xdist).** Added an autouse isolation fixture
+  (`tests/conftest.py`) that clears config-driving env vars and resets cached
+  config singletons (configuration manager, settings, resilience, feature flags,
+  token monitor) before every test — making the suite reorder-safe. This also
+  fixes a latent order-dependent leak where a config test could read — and print
+  on failure — the developer's real `.env` API keys. `make test` and the CI
+  coverage gate now run with `-n auto --dist=loadscope`; on a dev machine the
+  full unit suite dropped from ≈8 min (serial) to ≈5 min (~1.5×).
 
 ## [5.5.0] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   config singletons (configuration manager, settings, resilience, feature flags,
   token monitor) before every test — making the suite reorder-safe. This also
   fixes a latent order-dependent leak where a config test could read — and print
-  on failure — the developer's real `.env` API keys. `make test` and the CI
-  coverage gate now run with `-n auto --dist=loadscope`; on a dev machine the
-  full unit suite dropped from ≈8 min (serial) to ≈5 min (~1.5×).
+  on failure — the developer's real `.env` API keys. The fixture's own overhead
+  is negligible. `make test` and the CI coverage gate now run with
+  `-n auto --dist=loadscope`, which roughly halves wall-clock on this
+  largely wait-bound suite (≈13 min serial → ≈5 min parallel, 10-core dev
+  machine; exact times vary because some orchestrator unit tests still make real
+  network calls). The remaining wall-clock is dominated by those orchestrator
+  tests whose batch-prefetch path is unmocked; mocking it (as the prior PR did
+  for the yfinance discovery tests) is a separate follow-up to reach <3 min.
 
 ## [5.5.0] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.1] - 2026-06-08
+
 ### Changed
 
 - **Faster default test runs (~7min → ~3min, 2.4x).** Coverage instrumentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fixes a latent order-dependent leak where a config test could read — and print
   on failure — the developer's real `.env` API keys. The fixture's own overhead
   is negligible. `make test` and the CI coverage gate now run with
-  `-n auto --dist=loadscope`, which roughly halves wall-clock on this
-  largely wait-bound suite (≈13 min serial → ≈5 min parallel, 10-core dev
-  machine; exact times vary because some orchestrator unit tests still make real
-  network calls). The remaining wall-clock is dominated by those orchestrator
-  tests whose batch-prefetch path is unmocked; mocking it (as the prior PR did
-  for the yfinance discovery tests) is a separate follow-up to reach <3 min.
+  `-n auto --dist=loadscope`.
+- **Default unit run is now network-free and deterministic (~3 min → ~1m53s).**
+  Profiling showed the default suite was dominated — and made wildly
+  time-variable — by ~18 deep-analysis orchestrator "unit" tests that made real
+  network calls (Alpha Vantage / yfinance via the macro-snapshot and
+  batch-prefetch paths) wrapped in retry/backoff. These are now marked
+  `@pytest.mark.integration`, so `make test` (`-m "not integration"`) excludes
+  them and runs CPU-bound at ~1m53s on a 10-core machine (was ~3 min and
+  network-variable); they still run in the integration job. Pure-logic tests in
+  those files stay in the fast unit run. Fully mocking the orchestrator data
+  layer to return them to the unit suite is a possible future refinement.
 
 ## [5.5.0] - 2026-06-07
 

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ dev:
 
 # Testing
 test:
-	uv run pytest -m "not integration" -q
+	uv run pytest -m "not integration" -q -n auto --dist=loadscope
 
 test-verbose:
 	uv run pytest -m "not integration" -v
@@ -108,7 +108,7 @@ test-failures:
 
 coverage-check:
 	@echo "🔍 Checking test coverage..."
-	uv run pytest --cov=src/finwiz --cov-report=term-missing --cov-fail-under=65 --quiet
+	uv run pytest --cov=src/finwiz --cov-report=term-missing --cov-fail-under=65 --quiet -n auto --dist=loadscope
 	@echo "✅ Coverage meets minimum threshold (65%)"
 
 # Code Quality

--- a/docs/superpowers/plans/2026-06-07-test-isolation-and-xdist.md
+++ b/docs/superpowers/plans/2026-06-07-test-isolation-and-xdist.md
@@ -1,0 +1,398 @@
+# Test Isolation + pytest-xdist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the test suite reorder-safe (reset cached singletons + isolate config env per test, killing an API-key leak), then enable `pytest-xdist` so `make test` runs in parallel (~3min → target <30s).
+
+**Architecture:** Add one autouse, function-scoped fixture in `tests/conftest.py` that (a) clears the env vars that feed the config singletons and (b) nulls the cached singletons before every test. With state no longer leaking across tests, `-n auto --dist=loadscope` becomes safe; wire it into `make test` / `make coverage-check` (CI).
+
+**Tech Stack:** Python 3.12, uv, pytest + pytest-mock (`monkeypatch`), pytest-xdist.
+
+**Working branch:** `perf/test-isolation-xdist` (create before Task 1: `git checkout -b perf/test-isolation-xdist`).
+
+**Constraints:** pytest-mock only (NO `unittest.mock`). Line length ≤180. Do not weaken the 65% coverage gate. Keep the existing discovery network mocks.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `tests/conftest.py` | Global autouse isolation (singletons + env) | Modify |
+| `tests/unit/test_global_isolation.py` | Meta-tests proving the isolation fixture works | Create |
+| `tests/unit/utils/test_configuration_manager.py` | Drop the destructive `setup_method`; rely on autouse isolation | Modify |
+| `pyproject.toml` | Add `pytest-xdist` dev dep | Modify |
+| `Makefile` | `test` + `coverage-check` run `-n auto --dist=loadscope` | Modify |
+| `CHANGELOG.md` | `[Unreleased]` note | Modify |
+
+Singletons/globals involved (read-only references):
+- `src/finwiz/config/manager.py:379` — `_config_manager` (no reset fn; null it directly).
+- `src/finwiz/config/resilience_config.py` — `_resilience_config` + `reset_resilience_config()` (line 179).
+- `src/finwiz/infrastructure/monitoring/litellm_callback.py:179` — `_token_monitor`.
+
+---
+
+## Task 1: Autouse isolation fixture (singletons + env)
+
+**Files:**
+- Modify: `tests/conftest.py`
+- Test: `tests/unit/test_global_isolation.py`
+
+- [ ] **Step 1: Write the failing meta-tests**
+
+Create `tests/unit/test_global_isolation.py`:
+
+```python
+"""Meta-tests verifying the autouse isolation fixture in tests/conftest.py.
+
+These guard the reorder-safety guarantees that let the suite run under
+pytest-xdist: config-driving env vars are cleared and cached singletons are
+reset before every test.
+"""
+
+import os
+
+
+def test_api_key_env_vars_are_isolated():
+    # The developer's real .env keys must never be visible inside tests
+    # (prevents real-secret leakage into assertions/output).
+    for var in ("OPENAI_API_KEY", "CHART_IMG_API_KEY", "KRAKEN_API_KEY"):
+        assert os.getenv(var) is None, f"{var} leaked into the test environment"
+
+
+def test_resilience_env_vars_are_isolated():
+    assert os.getenv("FINWIZ_MAX_RETRIES") is None
+
+
+def test_config_manager_singleton_is_reset():
+    import finwiz.config.manager as cfg
+
+    assert cfg._config_manager is None
+
+
+def test_resilience_singleton_is_reset():
+    import finwiz.config.resilience_config as res
+
+    assert res._resilience_config is None
+
+
+def test_token_monitor_singleton_is_reset():
+    import finwiz.infrastructure.monitoring.litellm_callback as llm
+
+    assert llm._token_monitor is None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/unit/test_global_isolation.py -v --no-cov`
+Expected: FAIL (env vars present from `.env` and/or singletons not guaranteed None) — at least `test_api_key_env_vars_are_isolated` fails if a key is set in the environment.
+
+- [ ] **Step 3: Add the autouse isolation fixture to `tests/conftest.py`**
+
+In `tests/conftest.py`, after the existing imports/`os.environ.setdefault(...)` block and before the data fixtures (after line ~31, the `from tests.fixtures import (...)` block), add:
+
+```python
+# ---------------------------------------------------------------------------
+# Global reorder-safe isolation (enables pytest-xdist parallelism).
+#
+# Cached config singletons + the developer's real .env would otherwise leak
+# across tests, making results order-dependent (and leaking real API keys into
+# assertion output). This autouse fixture resets that state before every test.
+# ---------------------------------------------------------------------------
+
+# Env vars that feed config singletons. Cleared per-test so unit tests never
+# read the real .env and cannot pollute each other.
+_ISOLATED_ENV_VARS = (
+    # API keys — REQUIRED_API_KEYS in finwiz.config.manager
+    "OPENAI_API_KEY",
+    "SERPER_API_KEY",
+    "ALPHA_VANTAGE_API_KEY",
+    "CHART_IMG_API_KEY",
+    "TWELVE_DATA_API_KEY",
+    "X-CMC_PRO_API_KEY",
+    "KRAKEN_API_KEY",
+    # Resilience config — finwiz.config.resilience_config
+    "FINWIZ_MAX_RETRIES",
+    "FINWIZ_RETRY_BASE_DELAY",
+    "FINWIZ_RETRY_MAX_DELAY",
+    "FINWIZ_HOLDING_TIMEOUT",
+    "FINWIZ_FLOW_TIMEOUT",
+    "FINWIZ_CIRCUIT_BREAKER_THRESHOLD",
+    "FINWIZ_CIRCUIT_BREAKER_RECOVERY",
+    "FINWIZ_AUTO_RESUME",
+    "FINWIZ_STATE_MAX_AGE_HOURS",
+    "FINWIZ_PARALLEL_LIMIT",
+    "FINWIZ_DEEP_ANALYSIS_PARALLEL_LIMIT",
+    "FINWIZ_CLEANUP_STATE_ON_SUCCESS",
+    "FINWIZ_STATE_CLEANUP_MAX_AGE_DAYS",
+    "PORTFOLIO_PARALLEL_LIMIT",
+    "DEEP_ANALYSIS_PARALLEL_LIMIT",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_state(monkeypatch):
+    """Reset cached config singletons and clear config-driving env vars per test.
+
+    Makes the suite safe to run in parallel (pytest-xdist) and prevents unit
+    tests from reading the real ``.env`` (which also stops real secrets reaching
+    assertion output). ``monkeypatch`` auto-restores on teardown.
+
+    A test that needs a specific value sets it AFTER this fixture runs (e.g.
+    ``monkeypatch.setenv("OPENAI_API_KEY", "test-key")``), which wins.
+    """
+    import finwiz.config.manager as _cfg
+    import finwiz.config.resilience_config as _res
+    import finwiz.infrastructure.monitoring.litellm_callback as _llm
+
+    for var in _ISOLATED_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    monkeypatch.setattr(_cfg, "_config_manager", None, raising=False)
+    monkeypatch.setattr(_res, "_resilience_config", None, raising=False)
+    monkeypatch.setattr(_llm, "_token_monitor", None, raising=False)
+```
+
+(`pytest` is already imported in conftest.py.)
+
+- [ ] **Step 4: Run the meta-tests — verify they pass**
+
+Run: `uv run pytest tests/unit/test_global_isolation.py -v --no-cov`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Lint**
+
+Run: `uv run ruff check --fix tests/conftest.py tests/unit/test_global_isolation.py && uv run ruff format tests/conftest.py tests/unit/test_global_isolation.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/conftest.py tests/unit/test_global_isolation.py
+git commit -m "test: autouse fixture to isolate config singletons + env (reorder-safe)"
+```
+
+---
+
+## Task 2: Remove the destructive env-clearing from the config-manager tests
+
+**Files:**
+- Modify: `tests/unit/utils/test_configuration_manager.py`
+
+The class `TestConfigurationManager` (line 25) has a `setup_method` (lines 28-42) that does `del os.environ[var]` for 7 vars — destructive (never restored), incomplete, and the source of order-dependence. The autouse fixture from Task 1 now provides clean, restored env isolation for ALL classes (including `TestConfigurationManagerIntegration` at line 429, which had none). Remove the manual `setup_method`.
+
+- [ ] **Step 1: Delete the `setup_method`**
+
+In `tests/unit/utils/test_configuration_manager.py`, delete these lines (28-42) entirely:
+
+```python
+    def setup_method(self):
+        """Set up test environment."""
+        # Clear environment variables
+        env_vars_to_clear = [
+            "OPENAI_API_KEY",
+            "SERPER_API_KEY",
+            "ALPHA_VANTAGE_API_KEY",
+            "CHART_IMG_API_KEY",
+            "TWELVE_DATA_API_KEY",
+            "X-CMC_PRO_API_KEY",
+            "KRAKEN_API_KEY",
+        ]
+        for var in env_vars_to_clear:
+            if var in os.environ:
+                del os.environ[var]
+```
+
+Leave the rest of `TestConfigurationManager` and its tests intact. If `os` becomes unused after this deletion, the next step's ruff `--fix` removes the import; if other tests in the file still use `os` (e.g. `mocker.patch.dict("os.environ", ...)` references), leave it.
+
+- [ ] **Step 2: Run the whole file (and the previously-failing test) in isolation**
+
+Run: `uv run pytest tests/unit/utils/test_configuration_manager.py -v --no-cov`
+Expected: ALL pass, including `TestConfigurationManagerIntegration::test_should_handle_mixed_required_and_optional_keys` — and the test now operates on a clean env (no real `.env` keys present).
+
+- [ ] **Step 3: Prove the secret leak is gone**
+
+Run a deliberately-isolated single test and confirm its output contains no real key material. Run:
+`uv run pytest "tests/unit/utils/test_configuration_manager.py::TestConfigurationManagerIntegration::test_should_handle_mixed_required_and_optional_keys" -q --no-cov 2>&1 | tail -5`
+Expected: `1 passed`. (Because the autouse fixture cleared all API-key env vars, `ConfigurationManager.api_keys` can only contain values the test sets itself — never the developer's real keys — so even a future failure cannot print real secrets.)
+
+- [ ] **Step 4: Lint + commit**
+
+Run: `uv run ruff check --fix tests/unit/utils/test_configuration_manager.py && uv run ruff format tests/unit/utils/test_configuration_manager.py`
+
+```bash
+git add tests/unit/utils/test_configuration_manager.py
+git commit -m "test(config): drop destructive env-clearing; rely on autouse isolation (no secret leak)"
+```
+
+---
+
+## Task 3: Confirm the resilience reset test is reorder-safe
+
+**Files:**
+- Verify only: `tests/unit/config/test_resilience_config.py` (no change expected)
+
+`TestResetResilienceConfig::test_should_reset_singleton` (line ~533) assumes the singleton starts unset (`get_resilience_config()` reads `FINWIZ_MAX_RETRIES=5`). It failed under xdist when a prior test had already cached `_resilience_config`. Task 1's autouse fixture now nulls `_resilience_config` before every test, so the assumption holds regardless of order.
+
+- [ ] **Step 1: Run the resilience test file**
+
+Run: `uv run pytest tests/unit/config/test_resilience_config.py -v --no-cov`
+Expected: ALL pass.
+
+- [ ] **Step 2: Run it inside the broader config suite (cross-test contamination check)**
+
+Run: `uv run pytest tests/unit/config -q --no-cov`
+Expected: ALL pass — the autouse reset makes the singleton's starting state independent of any earlier test in the run.
+
+- [ ] **Step 3: No code change → no commit for this task.** (If a change WAS needed, the fix is the same pattern as Task 1 — reset the offending singleton in `_isolate_global_state`.)
+
+---
+
+## Task 4: Enable pytest-xdist
+
+**Files:**
+- Modify: `pyproject.toml`, `Makefile`
+
+- [ ] **Step 1: Add the dev dependency**
+
+In `pyproject.toml`, in `[dependency-groups]` `dev = [ ... ]`, add after `"pytest-timeout>=2.4.0",`:
+
+```python
+    "pytest-xdist>=3.6.0",
+```
+
+- [ ] **Step 2: Lock + sync**
+
+Run: `uv lock && uv sync --all-groups`
+Expected: adds `pytest-xdist` and `execnet`.
+
+- [ ] **Step 3: Parallelize `make test` and `make coverage-check`**
+
+In `Makefile`, change the `test` recipe from:
+
+```makefile
+test:
+	uv run pytest -m "not integration" -q
+```
+
+to:
+
+```makefile
+test:
+	uv run pytest -m "not integration" -q -n auto --dist=loadscope
+```
+
+And change the `coverage-check` recipe from:
+
+```makefile
+	uv run pytest --cov=src/finwiz --cov-report=term-missing --cov-fail-under=65 --quiet
+```
+
+to:
+
+```makefile
+	uv run pytest --cov=src/finwiz --cov-report=term-missing --cov-fail-under=65 --quiet -n auto --dist=loadscope
+```
+
+(Recipe lines use TAB indentation. Leave `test-verbose` and `coverage` serial.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock Makefile
+git commit -m "test: enable pytest-xdist (-n auto) for make test + coverage-check"
+```
+
+---
+
+## Task 5: Verify reorder-safety and flakiness
+
+**Files:** none (verification). Capture only PASS/FAIL summaries and test IDs — never dump full assertion output (secret-safety).
+
+- [ ] **Step 1: Run the full suite under xdist (loadscope) — run 1**
+
+Run: `uv run pytest -m "not integration" --no-cov -n auto --dist=loadscope -q -rf 2>&1 | tail -8`
+Expected: `N passed` (≈5164 incl. the 5 new meta-tests), `0 failed`.
+
+- [ ] **Step 2: Run it again — run 2 (flakiness check)**
+
+Run: `uv run pytest -m "not integration" --no-cov -n auto --dist=loadscope -q -rf 2>&1 | tail -8`
+Expected: identical `0 failed`. If any test fails in run 1 or 2, note its ID, find the shared state it depends on (singleton/env/file), and reset/isolate it in `tests/conftest.py::_isolate_global_state` (or that test's own `monkeypatch`). Re-run until two consecutive clean runs.
+
+- [ ] **Step 3: Stress with `--dist=load` (max reordering)**
+
+Run: `uv run pytest -m "not integration" --no-cov -n auto --dist=load -q -rf 2>&1 | tail -10`
+Expected: ideally `0 failed`. `load` distributes individual tests (more aggressive than `loadscope`) and may surface class-fixture-shared tests that are NOT true global-state bugs. If failures appear ONLY under `load` and are due to legitimate same-class fixture sharing (not global singletons/env), that's acceptable — `loadscope` (our chosen mode) keeps classes together. Record any such cases in the commit message; only fix true global-state leaks.
+
+- [ ] **Step 4: Confirm the coverage gate passes under xdist**
+
+Run: `make coverage-check 2>&1 | tail -6`
+Expected: `Coverage meets minimum threshold (65%)` and `0 failed`. If a test that previously relied on a real `.env` key now fails (env isolation), fix that test to set the value it needs via `monkeypatch.setenv(...)` or to mock the dependency — do NOT relax the autouse isolation.
+
+- [ ] **Step 5: Commit any straggler fixes**
+
+```bash
+git add -A
+git commit -m "test: isolate remaining order-dependent state for xdist"
+```
+(Skip if Steps 1-4 were clean with no changes.)
+
+---
+
+## Task 6: CHANGELOG + final gate
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update the changelog**
+
+In `CHANGELOG.md`, under the existing `## [Unreleased]` `### Changed` section (created by the previous test-speedup PR), append:
+
+```markdown
+- **Parallel test runs (pytest-xdist).** Added an autouse isolation fixture
+  (`tests/conftest.py`) that resets cached config singletons and clears
+  config-driving env vars before every test, making the suite reorder-safe;
+  this also fixes a latent leak where config tests could read — and print on
+  failure — the developer's real `.env` API keys. `make test` and the CI
+  coverage gate now run with `-n auto --dist=loadscope` (~3min → <1min).
+```
+
+- [ ] **Step 2: Final gates**
+
+Run: `uv run ruff check . 2>&1 | tail -3`
+Expected: `All checks passed!`
+
+Run: `make coverage-check 2>&1 | tail -4`
+Expected: passes, coverage ≥65%.
+
+Run: `uv run mypy src/finwiz 2>&1 | tail -2`
+Expected: `Success` (no src changes, but confirm nothing regressed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): note parallel test runs + test-isolation fix"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] Two consecutive `-n auto --dist=loadscope` full runs: `0 failed`.
+- [ ] `make coverage-check`: passes, coverage ≥65%, under xdist.
+- [ ] `grep -rn "OPENAI_API_KEY\|CHART_IMG_API_KEY" $(git ls-files 'tests/**') | grep -v conftest.py | grep -v _ISOLATED` — no test asserts on a real key value.
+- [ ] `make test` wall-clock noticeably reduced (record before/after).
+- [ ] ruff clean; mypy clean; no `unittest.mock` introduced.
+
+## Spec-coverage check
+
+- Reorder-safe singleton reset → Task 1. ✅
+- Env isolation (no real `.env` in tests) → Task 1. ✅
+- Secret-leak fixed + verified → Task 1 + Task 2 (Step 3). ✅
+- Remove destructive setup_method → Task 2. ✅
+- Resilience reset test reorder-safe → Task 3. ✅
+- Enable xdist (dep + make test + coverage-check/CI) → Task 4. ✅
+- Verify reorder-safety + flakiness + gate → Task 5. ✅
+- CHANGELOG, no version bump → Task 6. ✅
+- CI uses `make coverage-check` (already wired in the prior PR), so xdist + the 65% gate run in CI automatically. ✅

--- a/docs/superpowers/plans/2026-06-07-test-isolation-and-xdist.md
+++ b/docs/superpowers/plans/2026-06-07-test-isolation-and-xdist.md
@@ -2,13 +2,24 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make the test suite reorder-safe (reset cached singletons + isolate config env per test, killing an API-key leak), then enable `pytest-xdist` so `make test` runs in parallel (~3min → target <30s).
+**Goal:** Make the test suite reorder-safe (clear config-driving env vars + reset cached singletons before every test, killing an order-dependent API-key leak), then enable `pytest-xdist` so `make test` runs in parallel. Record the real before/after wall-clock; target ≈3 min → ≈1 min (do **not** hard-commit to "<30s" — xdist worker startup + import cost makes that optimistic).
 
-**Architecture:** Add one autouse, function-scoped fixture in `tests/conftest.py` that (a) clears the env vars that feed the config singletons and (b) nulls the cached singletons before every test. With state no longer leaking across tests, `-n auto --dist=loadscope` becomes safe; wire it into `make test` / `make coverage-check` (CI).
+**Architecture:** Add one autouse, function-scoped fixture in `tests/conftest.py` that (a) clears the env vars that feed the config singletons and (b) nulls the cached singletons — before every test, all via `monkeypatch` so teardown restores cleanly. With state no longer leaking across tests, `-n auto --dist=loadscope` becomes safe; wire it into `make test` / `make coverage-check` (CI).
+
+### Root cause (verified)
+
+The order-dependence and the secret leak come from two interacting facts:
+
+1. **Import-time `.env` pollution.** ~9 modules call a no-arg `load_dotenv()` at import (e.g. `core/app_initializer.py:25`, `config/llm/llm_config.py:35`, the crews, `tools/alpha_vantage_tool.py`). `load_dotenv()` walks up from the package to the repo root and loads the real `.env` into `os.environ` — **once per process**, before any test runs. Verified: importing `finwiz.core.app_initializer` alone populates `OPENAI_API_KEY`, `CHART_IMG_API_KEY`, `KRAKEN_API_KEY`, etc. The repo `.env` exists locally (112 assignments) and contains all seven API keys (required + optional).
+2. **A destructive, non-restored cleanup in one test class.** `TestConfigurationManager.setup_method` did `del os.environ[var]` for 7 keys with no restore — a permanent global mutation. So once that class ran, those keys were gone for the rest of the session; tests running *before* it still saw them. `TestConfigurationManagerIntegration` (no `setup_method`) asserts `"Chart-img" not in api_keys`, which only holds if an earlier class already deleted `CHART_IMG_API_KEY`. Under `pytest-xdist` reordering, when the integration test runs first the real `CHART_IMG_API_KEY` is still present → assertion fails **and the real key is printed in the failure output**.
+
+The fix: clear the config-driving env vars before *every* test (restored by `monkeypatch`, so no destructive global mutation), and null the cached singletons so env-derived/mutable state can't carry across tests. Deterministic regardless of order.
+
+> **Deliberately NOT done (and why):** We do **not** patch `load_dotenv` or override pydantic's `env_file`. Verified reasons: `ConfigurationManager`'s own "default `.env`" branch computes `parents[2]/.env` = `.../src/.env`, which does not exist, so constructing a manager re-loads nothing (no per-test re-injection). And `FinWizSettings` uses `env_prefix="FINWIZ_"`; `.env` has no `FINWIZ_`-prefixed API keys, so `get_settings()` surfaces no secrets. Per-test env clearing is therefore sufficient and simpler — don't add `.env`-blocking machinery for paths that don't leak.
 
 **Tech Stack:** Python 3.12, uv, pytest + pytest-mock (`monkeypatch`), pytest-xdist.
 
-**Working branch:** `perf/test-isolation-xdist` (create before Task 1: `git checkout -b perf/test-isolation-xdist`).
+**Working branch:** `perf/test-isolation-xdist` (already created).
 
 **Constraints:** pytest-mock only (NO `unittest.mock`). Line length ≤180. Do not weaken the 65% coverage gate. Keep the existing discovery network mocks.
 
@@ -18,21 +29,25 @@
 
 | File | Responsibility | Change |
 |---|---|---|
-| `tests/conftest.py` | Global autouse isolation (singletons + env) | Modify |
-| `tests/unit/test_global_isolation.py` | Meta-tests proving the isolation fixture works | Create |
+| `tests/conftest.py` | Global autouse isolation (clear env + reset singletons) | Modify |
+| `tests/unit/test_global_isolation.py` | Meta-tests proving the isolation fixture works (incl. constructing a real manager) | Create |
 | `tests/unit/utils/test_configuration_manager.py` | Drop the destructive `setup_method`; rely on autouse isolation | Modify |
 | `pyproject.toml` | Add `pytest-xdist` dev dep | Modify |
 | `Makefile` | `test` + `coverage-check` run `-n auto --dist=loadscope` | Modify |
 | `CHANGELOG.md` | `[Unreleased]` note | Modify |
 
-Singletons/globals involved (read-only references):
-- `src/finwiz/config/manager.py:379` — `_config_manager` (no reset fn; null it directly).
-- `src/finwiz/config/resilience_config.py` — `_resilience_config` + `reset_resilience_config()` (line 179).
-- `src/finwiz/infrastructure/monitoring/litellm_callback.py:179` — `_token_monitor`.
+Singletons reset by the fixture, with rationale:
+- `src/finwiz/config/manager.py:379` — `_config_manager` (env-derived; no reset fn — null directly).
+- `src/finwiz/config/settings.py:216` — `_settings` (env/`.env`-derived cache; `reset_settings()` existed but was unused). **Was missing from the original plan.**
+- `src/finwiz/config/resilience_config.py:87` — `_resilience_config` (env-derived; `reset_resilience_config()` at line 179).
+- `src/finwiz/config/features/flags.py:251` — `_feature_flags` (holds **mutable circuit-breaker state** mutated by `record_failure`; leaks across tests under any ordering). **Was missing from the original plan.**
+- `src/finwiz/infrastructure/monitoring/litellm_callback.py:179` — `_token_monitor` (mutable accumulator).
+
+> **Scope note on the other ~19 singletons.** A sweep found 24 module-level `_x: T | None = None` singletons. We reset the 5 above because unit tests exercise them and they carry env-derived or mutable state. The rest (cache managers, rate limiter, degradation manager, monitoring collectors, validation managers, etc.) are left alone deliberately — resetting everything risks masking real bugs and adds churn. The two full-suite verification runs in **Task 5** are the safety net: if a flake surfaces, add a targeted reset to `_isolate_global_state` using the same pattern, and note it.
 
 ---
 
-## Task 1: Autouse isolation fixture (singletons + env)
+## Task 1: Autouse isolation fixture (clear env + reset singletons)
 
 **Files:**
 - Modify: `tests/conftest.py`
@@ -47,21 +62,37 @@ Create `tests/unit/test_global_isolation.py`:
 
 These guard the reorder-safety guarantees that let the suite run under
 pytest-xdist: config-driving env vars are cleared and cached singletons are
-reset before every test.
+reset before every test, so the developer's real ``.env`` (loaded into
+``os.environ`` by import-time ``load_dotenv()`` calls) never bleeds into a test
+or its failure output.
 """
 
 import os
 
+import pytest
+
+from finwiz.config.manager import ConfigurationError, ConfigurationManager
+
 
 def test_api_key_env_vars_are_isolated():
-    # The developer's real .env keys must never be visible inside tests
-    # (prevents real-secret leakage into assertions/output).
-    for var in ("OPENAI_API_KEY", "CHART_IMG_API_KEY", "KRAKEN_API_KEY"):
+    # Real .env keys must never be visible inside tests.
+    for var in ("SERPER_API_KEY", "CHART_IMG_API_KEY", "KRAKEN_API_KEY"):
         assert os.getenv(var) is None, f"{var} leaked into the test environment"
 
 
 def test_resilience_env_vars_are_isolated():
     assert os.getenv("FINWIZ_MAX_RETRIES") is None
+
+
+def test_building_configuration_manager_sees_no_real_keys():
+    # Constructing a manager inside a test must find no API keys — proving the
+    # import-time .env pollution was cleared and nothing leaks into api_keys
+    # (which is what gets printed on failure).
+    mgr = ConfigurationManager()
+    with pytest.raises(ConfigurationError) as exc:
+        mgr.validate_api_keys()
+    assert "SERPER_API_KEY" in exc.value.missing_keys
+    assert mgr.api_keys == {}, "real .env keys leaked into ConfigurationManager.api_keys"
 
 
 def test_config_manager_singleton_is_reset():
@@ -70,10 +101,22 @@ def test_config_manager_singleton_is_reset():
     assert cfg._config_manager is None
 
 
+def test_settings_singleton_is_reset():
+    import finwiz.config.settings as settings
+
+    assert settings._settings is None
+
+
 def test_resilience_singleton_is_reset():
     import finwiz.config.resilience_config as res
 
     assert res._resilience_config is None
+
+
+def test_feature_flags_singleton_is_reset():
+    import finwiz.config.features.flags as flags
+
+    assert flags._feature_flags is None
 
 
 def test_token_monitor_singleton_is_reset():
@@ -85,80 +128,71 @@ def test_token_monitor_singleton_is_reset():
 - [ ] **Step 2: Run to verify it fails**
 
 Run: `uv run pytest tests/unit/test_global_isolation.py -v --no-cov`
-Expected: FAIL (env vars present from `.env` and/or singletons not guaranteed None) — at least `test_api_key_env_vars_are_isolated` fails if a key is set in the environment.
+Expected: FAIL. With a real `.env` present (loaded by import-time `load_dotenv()`), `test_api_key_env_vars_are_isolated` and `test_building_configuration_manager_sees_no_real_keys` fail (keys visible), and the singleton-reset tests fail (no fixture yet).
 
 - [ ] **Step 3: Add the autouse isolation fixture to `tests/conftest.py`**
 
-In `tests/conftest.py`, after the existing imports/`os.environ.setdefault(...)` block and before the data fixtures (after line ~31, the `from tests.fixtures import (...)` block), add:
+In `tests/conftest.py`, after the existing imports/`os.environ.setdefault(...)` block and the `from tests.fixtures import (...)` block (after line ~31), add:
 
 ```python
 # ---------------------------------------------------------------------------
 # Global reorder-safe isolation (enables pytest-xdist parallelism).
 #
-# Cached config singletons + the developer's real .env would otherwise leak
-# across tests, making results order-dependent (and leaking real API keys into
-# assertion output). This autouse fixture resets that state before every test.
+# Import-time load_dotenv() calls in ~9 modules load the real .env into
+# os.environ once per process. Combined with cached config singletons, that
+# state would otherwise leak across tests, making results order-dependent (and
+# leaking real API keys into assertion output on failure). This autouse fixture
+# resets that state before every test, via monkeypatch (auto-restored).
 # ---------------------------------------------------------------------------
 
-# Env vars that feed config singletons. Cleared per-test so unit tests never
-# read the real .env and cannot pollute each other.
-_ISOLATED_ENV_VARS = (
-    # API keys — REQUIRED_API_KEYS in finwiz.config.manager
-    "OPENAI_API_KEY",
-    "SERPER_API_KEY",
-    "ALPHA_VANTAGE_API_KEY",
-    "CHART_IMG_API_KEY",
-    "TWELVE_DATA_API_KEY",
-    "X-CMC_PRO_API_KEY",
-    "KRAKEN_API_KEY",
-    # Resilience config — finwiz.config.resilience_config
-    "FINWIZ_MAX_RETRIES",
-    "FINWIZ_RETRY_BASE_DELAY",
-    "FINWIZ_RETRY_MAX_DELAY",
-    "FINWIZ_HOLDING_TIMEOUT",
-    "FINWIZ_FLOW_TIMEOUT",
-    "FINWIZ_CIRCUIT_BREAKER_THRESHOLD",
-    "FINWIZ_CIRCUIT_BREAKER_RECOVERY",
-    "FINWIZ_AUTO_RESUME",
-    "FINWIZ_STATE_MAX_AGE_HOURS",
-    "FINWIZ_PARALLEL_LIMIT",
-    "FINWIZ_DEEP_ANALYSIS_PARALLEL_LIMIT",
-    "FINWIZ_CLEANUP_STATE_ON_SUCCESS",
-    "FINWIZ_STATE_CLEANUP_MAX_AGE_DAYS",
-    "PORTFOLIO_PARALLEL_LIMIT",
-    "DEEP_ANALYSIS_PARALLEL_LIMIT",
-)
+# Non-FINWIZ_-prefixed env vars resilience_config still honours (back-compat).
+_EXTRA_CONFIG_ENV_VARS = ("PORTFOLIO_PARALLEL_LIMIT", "DEEP_ANALYSIS_PARALLEL_LIMIT")
 
 
 @pytest.fixture(autouse=True)
 def _isolate_global_state(monkeypatch):
-    """Reset cached config singletons and clear config-driving env vars per test.
+    """Clear config-driving env vars and reset cached config singletons per test.
 
-    Makes the suite safe to run in parallel (pytest-xdist) and prevents unit
-    tests from reading the real ``.env`` (which also stops real secrets reaching
-    assertion output). ``monkeypatch`` auto-restores on teardown.
+    Makes the suite safe under pytest-xdist and prevents unit tests from seeing
+    the developer's real ``.env`` (which also stops real secrets reaching
+    assertion output). ``monkeypatch`` auto-restores on teardown, so there is no
+    destructive global mutation.
 
     A test that needs a specific value sets it AFTER this fixture runs (e.g.
-    ``monkeypatch.setenv("OPENAI_API_KEY", "test-key")``), which wins.
+    ``monkeypatch.setenv("SERPER_API_KEY", "test-serper-key-32-characters-long")``),
+    which wins.
     """
+    import finwiz.config.features.flags as _flags
     import finwiz.config.manager as _cfg
     import finwiz.config.resilience_config as _res
+    import finwiz.config.settings as _settings
     import finwiz.infrastructure.monitoring.litellm_callback as _llm
 
-    for var in _ISOLATED_ENV_VARS:
+    # Clear config-driving env vars. API-key names are sourced from the code (not
+    # duplicated); FINWIZ_-prefixed vars are cleared by scanning so new ones are
+    # covered automatically (FINWIZ_TEST_LOGS is preserved).
+    for kc in _cfg.ConfigurationManager.REQUIRED_API_KEYS:
+        monkeypatch.delenv(kc.env_var, raising=False)
+    for var in list(os.environ):
+        if var.startswith("FINWIZ_") and var != "FINWIZ_TEST_LOGS":
+            monkeypatch.delenv(var, raising=False)
+    for var in _EXTRA_CONFIG_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
 
+    # Reset env-derived / mutable-state singletons.
+    monkeypatch.setattr(_settings, "_settings", None, raising=False)
     monkeypatch.setattr(_cfg, "_config_manager", None, raising=False)
     monkeypatch.setattr(_res, "_resilience_config", None, raising=False)
+    monkeypatch.setattr(_flags, "_feature_flags", None, raising=False)
     monkeypatch.setattr(_llm, "_token_monitor", None, raising=False)
 ```
 
-(`pytest` is already imported in conftest.py.)
+(`pytest` and `os` are already imported in conftest.py.)
 
 - [ ] **Step 4: Run the meta-tests — verify they pass**
 
 Run: `uv run pytest tests/unit/test_global_isolation.py -v --no-cov`
-Expected: PASS (5 tests).
+Expected: PASS (8 tests).
 
 - [ ] **Step 5: Lint**
 
@@ -169,7 +203,7 @@ Expected: clean.
 
 ```bash
 git add tests/conftest.py tests/unit/test_global_isolation.py
-git commit -m "test: autouse fixture to isolate config singletons + env (reorder-safe)"
+git commit -m "test: autouse fixture to isolate config env + reset singletons (reorder-safe)"
 ```
 
 ---
@@ -179,11 +213,11 @@ git commit -m "test: autouse fixture to isolate config singletons + env (reorder
 **Files:**
 - Modify: `tests/unit/utils/test_configuration_manager.py`
 
-The class `TestConfigurationManager` (line 25) has a `setup_method` (lines 28-42) that does `del os.environ[var]` for 7 vars — destructive (never restored), incomplete, and the source of order-dependence. The autouse fixture from Task 1 now provides clean, restored env isolation for ALL classes (including `TestConfigurationManagerIntegration` at line 429, which had none). Remove the manual `setup_method`.
+The class `TestConfigurationManager` (line 25) has a `setup_method` (lines 28-42) that does `del os.environ[var]` for 7 vars — a **non-restored global mutation** and the source of the order-dependence (see Root cause). The autouse fixture from Task 1 now provides clean, restored isolation for ALL classes (including `TestConfigurationManagerIntegration` at line 429, which had none). Remove the manual `setup_method`.
 
 - [ ] **Step 1: Delete the `setup_method`**
 
-In `tests/unit/utils/test_configuration_manager.py`, delete these lines (28-42) entirely:
+In `tests/unit/utils/test_configuration_manager.py`, delete lines 28-42 entirely:
 
 ```python
     def setup_method(self):
@@ -203,18 +237,17 @@ In `tests/unit/utils/test_configuration_manager.py`, delete these lines (28-42) 
                 del os.environ[var]
 ```
 
-Leave the rest of `TestConfigurationManager` and its tests intact. If `os` becomes unused after this deletion, the next step's ruff `--fix` removes the import; if other tests in the file still use `os` (e.g. `mocker.patch.dict("os.environ", ...)` references), leave it.
+Leave the rest of `TestConfigurationManager` and its tests intact. If `os` becomes unused after this deletion, the next step's ruff `--fix` removes the import; if other tests still use `os` (e.g. `mocker.patch.dict("os.environ", ...)`), leave it.
 
-- [ ] **Step 2: Run the whole file (and the previously-failing test) in isolation**
+- [ ] **Step 2: Run the whole file in isolation**
 
 Run: `uv run pytest tests/unit/utils/test_configuration_manager.py -v --no-cov`
-Expected: ALL pass, including `TestConfigurationManagerIntegration::test_should_handle_mixed_required_and_optional_keys` — and the test now operates on a clean env (no real `.env` keys present).
+Expected: ALL pass, including `TestConfigurationManagerIntegration::test_should_handle_mixed_required_and_optional_keys`. Previously this was order-dependent: it only passed when an earlier class's destructive `del` had already removed `CHART_IMG_API_KEY`. The autouse fixture now clears it before every test regardless of order.
 
-- [ ] **Step 3: Prove the secret leak is gone**
+- [ ] **Step 3: Prove the leak is order-independent now**
 
-Run a deliberately-isolated single test and confirm its output contains no real key material. Run:
-`uv run pytest "tests/unit/utils/test_configuration_manager.py::TestConfigurationManagerIntegration::test_should_handle_mixed_required_and_optional_keys" -q --no-cov 2>&1 | tail -5`
-Expected: `1 passed`. (Because the autouse fixture cleared all API-key env vars, `ConfigurationManager.api_keys` can only contain values the test sets itself — never the developer's real keys — so even a future failure cannot print real secrets.)
+Run: `uv run pytest "tests/unit/utils/test_configuration_manager.py::TestConfigurationManagerIntegration::test_should_handle_mixed_required_and_optional_keys" -q --no-cov 2>&1 | tail -5`
+Expected: `1 passed`. Run in isolation (no earlier class to clear state), this previously could fail and print the real `CHART_IMG_API_KEY`. The autouse fixture clears all API-key env vars first, so `api_keys` can only contain values the test sets itself — no real secret can reach the output.
 
 - [ ] **Step 4: Lint + commit**
 
@@ -232,7 +265,7 @@ git commit -m "test(config): drop destructive env-clearing; rely on autouse isol
 **Files:**
 - Verify only: `tests/unit/config/test_resilience_config.py` (no change expected)
 
-`TestResetResilienceConfig::test_should_reset_singleton` (line ~533) assumes the singleton starts unset (`get_resilience_config()` reads `FINWIZ_MAX_RETRIES=5`). It failed under xdist when a prior test had already cached `_resilience_config`. Task 1's autouse fixture now nulls `_resilience_config` before every test, so the assumption holds regardless of order.
+`TestResetResilienceConfig::test_should_reset_singleton` (line ~533) assumes the singleton starts unset. It failed under xdist when a prior test had already cached `_resilience_config`. Task 1's autouse fixture now nulls `_resilience_config` before every test, so the assumption holds regardless of order.
 
 - [ ] **Step 1: Run the resilience test file**
 
@@ -242,7 +275,7 @@ Expected: ALL pass.
 - [ ] **Step 2: Run it inside the broader config suite (cross-test contamination check)**
 
 Run: `uv run pytest tests/unit/config -q --no-cov`
-Expected: ALL pass — the autouse reset makes the singleton's starting state independent of any earlier test in the run.
+Expected: ALL pass — the autouse reset makes the singleton's starting state independent of any earlier test.
 
 - [ ] **Step 3: No code change → no commit for this task.** (If a change WAS needed, the fix is the same pattern as Task 1 — reset the offending singleton in `_isolate_global_state`.)
 
@@ -294,7 +327,7 @@ to:
 	uv run pytest --cov=src/finwiz --cov-report=term-missing --cov-fail-under=65 --quiet -n auto --dist=loadscope
 ```
 
-(Recipe lines use TAB indentation. Leave `test-verbose` and `coverage` serial.)
+(Recipe lines use TAB indentation. `loadscope` keeps each module/class on one worker, so class-scoped fixtures stay correct. `pytest-cov` combines per-worker coverage automatically. Leave `test-verbose` and `coverage` serial.)
 
 - [ ] **Step 4: Commit**
 
@@ -307,17 +340,17 @@ git commit -m "test: enable pytest-xdist (-n auto) for make test + coverage-chec
 
 ## Task 5: Verify reorder-safety and flakiness
 
-**Files:** none (verification). Capture only PASS/FAIL summaries and test IDs — never dump full assertion output (secret-safety).
+**Files:** none (verification). Capture only PASS/FAIL summaries and test IDs — never dump full assertion output (secret-safety). **Run these locally where `.env` IS present** (that is the environment the order-dependence surfaces in).
 
-- [ ] **Step 1: Run the full suite under xdist (loadscope) — run 1**
+- [ ] **Step 1: Full suite under xdist (loadscope) — run 1**
 
 Run: `uv run pytest -m "not integration" --no-cov -n auto --dist=loadscope -q -rf 2>&1 | tail -8`
-Expected: `N passed` (≈5164 incl. the 5 new meta-tests), `0 failed`.
+Expected: `N passed` (≈5167 incl. the 8 new meta-tests), `0 failed`.
 
 - [ ] **Step 2: Run it again — run 2 (flakiness check)**
 
 Run: `uv run pytest -m "not integration" --no-cov -n auto --dist=loadscope -q -rf 2>&1 | tail -8`
-Expected: identical `0 failed`. If any test fails in run 1 or 2, note its ID, find the shared state it depends on (singleton/env/file), and reset/isolate it in `tests/conftest.py::_isolate_global_state` (or that test's own `monkeypatch`). Re-run until two consecutive clean runs.
+Expected: identical `0 failed`. If any test fails in run 1 or 2, note its ID, find the shared state it depends on (singleton/env/file), and reset/isolate it in `tests/conftest.py::_isolate_global_state` (or that test's own `monkeypatch`). Pay special attention to anything touching `_feature_flags` circuit-breaker state. Re-run until two consecutive clean runs.
 
 - [ ] **Step 3: Stress with `--dist=load` (max reordering)**
 
@@ -344,29 +377,25 @@ git commit -m "test: isolate remaining order-dependent state for xdist"
 **Files:**
 - Modify: `CHANGELOG.md`
 
-- [ ] **Step 1: Update the changelog**
+- [ ] **Step 1: Update the changelog** (use the wall-clock numbers actually measured in Task 5)
 
-In `CHANGELOG.md`, under the existing `## [Unreleased]` `### Changed` section (created by the previous test-speedup PR), append:
+In `CHANGELOG.md`, under the existing `## [Unreleased]` `### Changed` section, append:
 
 ```markdown
 - **Parallel test runs (pytest-xdist).** Added an autouse isolation fixture
-  (`tests/conftest.py`) that resets cached config singletons and clears
-  config-driving env vars before every test, making the suite reorder-safe;
-  this also fixes a latent leak where config tests could read — and print on
-  failure — the developer's real `.env` API keys. `make test` and the CI
-  coverage gate now run with `-n auto --dist=loadscope` (~3min → <1min).
+  (`tests/conftest.py`) that clears config-driving env vars and resets cached
+  config singletons (configuration manager, settings, resilience, feature flags,
+  token monitor) before every test — making the suite reorder-safe. This also
+  fixes a latent order-dependent leak where a config test could read — and print
+  on failure — the developer's real `.env` API keys. `make test` and the CI
+  coverage gate now run with `-n auto --dist=loadscope` (≈3 min → ≈<MEASURED> min).
 ```
 
 - [ ] **Step 2: Final gates**
 
-Run: `uv run ruff check . 2>&1 | tail -3`
-Expected: `All checks passed!`
-
-Run: `make coverage-check 2>&1 | tail -4`
-Expected: passes, coverage ≥65%.
-
-Run: `uv run mypy src/finwiz 2>&1 | tail -2`
-Expected: `Success` (no src changes, but confirm nothing regressed).
+Run: `uv run ruff check . 2>&1 | tail -3`  → Expected: `All checks passed!`
+Run: `make coverage-check 2>&1 | tail -4`  → Expected: passes, coverage ≥65%.
+Run: `uv run mypy src/finwiz 2>&1 | tail -2`  → Expected: `Success` (no src changes, confirm nothing regressed).
 
 - [ ] **Step 3: Commit**
 
@@ -379,20 +408,22 @@ git commit -m "docs(changelog): note parallel test runs + test-isolation fix"
 
 ## Final verification (before PR)
 
-- [ ] Two consecutive `-n auto --dist=loadscope` full runs: `0 failed`.
+- [ ] Two consecutive `-n auto --dist=loadscope` full runs **with `.env` present**: `0 failed`.
 - [ ] `make coverage-check`: passes, coverage ≥65%, under xdist.
-- [ ] `grep -rn "OPENAI_API_KEY\|CHART_IMG_API_KEY" $(git ls-files 'tests/**') | grep -v conftest.py | grep -v _ISOLATED` — no test asserts on a real key value.
-- [ ] `make test` wall-clock noticeably reduced (record before/after).
+- [ ] Meta-tests prove the mechanism: building a `ConfigurationManager()` inside a test sees no real keys; the 5 singletons are reset before each test.
+- [ ] `grep -rn "SERPER_API_KEY\|CHART_IMG_API_KEY" $(git ls-files 'tests/**') | grep -v conftest.py | grep -v test_global_isolation` — no test asserts on a real key value.
+- [ ] `make test` wall-clock recorded before/after; CHANGELOG number matches the measurement.
 - [ ] ruff clean; mypy clean; no `unittest.mock` introduced.
 
 ## Spec-coverage check
 
-- Reorder-safe singleton reset → Task 1. ✅
-- Env isolation (no real `.env` in tests) → Task 1. ✅
-- Secret-leak fixed + verified → Task 1 + Task 2 (Step 3). ✅
+- Reorder-safe env clearing (sourced from code; restored via monkeypatch) → Task 1. ✅
+- Reset cached singletons incl. `_settings` + `_feature_flags` → Task 1. ✅
+- Secret-leak fixed (order-independent) + verified by constructing a real manager → Task 1 (meta-tests) + Task 2 (Step 3). ✅
 - Remove destructive setup_method → Task 2. ✅
 - Resilience reset test reorder-safe → Task 3. ✅
 - Enable xdist (dep + make test + coverage-check/CI) → Task 4. ✅
-- Verify reorder-safety + flakiness + gate → Task 5. ✅
-- CHANGELOG, no version bump → Task 6. ✅
-- CI uses `make coverage-check` (already wired in the prior PR), so xdist + the 65% gate run in CI automatically. ✅
+- Verify reorder-safety + flakiness + gate, **locally with `.env` present** → Task 5. ✅
+- CHANGELOG with measured numbers, no version bump → Task 6. ✅
+- Remaining ~19 singletons: deliberately not reset; Task 5 runs are the safety net. ✅
+- CI uses `make coverage-check`, so xdist + the 65% gate run in CI automatically. ✅

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -372,6 +372,7 @@ dev = [
     "pytest-asyncio>=1.1.0",
     "pytest-mock>=3.15.1",
     "pytest-timeout>=2.4.0",
+    "pytest-xdist>=3.6.0",
     "types-pyyaml>=6.0.12.20250822",
     "faker>=33.1.0",
     "pytest-cov>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "finwiz"
-version = "5.5.0"
+version = "5.5.1"
 description = "finwiz using crewAI"
 authors = [{ name = "Frederic Jacquet", email = "fred.jacquet@gmail.com" }]
 requires-python = ">=3.12,<3.13"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,57 @@ from tests.fixtures import (
     create_stock_data,
 )
 
+# ---------------------------------------------------------------------------
+# Global reorder-safe isolation (enables pytest-xdist parallelism).
+#
+# Import-time load_dotenv() calls in ~9 modules load the real .env into
+# os.environ once per process. Combined with cached config singletons, that
+# state would otherwise leak across tests, making results order-dependent (and
+# leaking real API keys into assertion output on failure). This autouse fixture
+# resets that state before every test, via monkeypatch (auto-restored).
+# ---------------------------------------------------------------------------
+
+# Non-FINWIZ_-prefixed env vars resilience_config still honours (back-compat).
+_EXTRA_CONFIG_ENV_VARS = ("PORTFOLIO_PARALLEL_LIMIT", "DEEP_ANALYSIS_PARALLEL_LIMIT")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_state(monkeypatch):
+    """Clear config-driving env vars and reset cached config singletons per test.
+
+    Makes the suite safe under pytest-xdist and prevents unit tests from seeing
+    the developer's real ``.env`` (which also stops real secrets reaching
+    assertion output). ``monkeypatch`` auto-restores on teardown, so there is no
+    destructive global mutation.
+
+    A test that needs a specific value sets it AFTER this fixture runs (e.g.
+    ``monkeypatch.setenv("SERPER_API_KEY", "test-serper-key-32-characters-long")``),
+    which wins.
+    """
+    import finwiz.config.features.flags as _flags
+    import finwiz.config.manager as _cfg
+    import finwiz.config.resilience_config as _res
+    import finwiz.config.settings as _settings
+    import finwiz.infrastructure.monitoring.litellm_callback as _llm
+
+    # Clear config-driving env vars. API-key names are sourced from the code (not
+    # duplicated); FINWIZ_-prefixed vars are cleared by scanning so new ones are
+    # covered automatically (FINWIZ_TEST_LOGS is preserved).
+    for kc in _cfg.ConfigurationManager.REQUIRED_API_KEYS:
+        monkeypatch.delenv(kc.env_var, raising=False)
+    for var in list(os.environ):
+        if var.startswith("FINWIZ_") and var != "FINWIZ_TEST_LOGS":
+            monkeypatch.delenv(var, raising=False)
+    for var in _EXTRA_CONFIG_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    # Reset env-derived / mutable-state singletons.
+    monkeypatch.setattr(_settings, "_settings", None, raising=False)
+    monkeypatch.setattr(_cfg, "_config_manager", None, raising=False)
+    monkeypatch.setattr(_res, "_resilience_config", None, raising=False)
+    monkeypatch.setattr(_flags, "_feature_flags", None, raising=False)
+    monkeypatch.setattr(_llm, "_token_monitor", None, raising=False)
+
 
 # Make fixtures available as pytest fixtures
 @pytest.fixture

--- a/tests/unit/orchestrators/test_deep_analysis_data_collection.py
+++ b/tests/unit/orchestrators/test_deep_analysis_data_collection.py
@@ -100,6 +100,7 @@ class TestPythonDataCollection:
             }
         )
 
+    @pytest.mark.integration
     def test_collect_data_with_python_success(
         self, mocker, orchestrator, mock_yahoo_ticker_data, mock_yahoo_company_data, mock_quantitative_data, mock_sentiment_data, mock_sec_data
     ):
@@ -183,6 +184,7 @@ class TestPythonDataCollection:
         assert "overall_sentiment" in result
         assert result["overall_sentiment"] == "POSITIVE"
 
+    @pytest.mark.integration
     def test_collect_data_handles_tool_failures(self, mocker, orchestrator):
         """Test graceful handling when individual tools fail."""
         # ✅ CORRECT pytest-mock pattern: NO context managers
@@ -219,6 +221,7 @@ class TestPythonDataCollection:
         assert "overall_sentiment" in result
         assert result["overall_sentiment"] == "neutral"
 
+    @pytest.mark.integration
     def test_collect_data_etf_skips_sec_analysis(self, mocker, orchestrator):
         """Test that ETF assets skip SEC analysis (stock-only feature)."""
         # ✅ CORRECT pytest-mock pattern: NO context managers
@@ -280,6 +283,7 @@ class TestPythonDataCollection:
         assert "return_on_equity" in flattened  # From company_info.financial_metrics.return_on_equity
         assert "debt_to_equity" in flattened  # From company_info.financial_metrics.debt_to_equity
 
+    @pytest.mark.integration
     def test_numerical_stability_edge_cases(self, mocker, orchestrator):
         """Test handling of edge cases in numerical data."""
         edge_case_data = {
@@ -305,6 +309,7 @@ class TestPythonDataCollection:
         assert result["current_price"] == approx(0.0001)
         # NaN and None values should be handled gracefully in flattening
 
+    @pytest.mark.integration
     def test_json_parsing_robustness(self, mocker, orchestrator):
         """Test robust JSON parsing from tool outputs."""
         # ✅ CORRECT pytest-mock pattern: NO context managers
@@ -390,6 +395,7 @@ class TestPythonDataCollection:
         assert EnhancedSECAnalysisTool is not None
         assert DeepAnalysisScorer is not None
 
+    @pytest.mark.integration
     def test_batch_mode_parameter_propagation(self, mocker, orchestrator):
         """Test that batch_enabled parameter is properly used."""
         # ✅ CORRECT pytest-mock pattern: NO context managers

--- a/tests/unit/orchestrators/test_deep_analysis_orchestrator.py
+++ b/tests/unit/orchestrators/test_deep_analysis_orchestrator.py
@@ -163,11 +163,13 @@ class TestDeepAnalysisOrchestrator:
             processing_time_seconds=5.0,
         )
 
+    @pytest.mark.integration
     def test_should_return_empty_dict_when_no_holdings(self, orchestrator):
         """Test deep analysis with no holdings."""
         result = orchestrator.run_deep_analysis_on_holdings([])
         assert result == {}
 
+    @pytest.mark.integration
     def test_should_analyze_single_holding(self, mocker, orchestrator, mock_deep_analysis_result, mock_enriched_analysis):
         """Test analysis of a single holding using functional pipeline."""
         # Mock the functional pipeline at the import location
@@ -186,6 +188,7 @@ class TestDeepAnalysisOrchestrator:
         assert result["AAPL"].grade == "A"
         assert result["AAPL"].composite_score == 0.82
 
+    @pytest.mark.integration
     def test_should_analyze_multiple_holdings(self, mocker, orchestrator, mock_deep_analysis_result, mock_enriched_analysis):
         """Test analysis of multiple holdings."""
 
@@ -228,6 +231,7 @@ class TestDeepAnalysisOrchestrator:
         assert "AAPL" in result
         assert "GOOGL" in result
 
+    @pytest.mark.integration
     def test_should_handle_analysis_failure_gracefully(self, mocker, orchestrator):
         """Test that analysis failures surface a synthetic pending result.
 
@@ -274,6 +278,7 @@ class TestDeepAnalysisOrchestrator:
         assert pending.recommendation == "WAIT"
         assert "crew dépassé 900s" in pending.rationale
 
+    @pytest.mark.integration
     def test_should_skip_invalid_holdings(self, mocker, orchestrator, mock_deep_analysis_result, mock_enriched_analysis):
         """Test that holdings without ticker or asset_class are skipped."""
         mocker.patch(
@@ -294,6 +299,7 @@ class TestDeepAnalysisOrchestrator:
         assert len(result) == 1
         assert "AAPL" in result
 
+    @pytest.mark.integration
     def test_should_store_enriched_analysis(self, mocker, orchestrator, mock_deep_analysis_result, mock_enriched_analysis, tmp_path):
         """Test that enriched analysis is stored for HTML generation."""
         mocker.patch(
@@ -315,6 +321,7 @@ class TestDeepAnalysisOrchestrator:
         assert enriched is not None
         assert enriched.ticker == "AAPL"
 
+    @pytest.mark.integration
     @pytest.mark.parametrize(
         "holdings",
         [
@@ -403,6 +410,7 @@ class TestDeepAnalysisOrchestrator:
         composite_score=st.floats(min_value=0.0, max_value=1.0),
     )
     @settings(max_examples=50, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @pytest.mark.integration
     def test_property_result_structure_validation(self, mocker, ticker, asset_class, grade, composite_score):
         """
         **Feature: flow-orchestrator-refactoring, Property 9: Deep Analysis Result Structure**
@@ -487,6 +495,7 @@ class TestDeepAnalysisOrchestrator:
         asset_class=st.sampled_from(["stock", "etf", "crypto"]),
     )
     @settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @pytest.mark.integration
     def test_property_pipeline_integration(self, mocker, ticker, asset_class):
         """
         **Feature: deep-analysis-pipeline, Property: Pipeline Integration**

--- a/tests/unit/test_global_isolation.py
+++ b/tests/unit/test_global_isolation.py
@@ -1,0 +1,65 @@
+"""Meta-tests verifying the autouse isolation fixture in tests/conftest.py.
+
+These guard the reorder-safety guarantees that let the suite run under
+pytest-xdist: config-driving env vars are cleared and cached singletons are
+reset before every test, so the developer's real ``.env`` (loaded into
+``os.environ`` by import-time ``load_dotenv()`` calls) never bleeds into a test
+or its failure output.
+"""
+
+import os
+
+import pytest
+
+from finwiz.config.manager import ConfigurationError, ConfigurationManager
+
+
+def test_api_key_env_vars_are_isolated():
+    # Real .env keys must never be visible inside tests.
+    for var in ("SERPER_API_KEY", "CHART_IMG_API_KEY", "KRAKEN_API_KEY"):
+        assert os.getenv(var) is None, f"{var} leaked into the test environment"
+
+
+def test_resilience_env_vars_are_isolated():
+    assert os.getenv("FINWIZ_MAX_RETRIES") is None
+
+
+def test_building_configuration_manager_sees_no_real_keys():
+    # Constructing a manager inside a test must find no API keys — proving the
+    # import-time .env pollution was cleared and nothing leaks into api_keys
+    # (which is what gets printed on failure).
+    mgr = ConfigurationManager()
+    with pytest.raises(ConfigurationError) as exc:
+        mgr.validate_api_keys()
+    assert "SERPER_API_KEY" in exc.value.missing_keys
+    assert mgr.api_keys == {}, "real .env keys leaked into ConfigurationManager.api_keys"
+
+
+def test_config_manager_singleton_is_reset():
+    import finwiz.config.manager as cfg
+
+    assert cfg._config_manager is None
+
+
+def test_settings_singleton_is_reset():
+    import finwiz.config.settings as settings
+
+    assert settings._settings is None
+
+
+def test_resilience_singleton_is_reset():
+    import finwiz.config.resilience_config as res
+
+    assert res._resilience_config is None
+
+
+def test_feature_flags_singleton_is_reset():
+    import finwiz.config.features.flags as flags
+
+    assert flags._feature_flags is None
+
+
+def test_token_monitor_singleton_is_reset():
+    import finwiz.infrastructure.monitoring.litellm_callback as llm
+
+    assert llm._token_monitor is None

--- a/tests/unit/tools/test_batch_prefetch_tools.py
+++ b/tests/unit/tools/test_batch_prefetch_tools.py
@@ -169,8 +169,9 @@ class TestAlphaVantageToolWithPrefetch:
     """Test AlphaVantageCompanyOverviewTool with pre-fetched data."""
 
     @pytest.fixture
-    def tool(self):
+    def tool(self, monkeypatch):
         """Create tool instance."""
+        monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "test-alpha-vantage-key")
         return AlphaVantageCompanyOverviewTool()
 
     @pytest.fixture

--- a/tests/unit/utils/test_configuration_manager.py
+++ b/tests/unit/utils/test_configuration_manager.py
@@ -25,22 +25,6 @@ from finwiz.config.manager import (
 class TestConfigurationManager:
     """Test suite for ConfigurationManager class."""
 
-    def setup_method(self):
-        """Set up test environment."""
-        # Clear environment variables
-        env_vars_to_clear = [
-            "OPENAI_API_KEY",
-            "SERPER_API_KEY",
-            "ALPHA_VANTAGE_API_KEY",
-            "CHART_IMG_API_KEY",
-            "TWELVE_DATA_API_KEY",
-            "X-CMC_PRO_API_KEY",
-            "KRAKEN_API_KEY",
-        ]
-        for var in env_vars_to_clear:
-            if var in os.environ:
-                del os.environ[var]
-
     def test_should_initialize_with_required_api_keys(self):
         """Test that ConfigurationManager initializes with expected API key configs."""
         # Arrange & Act

--- a/uv.lock
+++ b/uv.lock
@@ -782,6 +782,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "faker"
 version = "40.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -914,6 +923,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "safety" },
     { name = "scipy-stubs" },
@@ -984,6 +994,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = ">=0.4.8,<1.0.0" },
     { name = "safety", specifier = ">=3.2.4" },
     { name = "scipy-stubs", specifier = ">=1.17.1.4" },
@@ -2908,6 +2919,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Makes the test suite **reorder-safe** so it can run under `pytest-xdist`, fixes a latent **secret-leak** in the config tests, and removes the network domination that made `make test` slow and time-variable.

**Net result: clean `make test` ≈ 1m53s, CPU-bound and deterministic** (was ~3 min and network-variable; coverage 74.9%, 0 failed under `-n auto --dist=loadscope`).

## What changed

- **Autouse isolation fixture** (`tests/conftest.py`): before every test, clears config-driving env vars (API keys sourced from `ConfigurationManager.REQUIRED_API_KEYS` + a `FINWIZ_*` scan) and resets 5 cached config singletons (configuration manager, settings, resilience, feature flags, token monitor) via `monkeypatch` (auto-restored — no destructive global mutation). Makes results order-independent and stops config tests from reading/printing the developer's real `.env` keys. 8 meta-tests guard it (`tests/unit/test_global_isolation.py`).
- **Removed a destructive `setup_method`** in `test_configuration_manager.py` (non-restored `del os.environ[...]` — the original order-dependence) in favor of the autouse fixture.
- **Enabled pytest-xdist** (`pytest-xdist>=3.6.0`); `make test` and `coverage-check` run `-n auto --dist=loadscope`.
- **Marked ~18 network-dependent deep-analysis orchestrator tests `@pytest.mark.integration`** — they made real Alpha Vantage/yfinance calls (via `_ensure_macro_snapshot_on_state` + `run_batch_prefetch` + `DeepAnalysisDataCollector`, wrapped in retry/backoff), which dominated wall-clock and made it network-variable. They now run in the integration job; pure-logic tests in those files stay in the fast unit run.
- Fixed an env-isolation straggler (`ALPHA_VANTAGE_API_KEY` set in a tool fixture).
- Plan + CHANGELOG docs.

## Verification

- Two consecutive full `-n auto --dist=loadscope` runs: 5167 passed, 0 failed, 0 errors.
- `make coverage-check`: 74.9% (gate 65%), passes under xdist.
- ruff clean; mypy clean (527 files).
- No `unittest.mock` introduced (pytest-mock only).

## Notes / follow-ups

- The orchestrator tests' network dependence is pre-existing; fully mocking their data layer to return them to the fast unit run is a possible future refinement.
- Separately discovered (not in this PR): the HTML report reuses stale per-holding `_enriched.json` from prior runs for holdings that fail re-analysis, and the portfolio strategic posture over-anchors on the best-covered stock — to be addressed in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Bumped package to 5.5.1 and added a CHANGELOG entry.

* **Tests**
  * Tests now run in parallel for faster performance; default test runs are isolated and network-free.
  * Deep-analysis tests reclassified as integration tests to keep the standard suite lightweight.
  * Added meta-tests validating test-environment and singleton isolation.

* **Documentation**
  * Added a plan for test isolation and parallelization.

* **Chores**
  * Added pytest-xdist as a dev dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->