### PR TITLE
feat(portfolio): EUR-weighted holdings from CSV Quantity + live FX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.0] - 2026-06-09
+
+### Added
+
+- **EUR-weighted portfolio allocation from a CSV `Quantity` column.** Each holding
+  can now carry a position `Quantity`; FinWiz values it in its native currency via
+  the price API, converts to a EUR base via a live yfinance FX provider (per-run
+  cache; `GBp`/`GBX` pence handled with a single ÷100), and stamps
+  `quantity / native_currency / native_value / eur_value / weight` plus a
+  portfolio-level `total_value_eur` onto the review. 100% deterministic Python
+  (`scoring/portfolio_valuation.py`, injected `price_fn`/`fx_fn`); graceful
+  degradation — missing quantity/price/FX leaves a `None` weight and never crashes,
+  and the EUR total is computed over priced holdings only. New `make fix-currencies`
+  rewrites the CSV `Currency` column from the authoritative price API (explicit,
+  atomic, idempotent; never on a normal run).
+- **Allocation surfaced in the portfolio review report** — a total-value hero,
+  weight-sorted breakdown with weight bars, and `Poids` / `Valeur (€)` columns in
+  the holdings table. Degrades to a guidance note when no quantities are set.
+
+### Changed
+
+- **Modern-fintech redesign of the portfolio review report.** Replaced the
+  purple-gradient / blue-table look with a restrained white-card system on a cool
+  off-white background, a single emerald accent, light small-caps table headers,
+  tabular numerics, and refined badges. Light + dark mode; existing section classes
+  restyled coherently.
+
 ## [5.5.1] - 2026-06-08
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # FinWiz Development Makefile
 
-.PHONY: help install test test-verbose test-all test-integration lint lint-check format clean setup dev check check-unittest-mock check-file-size check-stage-contract cleanup mypy coverage coverage-report coverage-check docs-build docs-build-strict docs-serve docs-deploy docs-lint docs-validate docs-clean all ci sbom audit
+.PHONY: help install test test-verbose test-all test-integration lint lint-check format clean setup dev check check-unittest-mock check-file-size check-stage-contract cleanup fix-currencies mypy coverage coverage-report coverage-check docs-build docs-build-strict docs-serve docs-deploy docs-lint docs-validate docs-clean all ci sbom audit
 
 # Default target
 help:
@@ -175,6 +175,9 @@ cleanup-temp:
 
 cleanup:
 	python scripts/cleanup_master.py
+
+fix-currencies:  ## Rewrite data/*.csv Currency columns from the authoritative price API (network; explicit)
+	uv run python scripts/fix_csv_currencies.py
 
 # Type checking
 mypy:

--- a/docs/superpowers/plans/2026-06-08-portfolio-allocation-data.md
+++ b/docs/superpowers/plans/2026-06-08-portfolio-allocation-data.md
@@ -1,0 +1,1462 @@
+# Portfolio Allocation Data Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each holding a position `Quantity` from the CSV, value it in its native currency via the price API, convert to a EUR base via live FX, and surface `quantity / native_currency / native_value / eur_value / weight` on the holding model so the portfolio can be represented by allocation.
+
+**Architecture:** A new deterministic, pure-Python valuation unit (`scoring/portfolio_valuation.py`) takes holdings + injected `price_fn`/`fx_fn` and computes per-holding EUR value and portfolio weight. A new live FX provider (`data/fx_rates.py`) resolves `<ccy>EUR` rates via yfinance with a per-run cache. The existing async `PortfolioPriceService` (already returns price **and** quote currency) supplies prices; the wiring in `build_portfolio_review` pre-fetches prices, runs `value_holdings`, and stamps weights onto `HoldingDecision`s. AI Minimalism: this is 100% Python, no AI. An explicit `make fix-currencies` rewrites the unreliable CSV `Currency` column from the authoritative price-API currency (never on a normal run).
+
+**Tech Stack:** Python 3.12, Pydantic v2, yfinance, asyncio, pytest + pytest-mock (`mocker`), `make`.
+
+---
+
+## Key facts the implementer must know (verified against the codebase)
+
+- **Price + currency already exist together.** `PortfolioPriceService.get_current_price(symbol) -> PriceData | None` and `get_current_prices(symbols) -> dict[str, PriceData]` (in `src/finwiz/tools/portfolio_price_service.py`). `PriceData` (`src/finwiz/schemas/rebalancing/core.py:106`) has `.price: float` and `.currency: str`. **No new price accessor is needed** — the spec's top open risk is resolved.
+- **`get_current_prices` keys the result dict by the symbol string you pass in** (it uppercases only for the internal fetch). Pass the already-normalized ticker (e.g. `"AAPL"`, `"BTC-USD"`) and look results up by that same string.
+- **Ticker normalization** lives on `PortfolioHoldingsProcessor.normalize_ticker(raw, asset_class)` (strips `YAHOO:` prefix, adds `-USD` for crypto). Tickers in `RawHolding.ticker` are already normalized by the time holdings are built.
+- **Wiring point:** `build_portfolio_review` in `src/finwiz/orchestrators/portfolio_review_orchestrator.py`, after `decisions` are produced and `merge_deep_analysis_from_flow_state` runs, right before `PortfolioReview(...)` is constructed (around line 137).
+- **`value_holdings` skips any holding whose `quantity is None` BEFORE calling `price_fn`.** Therefore, when no holding has a quantity (every existing unit test, and production until users fill the column), the wiring must make **zero** network calls and leave all weights `None`. This keeps the existing offline tests in `tests/unit/orchestrators/test_portfolio_review.py` green.
+- **`RawHolding` is a `@dataclass`** (not Pydantic) in `src/finwiz/schemas/portfolio_processing.py`. `HoldingDecision` and `PortfolioReview` are Pydantic v2 models with `extra="forbid"` in `src/finwiz/schemas/portfolio_review.py`. Pydantic v2 allows plain attribute assignment after construction (no `validate_assignment`), so `decision.weight = ...` works once the field exists.
+- **Pydantic models go in `schemas/`** (project rule). The pure valuation function goes in `scoring/`, but its result models (`HoldingValuation`, `ValuationResult`) go in `schemas/portfolio_valuation.py`.
+- **unittest.mock is BANNED.** Use `mocker.patch(...)` (pytest-mock) only.
+- **Async tests** in this repo are written as `async def test_...` with no decorator (pytest-asyncio auto mode is configured). Follow that style.
+- **GBp (pence) quirk:** LSE tickers can report currency `"GBp"` (capital G, capital B, lowercase p) priced in pence. The FX provider maps `GBp`/`GBX` → `GBP` and divides the rate by 100, so a pence-quoted `native_value` converts to EUR correctly. The division lives **only** in `fx_rates` (single site, no double division).
+
+## File structure
+
+| File | Responsibility |
+|------|----------------|
+| `src/finwiz/schemas/portfolio_processing.py` (modify) | `RawHolding.quantity: float \| None` |
+| `src/finwiz/schemas/portfolio_review.py` (modify) | `HoldingDecision` weight fields; `PortfolioReview.total_value_eur` |
+| `src/finwiz/schemas/portfolio_valuation.py` (new) | `HoldingValuation`, `ValuationResult` Pydantic models |
+| `src/finwiz/data/fx_rates.py` (new) | `get_fx_rate()` live FX→EUR + per-run cache + `clear_fx_cache()` |
+| `src/finwiz/scoring/portfolio_valuation.py` (new) | pure `value_holdings(...)` |
+| `src/finwiz/orchestrators/portfolio_holdings_processor.py` (modify) | parse `Quantity` from CSV into `RawHolding.quantity` |
+| `src/finwiz/orchestrators/portfolio_review_orchestrator.py` (modify) | pre-fetch prices, run valuation, stamp weights, set `total_value_eur` |
+| `scripts/fix_csv_currencies.py` (new) | pure CSV rewrite fn + `main()` wiring the live currency resolver |
+| `Makefile` (modify) | `fix-currencies` target |
+| `data/stock.csv`, `data/etf.csv`, `data/crypto.csv` (modify) | add empty `Quantity` column |
+
+---
+
+## Task 1: `RawHolding.quantity` field + CSV ingestion
+
+**Files:**
+- Modify: `src/finwiz/schemas/portfolio_processing.py:17-26`
+- Modify: `src/finwiz/orchestrators/portfolio_holdings_processor.py:125-188`
+- Test: `tests/unit/orchestrators/test_portfolio_holdings_processor.py` (add to existing file)
+
+- [ ] **Step 1: Write the failing test for quantity parsing**
+
+Add to `tests/unit/orchestrators/test_portfolio_holdings_processor.py`:
+
+```python
+class TestQuantityIngestion:
+    """CSV `Quantity` column parsing into RawHolding.quantity."""
+
+    def test_parses_valid_quantity(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "stock.csv"
+        csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,Yahoo:AAPL,USD,true,10.5\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "stock")
+
+        assert len(holdings) == 1
+        assert holdings[0].quantity == 10.5
+
+    def test_blank_quantity_is_none(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "stock.csv"
+        csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,Yahoo:AAPL,USD,true,\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "stock")
+
+        assert holdings[0].quantity is None
+
+    def test_garbage_quantity_is_none(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "stock.csv"
+        csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,Yahoo:AAPL,USD,true,abc\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "stock")
+
+        assert holdings[0].quantity is None
+
+    def test_missing_quantity_column_is_none(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "stock.csv"
+        csv.write_text("Name,Ticker,Currency,Active\nApple,Yahoo:AAPL,USD,true\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "stock")
+
+        assert holdings[0].quantity is None
+
+    def test_crypto_quantity_parsed(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "crypto.csv"
+        csv.write_text("Name,Ticker,Active,Quantity\nBitcoin,BTC,true,0.25\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "crypto")
+
+        assert holdings[0].quantity == 0.25
+        assert holdings[0].ticker == "BTC-USD"  # crypto normalization still applies
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/unit/orchestrators/test_portfolio_holdings_processor.py::TestQuantityIngestion -v`
+Expected: FAIL — `RawHolding.__init__() got an unexpected keyword argument 'quantity'` (or `AttributeError: 'RawHolding' object has no attribute 'quantity'`).
+
+- [ ] **Step 3: Add the `quantity` field to `RawHolding`**
+
+In `src/finwiz/schemas/portfolio_processing.py`, change the `RawHolding` dataclass to:
+
+```python
+@dataclass
+class RawHolding:
+    """Raw holding data from CSV."""
+
+    asset_class: AssetClass
+    name: str
+    ticker: str
+    currency: str
+    source_file: str
+    line_number: int
+    quantity: float | None = None
+```
+
+- [ ] **Step 4: Parse `Quantity` in `_read_csv_holdings`**
+
+In `src/finwiz/orchestrators/portfolio_holdings_processor.py`, inside `_read_csv_holdings`, add a parse helper just above the class (module level, after `logger = ...`):
+
+```python
+def _parse_quantity(raw: str | None) -> float | None:
+    """Parse a CSV Quantity cell into a float; blank/invalid -> None (debug-logged)."""
+    s = (raw or "").strip()
+    if not s:
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        logger.debug("Ignoring unparseable Quantity value %r", s)
+        return None
+```
+
+Then in the loop, after `active_raw = ...`, add:
+
+```python
+                    quantity = _parse_quantity(row.get("Quantity"))
+```
+
+And add `quantity=quantity` to the `RawHolding(...)` construction:
+
+```python
+                    holdings.append(
+                        RawHolding(
+                            asset_class=asset_class,
+                            name=name or "Unknown",
+                            ticker=ticker or "UNKNOWN",
+                            currency=currency or "USD",
+                            source_file=str(path),
+                            line_number=line_num,
+                            quantity=quantity,
+                        )
+                    )
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/unit/orchestrators/test_portfolio_holdings_processor.py::TestQuantityIngestion -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finwiz/schemas/portfolio_processing.py src/finwiz/orchestrators/portfolio_holdings_processor.py tests/unit/orchestrators/test_portfolio_holdings_processor.py
+git commit -m "feat(portfolio): parse CSV Quantity into RawHolding.quantity"
+```
+
+---
+
+## Task 2: Holding-model weight fields
+
+**Files:**
+- Modify: `src/finwiz/schemas/portfolio_review.py:134-181` (`HoldingDecision`), `:210-230` (`PortfolioReview`)
+- Test: `tests/unit/schemas/test_portfolio_review_enhancements.py` (add to existing file)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/schemas/test_portfolio_review_enhancements.py`:
+
+```python
+class TestAllocationFields:
+    """Allocation/valuation fields on HoldingDecision and PortfolioReview."""
+
+    def _risk(self):
+        from finwiz.schemas.common import RiskAssessmentStandardized
+
+        return RiskAssessmentStandardized(score=2.5, level="Medium", risk_factors=[])
+
+    def test_holding_decision_allocation_fields_default_none(self):
+        from finwiz.schemas.portfolio_review import HoldingDecision
+
+        d = HoldingDecision(
+            asset_class="stock",
+            name="Apple",
+            ticker="AAPL",
+            currency="USD",
+            decision="KEEP",
+            composite_score=0.8,
+            grade="A",
+            grade_description="Strong",
+            recommended_action="hold",
+            risk=self._risk(),
+        )
+
+        assert d.quantity is None
+        assert d.native_currency is None
+        assert d.native_value is None
+        assert d.eur_value is None
+        assert d.weight is None
+
+    def test_holding_decision_allocation_fields_assignable(self):
+        from finwiz.schemas.portfolio_review import HoldingDecision
+
+        d = HoldingDecision(
+            asset_class="stock",
+            name="Apple",
+            ticker="AAPL",
+            currency="USD",
+            decision="KEEP",
+            composite_score=0.8,
+            grade="A",
+            grade_description="Strong",
+            recommended_action="hold",
+            risk=self._risk(),
+        )
+        d.quantity = 10.0
+        d.native_currency = "USD"
+        d.native_value = 1500.0
+        d.eur_value = 1380.0
+        d.weight = 0.25
+
+        assert d.weight == 0.25
+
+    def test_weight_must_be_between_0_and_1(self):
+        import pytest
+        from pydantic import ValidationError
+        from finwiz.schemas.portfolio_review import HoldingDecision
+
+        with pytest.raises(ValidationError):
+            HoldingDecision(
+                asset_class="stock",
+                name="Apple",
+                ticker="AAPL",
+                currency="USD",
+                decision="KEEP",
+                composite_score=0.8,
+                grade="A",
+                grade_description="Strong",
+                recommended_action="hold",
+                risk=self._risk(),
+                weight=1.5,
+            )
+
+    def test_portfolio_review_total_value_eur_default_none(self):
+        from datetime import UTC, datetime
+        from finwiz.schemas.portfolio_review import PortfolioReview
+
+        review = PortfolioReview(as_of=datetime.now(UTC))
+
+        assert review.total_value_eur is None
+```
+
+(`RiskAssessmentStandardized` lives in `src/finwiz/schemas/common.py`: `score: float (0..5)`, `level: Literal["Low","Medium","High","Very High"]`, `risk_factors: list[str]` — the `_risk()` helper above matches it.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/unit/schemas/test_portfolio_review_enhancements.py::TestAllocationFields -v`
+Expected: FAIL — `extra="forbid"` rejects `quantity`/`weight`/`total_value_eur` (Pydantic `ValidationError: Extra inputs are not permitted`), or `AttributeError` on `d.quantity`.
+
+- [ ] **Step 3: Add the fields**
+
+In `src/finwiz/schemas/portfolio_review.py`, inside `HoldingDecision`, add after the `confidence` field (around line 181):
+
+```python
+    # Allocation/valuation (deterministic Python; see scoring/portfolio_valuation.py).
+    # All optional — populated only when a CSV Quantity and live price/FX resolve.
+    quantity: float | None = Field(default=None, description="Position size (units/shares) from the CSV")
+    native_currency: str | None = Field(default=None, description="Authoritative quote currency from the price API")
+    native_value: float | None = Field(default=None, description="quantity * native price, in native currency")
+    eur_value: float | None = Field(default=None, description="native_value converted to EUR via live FX")
+    weight: float | None = Field(default=None, ge=0.0, le=1.0, description="Share of total EUR portfolio value (0..1)")
+```
+
+In `PortfolioReview`, add after `holdings` (around line 215):
+
+```python
+    total_value_eur: float | None = Field(default=None, description="Sum of holdings' eur_value (priced holdings only); None when nothing could be priced")
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/unit/schemas/test_portfolio_review_enhancements.py::TestAllocationFields -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/schemas/portfolio_review.py tests/unit/schemas/test_portfolio_review_enhancements.py
+git commit -m "feat(portfolio): add allocation/weight fields to HoldingDecision and PortfolioReview"
+```
+
+---
+
+## Task 3: Valuation result schemas
+
+**Files:**
+- Create: `src/finwiz/schemas/portfolio_valuation.py`
+- Test: `tests/unit/schemas/test_portfolio_valuation.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/schemas/test_portfolio_valuation.py`:
+
+```python
+"""Unit tests for portfolio valuation result schemas."""
+
+from finwiz.schemas.portfolio_valuation import HoldingValuation, ValuationResult
+
+
+def test_holding_valuation_defaults():
+    hv = HoldingValuation(ticker="AAPL")
+
+    assert hv.ticker == "AAPL"
+    assert hv.quantity is None
+    assert hv.native_currency is None
+    assert hv.native_value is None
+    assert hv.eur_value is None
+    assert hv.weight is None
+
+
+def test_holding_valuation_fields_mutable():
+    hv = HoldingValuation(ticker="AAPL")
+    hv.eur_value = 100.0
+    hv.weight = 0.5
+
+    assert hv.eur_value == 100.0
+    assert hv.weight == 0.5
+
+
+def test_valuation_result_defaults():
+    result = ValuationResult()
+
+    assert result.per_ticker == {}
+    assert result.total_value_eur is None
+    assert result.priced_count == 0
+    assert result.total_count == 0
+    assert result.coverage_note == ""
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/unit/schemas/test_portfolio_valuation.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'finwiz.schemas.portfolio_valuation'`.
+
+- [ ] **Step 3: Create the schema module**
+
+Create `src/finwiz/schemas/portfolio_valuation.py`:
+
+```python
+"""Result models for deterministic portfolio valuation.
+
+Produced by `finwiz.scoring.portfolio_valuation.value_holdings`. Pure data —
+no AI, no network. Models live here per the schemas-in-`schemas/` rule.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class HoldingValuation(BaseModel):
+    """Per-holding valuation output. All money fields optional (graceful degradation)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ticker: str
+    quantity: float | None = None
+    native_currency: str | None = None
+    native_value: float | None = None
+    eur_value: float | None = None
+    weight: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class ValuationResult(BaseModel):
+    """Portfolio-level valuation: per-ticker breakdown, total EUR, coverage."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    per_ticker: dict[str, HoldingValuation] = Field(default_factory=dict)
+    total_value_eur: float | None = None
+    priced_count: int = 0
+    total_count: int = 0
+    coverage_note: str = ""
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/unit/schemas/test_portfolio_valuation.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/schemas/portfolio_valuation.py tests/unit/schemas/test_portfolio_valuation.py
+git commit -m "feat(portfolio): add HoldingValuation/ValuationResult schemas"
+```
+
+---
+
+## Task 4: Live FX provider (`fx_rates.py`)
+
+**Files:**
+- Create: `src/finwiz/data/fx_rates.py`
+- Test: `tests/unit/data/test_fx_rates.py`
+
+The unit tests patch the internal `_fetch_pair_rate` (the only network site) so no network is hit. The real `_fetch_pair_rate` is exercised by a separate `@pytest.mark.integration` test.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `tests/unit/data/test_fx_rates.py`:
+
+```python
+"""Unit tests for the live FX provider (network mocked)."""
+
+import pytest
+
+from finwiz.data import fx_rates
+
+
+@pytest.fixture(autouse=True)
+def _reset_fx_cache():
+    """Each test starts with an empty per-run FX cache."""
+    fx_rates.clear_fx_cache()
+    yield
+    fx_rates.clear_fx_cache()
+
+
+def test_identity_rate_is_one_without_network(mocker):
+    spy = mocker.patch("finwiz.data.fx_rates._fetch_pair_rate")
+
+    assert fx_rates.get_fx_rate("EUR", "EUR") == 1.0
+    spy.assert_not_called()
+
+
+def test_simple_pair_lookup(mocker):
+    mocker.patch("finwiz.data.fx_rates._fetch_pair_rate", return_value=0.92)
+
+    assert fx_rates.get_fx_rate("CHF", "EUR") == 0.92
+
+
+def test_gbp_pence_divided_by_100(mocker):
+    # GBPEUR is ~1.17; a GBp (pence) amount must convert at rate/100.
+    mocker.patch("finwiz.data.fx_rates._fetch_pair_rate", return_value=1.17)
+
+    rate = fx_rates.get_fx_rate("GBp", "EUR")
+
+    assert rate == pytest.approx(0.0117)
+
+
+def test_failure_returns_none(mocker):
+    mocker.patch("finwiz.data.fx_rates._fetch_pair_rate", return_value=None)
+
+    assert fx_rates.get_fx_rate("CHF", "EUR") is None
+
+
+def test_per_run_cache_hits_once(mocker):
+    spy = mocker.patch("finwiz.data.fx_rates._fetch_pair_rate", return_value=0.92)
+
+    fx_rates.get_fx_rate("CHF", "EUR")
+    fx_rates.get_fx_rate("CHF", "EUR")
+
+    spy.assert_called_once()
+
+
+def test_blank_currency_returns_none(mocker):
+    spy = mocker.patch("finwiz.data.fx_rates._fetch_pair_rate")
+
+    assert fx_rates.get_fx_rate("", "EUR") is None
+    spy.assert_not_called()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/unit/data/test_fx_rates.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'finwiz.data.fx_rates'`.
+
+- [ ] **Step 3: Create the FX provider**
+
+Create `src/finwiz/data/fx_rates.py`:
+
+```python
+"""Live FX rate provider (yfinance), EUR-based, with a per-run cache.
+
+Best-effort: any failure yields `None` and the caller treats the affected
+weight as unknown. Pure deterministic glue around a network call (AI Minimalism).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import yfinance as yf  # yfinance has no official type stubs
+
+logger = logging.getLogger(__name__)
+
+# Sub-unit (minor) currency codes -> (major ISO code, divisor).
+# e.g. LSE quotes "GBp" (pence); 100 pence = 1 GBP.
+_MINOR_UNITS: dict[str, tuple[str, float]] = {
+    "GBp": ("GBP", 100.0),
+    "GBX": ("GBP", 100.0),
+    "ZAc": ("ZAR", 100.0),
+    "ILA": ("ILS", 100.0),
+}
+
+# Per-run cache keyed by (from_ccy, base) -> rate or None. Reset via clear_fx_cache().
+_FX_CACHE: dict[tuple[str, str], float | None] = {}
+
+
+def clear_fx_cache() -> None:
+    """Clear the per-run FX cache (used by tests and between flow runs)."""
+    _FX_CACHE.clear()
+
+
+def _fetch_pair_rate(from_ccy: str, base: str) -> float | None:
+    """Fetch the spot rate for `<from_ccy><base>=X` from yfinance. Network site."""
+    pair = f"{from_ccy}{base}=X"
+    try:
+        ticker = yf.Ticker(pair)
+        # Primary: fast_info last price.
+        try:
+            rate = ticker.fast_info["lastPrice"]
+        except Exception:
+            rate = getattr(ticker.fast_info, "last_price", None)
+        if rate and float(rate) > 0:
+            return float(rate)
+
+        # Fallback: 1-day history close.
+        hist = ticker.history(period="1d")
+        if not hist.empty and "Close" in hist.columns:
+            close = float(hist["Close"].iloc[-1])
+            if close > 0:
+                return close
+    except Exception as exc:  # best-effort
+        logger.warning("FX lookup failed for %s: %s", pair, exc)
+    return None
+
+
+def get_fx_rate(from_ccy: str, base: str = "EUR") -> float | None:
+    """Return the rate to multiply a `from_ccy` amount by to get `base`.
+
+    Identity (1.0) when currencies match. Minor units (GBp/GBX/ZAc/ILA) are
+    mapped to their major unit and the rate divided by 100. Best-effort: any
+    failure returns None. Results (including None) are cached per run.
+    """
+    raw = (from_ccy or "").strip()
+    base_ccy = (base or "EUR").strip().upper()
+    if not raw or not base_ccy:
+        return None
+
+    cache_key = (raw, base_ccy)
+    if cache_key in _FX_CACHE:
+        return _FX_CACHE[cache_key]
+
+    major, divisor = _MINOR_UNITS.get(raw, (raw.upper(), 1.0))
+
+    if major == base_ccy:
+        result: float | None = 1.0 / divisor
+    else:
+        pair_rate = _fetch_pair_rate(major, base_ccy)
+        result = None if pair_rate is None else pair_rate / divisor
+
+    _FX_CACHE[cache_key] = result
+    return result
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/unit/data/test_fx_rates.py -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Add the live integration test**
+
+Create `tests/integration/test_fx_rates_live.py` (create the file; the `integration` marker is already registered in `pyproject.toml`/`pytest.ini`):
+
+```python
+"""Live network test for the FX provider. Excluded from default `make test`."""
+
+import pytest
+
+from finwiz.data import fx_rates
+
+
+@pytest.mark.integration
+def test_live_chf_eur_rate_is_plausible():
+    fx_rates.clear_fx_cache()
+    rate = fx_rates.get_fx_rate("CHF", "EUR")
+
+    assert rate is not None
+    assert 0.5 < rate < 2.0  # sanity band, not a precise assertion
+```
+
+- [ ] **Step 6: Verify the integration test is excluded from the default run, then runs on demand**
+
+Run: `uv run pytest tests/unit/data/test_fx_rates.py tests/integration/test_fx_rates_live.py -v -m "not integration"`
+Expected: the live test is deselected; unit tests PASS.
+
+(Optional, requires network) Run: `uv run pytest tests/integration/test_fx_rates_live.py -v -m integration`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/finwiz/data/fx_rates.py tests/unit/data/test_fx_rates.py tests/integration/test_fx_rates_live.py
+git commit -m "feat(portfolio): add live yfinance FX->EUR provider with per-run cache"
+```
+
+---
+
+## Task 5: Pure `value_holdings`
+
+**Files:**
+- Create: `src/finwiz/scoring/portfolio_valuation.py`
+- Test: `tests/unit/scoring/test_portfolio_valuation.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/scoring/test_portfolio_valuation.py`:
+
+```python
+"""Unit tests for pure portfolio valuation (price_fn / fx_fn injected, no network)."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from finwiz.scoring.portfolio_valuation import value_holdings
+
+
+@dataclass
+class _H:
+    """Minimal holding stand-in (matches the .ticker/.quantity attributes used)."""
+
+    ticker: str
+    quantity: float | None
+
+
+def test_full_data_weights_sum_to_one():
+    holdings = [_H("AAPL", 10.0), _H("MSFT", 5.0)]
+    prices = {"AAPL": (100.0, "EUR"), "MSFT": (200.0, "EUR")}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: 1.0,
+    )
+
+    # AAPL: 1000 EUR, MSFT: 1000 EUR -> total 2000, each weight 0.5
+    assert result.total_value_eur == pytest.approx(2000.0)
+    assert result.per_ticker["AAPL"].eur_value == pytest.approx(1000.0)
+    assert result.per_ticker["AAPL"].weight == pytest.approx(0.5)
+    assert result.per_ticker["MSFT"].weight == pytest.approx(0.5)
+    total_weight = sum(hv.weight for hv in result.per_ticker.values() if hv.weight is not None)
+    assert total_weight == pytest.approx(1.0)
+
+
+def test_multi_currency_conversion():
+    holdings = [_H("AAPL", 10.0), _H("NESN", 10.0)]
+    prices = {"AAPL": (100.0, "USD"), "NESN": (100.0, "CHF")}
+    fx = {"USD": 0.9, "CHF": 1.0}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: fx.get(c),
+    )
+
+    # AAPL: 10*100*0.9 = 900 EUR; NESN: 10*100*1.0 = 1000 EUR; total 1900
+    assert result.per_ticker["AAPL"].eur_value == pytest.approx(900.0)
+    assert result.per_ticker["NESN"].eur_value == pytest.approx(1000.0)
+    assert result.total_value_eur == pytest.approx(1900.0)
+    assert result.per_ticker["AAPL"].weight == pytest.approx(900.0 / 1900.0)
+
+
+def test_missing_quantity_excluded_and_no_price_call():
+    calls = []
+
+    def price_fn(t):
+        calls.append(t)
+        return (100.0, "EUR")
+
+    holdings = [_H("AAPL", None), _H("MSFT", 5.0)]
+
+    result = value_holdings(holdings, base="EUR", price_fn=price_fn, fx_fn=lambda c: 1.0)
+
+    assert result.per_ticker["AAPL"].weight is None
+    assert result.per_ticker["AAPL"].eur_value is None
+    assert "AAPL" not in calls  # price_fn NOT called for quantity-less holding
+    assert result.per_ticker["MSFT"].weight == pytest.approx(1.0)
+    assert result.priced_count == 1
+    assert result.total_count == 2
+
+
+def test_missing_price_yields_none_weight():
+    holdings = [_H("AAPL", 10.0), _H("MSFT", 5.0)]
+    prices = {"MSFT": (200.0, "EUR")}  # AAPL price unavailable
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: 1.0,
+    )
+
+    assert result.per_ticker["AAPL"].weight is None
+    assert result.per_ticker["AAPL"].native_value is None
+    assert result.per_ticker["MSFT"].weight == pytest.approx(1.0)
+
+
+def test_missing_fx_keeps_native_value_but_none_weight():
+    holdings = [_H("NESN", 10.0)]
+    prices = {"NESN": (100.0, "CHF")}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: None,  # FX unavailable
+    )
+
+    hv = result.per_ticker["NESN"]
+    assert hv.native_value == pytest.approx(1000.0)  # surfaced
+    assert hv.native_currency == "CHF"
+    assert hv.eur_value is None
+    assert hv.weight is None
+    assert result.total_value_eur is None  # nothing priced into EUR
+
+
+def test_empty_holdings_no_crash():
+    result = value_holdings([], base="EUR", price_fn=lambda t: None, fx_fn=lambda c: 1.0)
+
+    assert result.per_ticker == {}
+    assert result.total_value_eur is None
+    assert result.total_count == 0
+
+
+def test_coverage_note_reports_counts():
+    holdings = [_H("AAPL", 10.0), _H("MSFT", None)]
+    prices = {"AAPL": (100.0, "EUR")}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: 1.0,
+    )
+
+    assert "1 of 2" in result.coverage_note
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/unit/scoring/test_portfolio_valuation.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'finwiz.scoring.portfolio_valuation'`.
+
+- [ ] **Step 3: Implement `value_holdings`**
+
+Create `src/finwiz/scoring/portfolio_valuation.py`:
+
+```python
+"""Pure deterministic portfolio valuation: quantities + price/FX -> EUR weights.
+
+No AI, no network — `price_fn` and `fx_fn` are injected for testability and are
+the only I/O boundaries. AI Minimalism: when Python can compute it, Python does.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Protocol
+
+from finwiz.schemas.portfolio_valuation import HoldingValuation, ValuationResult
+
+# price_fn(ticker) -> (price, native_currency) or None when unavailable.
+PriceFn = Callable[[str], tuple[float, str] | None]
+# fx_fn(native_currency) -> rate to multiply by for the base currency, or None.
+FxFn = Callable[[str], float | None]
+
+
+class _HasTickerQuantity(Protocol):
+    ticker: str
+    quantity: float | None
+
+
+def value_holdings(
+    holdings: Iterable[_HasTickerQuantity],
+    *,
+    base: str = "EUR",
+    price_fn: PriceFn,
+    fx_fn: FxFn,
+) -> ValuationResult:
+    """Value each holding and compute portfolio weights.
+
+    For each holding WITH a quantity: resolve (price, native_ccy) via price_fn,
+    compute native_value = quantity * price, convert to base via fx_fn(native_ccy).
+    Holdings missing quantity/price/FX get weight=None and are excluded from the
+    base total. Weights are eur_value / total over the holdings that fully resolved.
+    """
+    per_ticker: dict[str, HoldingValuation] = {}
+    total = 0.0
+    priced = 0
+    total_count = 0
+
+    for holding in holdings:
+        total_count += 1
+        ticker = holding.ticker
+        quantity = holding.quantity
+        hv = HoldingValuation(ticker=ticker, quantity=quantity)
+        per_ticker[ticker] = hv
+
+        if quantity is None:
+            continue
+
+        priced_pair = price_fn(ticker)
+        if priced_pair is None:
+            continue
+
+        price, native_ccy = priced_pair
+        hv.native_currency = native_ccy
+        hv.native_value = quantity * price
+
+        rate = fx_fn(native_ccy)
+        if rate is None:
+            continue
+
+        hv.eur_value = hv.native_value * rate
+        total += hv.eur_value
+        priced += 1
+
+    total_eur = total if priced > 0 else None
+    if total_eur and total_eur > 0:
+        for hv in per_ticker.values():
+            if hv.eur_value is not None:
+                hv.weight = hv.eur_value / total_eur
+
+    pct = (priced / total_count * 100.0) if total_count else 0.0
+    note = f"{priced} of {total_count} holdings priced; {pct:.0f}% of holdings by count weighted"
+
+    return ValuationResult(
+        per_ticker=per_ticker,
+        total_value_eur=total_eur,
+        priced_count=priced,
+        total_count=total_count,
+        coverage_note=note,
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/unit/scoring/test_portfolio_valuation.py -v`
+Expected: PASS (7 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/scoring/portfolio_valuation.py tests/unit/scoring/test_portfolio_valuation.py
+git commit -m "feat(portfolio): pure value_holdings (quantity+price+FX -> EUR weights)"
+```
+
+---
+
+## Task 6: Wire valuation into `build_portfolio_review`
+
+**Files:**
+- Modify: `src/finwiz/orchestrators/portfolio_review_orchestrator.py:80-143`
+- Test: `tests/unit/orchestrators/test_portfolio_review.py` (add to existing file)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/orchestrators/test_portfolio_review.py`:
+
+```python
+class TestAllocationWiring:
+    """build_portfolio_review stamps weights and total_value_eur when quantities exist."""
+
+    async def test_weights_stamped_from_quantities(self, tmp_path, mocker):
+        from finwiz.orchestrators.portfolio_review_orchestrator import build_portfolio_review
+
+        stock_csv = tmp_path / "stock.csv"
+        stock_csv.write_text(
+            "Name,Ticker,Currency,Active,Quantity\n"
+            "Apple,AAPL,USD,true,10\n"
+            "Microsoft,MSFT,USD,true,10\n"
+        )
+
+        mock_validator = mocker.patch("finwiz.orchestrators.portfolio_holdings_processor.TickerExistenceValidationTool")
+        mock_validator.return_value._run.return_value = {"valid": True, "meta": {"source": "yahoo"}}
+
+        # Mock the price service so no network is hit.
+        from finwiz.schemas.rebalancing.core import PriceData
+
+        async def fake_get_current_prices(symbols):
+            return {s: PriceData(symbol=s, price=100.0, currency="EUR") for s in symbols}
+
+        price_service = mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.PortfolioPriceService")
+        price_service.return_value.get_current_prices = fake_get_current_prices
+
+        # Mock FX (EUR identity) — guard against any accidental network.
+        mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.get_fx_rate", return_value=1.0)
+
+        review, _summary = await build_portfolio_review(stock_csv=stock_csv)
+
+        weights = {h.ticker: h.weight for h in review.holdings}
+        assert weights["AAPL"] == pytest.approx(0.5)
+        assert weights["MSFT"] == pytest.approx(0.5)
+        assert review.total_value_eur == pytest.approx(2000.0)
+        aapl = next(h for h in review.holdings if h.ticker == "AAPL")
+        assert aapl.quantity == 10.0
+        assert aapl.eur_value == pytest.approx(1000.0)
+
+    async def test_no_quantities_means_no_price_fetch_and_none_weights(self, tmp_path, mocker):
+        from finwiz.orchestrators.portfolio_review_orchestrator import build_portfolio_review
+
+        stock_csv = tmp_path / "stock.csv"
+        stock_csv.write_text("Name,Ticker,Currency,Active\nApple,AAPL,USD,true\n")
+
+        mock_validator = mocker.patch("finwiz.orchestrators.portfolio_holdings_processor.TickerExistenceValidationTool")
+        mock_validator.return_value._run.return_value = {"valid": True, "meta": {"source": "yahoo"}}
+
+        price_service = mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.PortfolioPriceService")
+
+        review, _summary = await build_portfolio_review(stock_csv=stock_csv)
+
+        # No quantity anywhere -> the price service is never constructed.
+        price_service.assert_not_called()
+        assert review.holdings[0].weight is None
+        assert review.total_value_eur is None
+
+    async def test_valuation_failure_is_graceful(self, tmp_path, mocker):
+        from finwiz.orchestrators.portfolio_review_orchestrator import build_portfolio_review
+
+        stock_csv = tmp_path / "stock.csv"
+        stock_csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,AAPL,USD,true,10\n")
+
+        mock_validator = mocker.patch("finwiz.orchestrators.portfolio_holdings_processor.TickerExistenceValidationTool")
+        mock_validator.return_value._run.return_value = {"valid": True, "meta": {"source": "yahoo"}}
+
+        # Price service blows up -> review must still be produced, weights None.
+        price_service = mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.PortfolioPriceService")
+        price_service.return_value.get_current_prices = mocker.AsyncMock(side_effect=RuntimeError("boom"))
+
+        review, _summary = await build_portfolio_review(stock_csv=stock_csv)
+
+        assert len(review.holdings) == 1
+        assert review.holdings[0].weight is None
+        assert review.total_value_eur is None
+```
+
+Add `import pytest` at the top of the test file if not already present.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/unit/orchestrators/test_portfolio_review.py::TestAllocationWiring -v`
+Expected: FAIL — `AttributeError`/`ImportError`: `PortfolioPriceService` / `get_fx_rate` are not yet imported into `portfolio_review_orchestrator`, and weights are not stamped.
+
+- [ ] **Step 3: Implement the wiring**
+
+In `src/finwiz/orchestrators/portfolio_review_orchestrator.py`, add imports near the top (after the existing `from finwiz.schemas.portfolio_review import PortfolioReview`):
+
+```python
+from finwiz.data.fx_rates import get_fx_rate
+from finwiz.schemas.portfolio_processing import RawHolding
+from finwiz.schemas.portfolio_valuation import ValuationResult
+from finwiz.scoring.portfolio_valuation import value_holdings
+from finwiz.tools.portfolio_price_service import PortfolioPriceService
+```
+
+Add a private helper above `build_portfolio_review`:
+
+```python
+async def _value_portfolio(raw_holdings: list[RawHolding]) -> ValuationResult | None:
+    """Pre-fetch prices and compute EUR weights. Best-effort: None on any failure.
+
+    Short-circuits (no price service, no network) when no holding has a quantity.
+    """
+    tickers = list({h.ticker for h in raw_holdings if h.quantity is not None})
+    if not tickers:
+        return None
+
+    try:
+        service = PortfolioPriceService()
+        prices = await service.get_current_prices(tickers)
+
+        def price_fn(ticker: str) -> tuple[float, str] | None:
+            pd = prices.get(ticker)
+            if pd is None:
+                return None
+            return (pd.price, pd.currency)
+
+        return value_holdings(
+            raw_holdings,
+            base="EUR",
+            price_fn=price_fn,
+            fx_fn=get_fx_rate,
+        )
+    except Exception as exc:  # never break the review over valuation
+        logger.warning("Portfolio valuation failed; weights unavailable this run: %s", exc)
+        return None
+```
+
+In `build_portfolio_review`, replace the block from the `if flow_state is not None:` merge through the `review = PortfolioReview(...)` construction (currently lines ~133-141) with:
+
+```python
+    if flow_state is not None:
+        logger.info("Merging deep analysis data from Flow state")
+        decisions = merge_deep_analysis_from_flow_state(decisions, flow_state)
+
+    total_value_eur: float | None = None
+    valuation = await _value_portfolio(raw_holdings)
+    if valuation is not None:
+        total_value_eur = valuation.total_value_eur
+        for decision in decisions:
+            hv = valuation.per_ticker.get(decision.ticker)
+            if hv is None:
+                continue
+            decision.quantity = hv.quantity
+            decision.native_currency = hv.native_currency
+            decision.native_value = hv.native_value
+            decision.eur_value = hv.eur_value
+            decision.weight = hv.weight
+        logger.info("Valuation coverage: %s", valuation.coverage_note)
+
+    review = PortfolioReview(
+        as_of=datetime.now(UTC),
+        base_currency=base_currency,
+        holdings=decisions,
+        total_value_eur=total_value_eur,
+    )
+
+    return review, summary
+```
+
+Note: `raw_holdings` is already in scope in `build_portfolio_review` (assigned from `processor.load_all_holdings(...)`).
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `uv run pytest tests/unit/orchestrators/test_portfolio_review.py::TestAllocationWiring -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Run the FULL existing review + processor suites to confirm no regression**
+
+Run: `uv run pytest tests/unit/orchestrators/test_portfolio_review.py tests/unit/orchestrators/test_portfolio_holdings_processor.py -v`
+Expected: PASS (all existing tests still green — the quantity-less CSVs in the old tests trigger the short-circuit, so no price service is constructed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finwiz/orchestrators/portfolio_review_orchestrator.py tests/unit/orchestrators/test_portfolio_review.py
+git commit -m "feat(portfolio): stamp EUR weights and total_value_eur in build_portfolio_review"
+```
+
+---
+
+## Task 7: `make fix-currencies` (CSV Currency rewrite tool)
+
+**Files:**
+- Create: `scripts/fix_csv_currencies.py`
+- Modify: `Makefile` (add `fix-currencies` target + `.PHONY`)
+- Test: `tests/unit/scripts/test_fix_csv_currencies.py`
+
+The core rewrite is a pure function taking an injected `resolve_currency_fn`, so tests need no network. `main()` wires the real resolver (price API).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/scripts/test_fix_csv_currencies.py`:
+
+```python
+"""Unit tests for the fix-currencies CSV rewrite tool (resolver injected)."""
+
+import csv
+
+from scripts.fix_csv_currencies import rewrite_csv_currencies
+
+
+def _rows(path):
+    with path.open(newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def test_rewrites_currency_from_resolver(tmp_path):
+    csv_path = tmp_path / "etf.csv"
+    csv_path.write_text(
+        "Name,Ticker,Currency,Active\n"
+        "Amundi EM,Yahoo:AEEM.PA,USD,true\n"
+        "UBS Gold,Yahoo:AUUSI.SW,USD,true\n"
+    )
+
+    def resolver(ticker):
+        return {"AEEM.PA": "EUR", "AUUSI.SW": "CHF"}.get(ticker)
+
+    changes = rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    assert rows[0]["Currency"] == "EUR"
+    assert rows[1]["Currency"] == "CHF"
+    assert ("AEEM.PA", "USD", "EUR") in changes
+
+
+def test_preserves_other_columns_and_order(tmp_path):
+    csv_path = tmp_path / "stock.csv"
+    csv_path.write_text(
+        "Name,Ticker,Currency,Active\n"
+        "Apple,Yahoo:AAPL,USD,true\n"
+        "Nestle,Yahoo:NESN.SW,USD,true\n"
+    )
+
+    def resolver(ticker):
+        return {"AAPL": "USD", "NESN.SW": "CHF"}.get(ticker)
+
+    rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    assert [r["Ticker"] for r in rows] == ["Yahoo:AAPL", "Yahoo:NESN.SW"]
+    assert rows[0]["Active"] == "true"
+    assert list(rows[0].keys()) == ["Name", "Ticker", "Currency", "Active"]
+
+
+def test_adds_currency_column_to_crypto(tmp_path):
+    csv_path = tmp_path / "crypto.csv"
+    csv_path.write_text("Name,Ticker,Active\nBitcoin,BTC,true\n")
+
+    def resolver(ticker):
+        return "USD"
+
+    rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    assert "Currency" in rows[0]
+    assert rows[0]["Currency"] == "USD"
+
+
+def test_per_ticker_failure_leaves_row_unchanged(tmp_path):
+    csv_path = tmp_path / "stock.csv"
+    csv_path.write_text(
+        "Name,Ticker,Currency,Active\n"
+        "Apple,Yahoo:AAPL,USD,true\n"
+        "Broken,Yahoo:BAD,EUR,true\n"
+    )
+
+    def resolver(ticker):
+        return "CHF" if ticker == "AAPL" else None  # BAD unresolved
+
+    rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    assert rows[0]["Currency"] == "CHF"
+    assert rows[1]["Currency"] == "EUR"  # untouched
+
+
+def test_idempotent(tmp_path):
+    csv_path = tmp_path / "stock.csv"
+    csv_path.write_text("Name,Ticker,Currency,Active\nApple,Yahoo:AAPL,USD,true\n")
+
+    def resolver(ticker):
+        return "EUR"
+
+    first = rewrite_csv_currencies(csv_path, resolver)
+    second = rewrite_csv_currencies(csv_path, resolver)
+
+    assert first == [("AAPL", "USD", "EUR")]
+    assert second == []  # nothing changed the second time
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/unit/scripts/test_fix_csv_currencies.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.fix_csv_currencies'`.
+
+- [ ] **Step 3: Implement the tool**
+
+Create `scripts/fix_csv_currencies.py`:
+
+```python
+"""Rewrite the `Currency` column of the portfolio CSVs from the authoritative
+price-API currency. Run explicitly via `make fix-currencies` — never on a normal
+analysis run. Atomic per file (temp + replace); per-ticker failures leave the row
+untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import logging
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+logger = logging.getLogger(__name__)
+
+# resolver(normalized_ticker) -> ISO currency code, or None when unresolved.
+CurrencyResolver = Callable[[str], str | None]
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_CSV_FILES = [
+    _PROJECT_ROOT / "data" / "stock.csv",
+    _PROJECT_ROOT / "data" / "etf.csv",
+    _PROJECT_ROOT / "data" / "crypto.csv",
+]
+
+
+def _normalize_ticker(raw: str, asset_class: str) -> str:
+    """Strip the source prefix (and add -USD for crypto) for price-API lookup."""
+    from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+    return PortfolioHoldingsProcessor().normalize_ticker(raw, asset_class=asset_class)  # type: ignore[arg-type]
+
+
+def rewrite_csv_currencies(
+    path: Path,
+    resolve_currency_fn: CurrencyResolver,
+) -> list[tuple[str, str, str]]:
+    """Rewrite `path`'s Currency column using the resolver.
+
+    Returns a list of (normalized_ticker, old_currency, new_currency) for rows
+    that changed. Adds a `Currency` column if absent (e.g. crypto.csv). Atomic.
+    """
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+
+    asset_class = "crypto" if path.stem == "crypto" else ("etf" if path.stem == "etf" else "stock")
+    has_currency = "Currency" in fieldnames
+    if not has_currency:
+        # Insert Currency right after Ticker if present, else append.
+        insert_at = fieldnames.index("Ticker") + 1 if "Ticker" in fieldnames else len(fieldnames)
+        fieldnames.insert(insert_at, "Currency")
+
+    changes: list[tuple[str, str, str]] = []
+    for row in rows:
+        raw_ticker = (row.get("Ticker") or "").strip()
+        if not raw_ticker:
+            row.setdefault("Currency", row.get("Currency", ""))
+            continue
+        norm = _normalize_ticker(raw_ticker, asset_class)
+        old = (row.get("Currency") or "").strip()
+        new = resolve_currency_fn(norm)
+        if new is None:
+            logger.warning("Could not resolve currency for %s; leaving %r", norm, old)
+            row["Currency"] = old
+            continue
+        if new != old:
+            changes.append((norm, old, new))
+        row["Currency"] = new
+
+    # Atomic write: temp file in the same dir, then replace.
+    with NamedTemporaryFile("w", newline="", encoding="utf-8", dir=path.parent, delete=False) as tmp:
+        writer = csv.DictWriter(tmp, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in fieldnames})
+        tmp_path = Path(tmp.name)
+    os.replace(tmp_path, path)
+
+    return changes
+
+
+def _build_live_resolver() -> CurrencyResolver:
+    """Resolver backed by the live price API (network)."""
+    from finwiz.tools.portfolio_price_service import PortfolioPriceService
+
+    service = PortfolioPriceService()
+
+    def resolve(norm_ticker: str) -> str | None:
+        try:
+            price_data = asyncio.run(service.get_current_price(norm_ticker))
+        except Exception as exc:
+            logger.warning("Price lookup failed for %s: %s", norm_ticker, exc)
+            return None
+        return price_data.currency if price_data is not None else None
+
+    return resolve
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    resolver = _build_live_resolver()
+    for csv_path in _CSV_FILES:
+        if not csv_path.exists():
+            logger.info("skip (missing): %s", csv_path)
+            continue
+        changes = rewrite_csv_currencies(csv_path, resolver)
+        if changes:
+            logger.info("%s: %d currency change(s)", csv_path.name, len(changes))
+            for ticker, old, new in changes:
+                logger.info("  %-14s %s -> %s", ticker, old or "(none)", new)
+        else:
+            logger.info("%s: no changes", csv_path.name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/unit/scripts/test_fix_csv_currencies.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Add the Makefile target**
+
+In `Makefile`, add `fix-currencies` to the `.PHONY` line (line 3) and add this target (place it near the other data/utility targets, e.g. after `cleanup:`):
+
+```makefile
+fix-currencies:  ## Rewrite data/*.csv Currency columns from the authoritative price API (network; explicit)
+	uv run python scripts/fix_csv_currencies.py
+```
+
+- [ ] **Step 6: Verify the target is wired (dry check — no network needed for `make -n`)**
+
+Run: `make -n fix-currencies`
+Expected: prints `uv run python scripts/fix_csv_currencies.py`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/fix_csv_currencies.py tests/unit/scripts/test_fix_csv_currencies.py Makefile
+git commit -m "feat(portfolio): add 'make fix-currencies' CSV currency rewrite tool"
+```
+
+---
+
+## Task 8: Add the `Quantity` column to the data CSVs
+
+This is the operational enablement step. We add an empty `Quantity` column to each CSV (blank = no position size yet; the pipeline stays inert/graceful until a user fills values). We do **not** invent position sizes.
+
+**Files:**
+- Modify: `data/stock.csv`, `data/etf.csv`, `data/crypto.csv`
+
+- [ ] **Step 1: Add an empty `Quantity` column to all three CSVs**
+
+Run this exact script (appends a `Quantity` header and an empty trailing cell to each data row, preserving all existing columns and row order):
+
+```bash
+uv run python - <<'PY'
+import csv
+from pathlib import Path
+
+for name in ("data/stock.csv", "data/etf.csv", "data/crypto.csv"):
+    path = Path(name)
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+    if "Quantity" in fieldnames:
+        print(f"{name}: already has Quantity, skipping")
+        continue
+    fieldnames.append("Quantity")
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            row["Quantity"] = ""
+            writer.writerow(row)
+    print(f"{name}: added empty Quantity column ({len(rows)} rows)")
+PY
+```
+
+Expected output: three lines confirming the column was added with the row counts.
+
+- [ ] **Step 2: Verify the headers**
+
+Run: `head -1 data/stock.csv data/etf.csv data/crypto.csv`
+Expected: each header now ends with `,Quantity` (e.g. `Name,Ticker,Currency,Active,Quantity`; crypto: `Name,Ticker,Active,Quantity`).
+
+- [ ] **Step 3: Verify ingestion still parses cleanly (no crash, quantities are None)**
+
+Run: `uv run pytest tests/unit/orchestrators/test_portfolio_holdings_processor.py -v`
+Expected: PASS — blank quantities parse to `None`, no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/stock.csv data/etf.csv data/crypto.csv
+git commit -m "chore(data): add empty Quantity column to portfolio CSVs"
+```
+
+---
+
+## Task 9: Full-suite verification + quality gates
+
+- [ ] **Step 1: Run the full default unit test suite**
+
+Run: `make test`
+Expected: PASS, no new failures. (Integration tests, including the live FX test, are excluded by the default `-m "not integration"`.)
+
+- [ ] **Step 2: Lint + format**
+
+Run: `make lint`
+Expected: ruff check + format clean (auto-fixes applied; re-run if it reports fixes).
+
+- [ ] **Step 3: Type check the touched modules**
+
+Run: `uv run mypy src/finwiz/data/fx_rates.py src/finwiz/scoring/portfolio_valuation.py src/finwiz/schemas/portfolio_valuation.py src/finwiz/orchestrators/portfolio_review_orchestrator.py src/finwiz/orchestrators/portfolio_holdings_processor.py`
+Expected: no errors. (yfinance is untyped; the `# yfinance has no official type stubs` comment mirrors the existing convention in `portfolio_price_service.py`.)
+
+- [ ] **Step 4: unittest.mock ban check**
+
+Run: `make check-unittest-mock`
+Expected: PASS — all new tests use `mocker` (pytest-mock), zero `unittest.mock` imports.
+
+- [ ] **Step 5: Commit any lint/format fixups**
+
+```bash
+git add -A
+git commit -m "chore(portfolio): lint/format/type fixups for allocation data" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes (traceability to the spec)
+
+- **Quantity from CSV → `RawHolding.quantity`:** Task 1.
+- **Native value + EUR conversion + weight on the holding model:** Tasks 2, 5, 6.
+- **Surface `quantity / native_currency / native_value / eur_value / weight`:** Task 2 (model) + Task 6 (stamping).
+- **`make fix-currencies` (explicit, atomic, idempotent, adds crypto Currency):** Task 7.
+- **Graceful degradation (missing quantity/price/FX → weight None; never crashes; total over priced holdings):** Tasks 5 (pure logic) + 6 (`_value_portfolio` try/except + short-circuit).
+- **FX live via yfinance pairs, per-run cache, GBp/100:** Task 4.
+- **`PortfolioReview.total_value_eur` for the report header:** Tasks 2 + 6.
+- **Network calls isolated to `@pytest.mark.integration`:** Task 4 Step 5 (FX) + Task 7 keeps the network in `_build_live_resolver` (untested) while the pure rewrite is unit-tested.
+
+**Deliberate scope decision (flag for reviewer):** `PortfolioReview.base_currency` keeps its existing default (`"CHF"`) and is **not** changed to `"EUR"`. The spec's narrative says "base currency EUR", but the *weight* is a dimensionless ratio and `total_value_eur` already carries the EUR total explicitly, so changing the long-standing `base_currency` default is unnecessary and risks regressions elsewhere. The valuation is hard-coded to EUR internally. If the report header must literally display "EUR", that is a one-line follow-up in the report renderer (out of scope here, consistent with the spec's "Non-goals: changing the report-posture plan").
+
+**Consumption by the strategic-posture combine** (the prerequisite-of relationship in the spec header) is explicitly out of scope for this plan — it is the small follow-up edit to the report-posture plan's B2/B4, as the spec states.
+```

--- a/docs/superpowers/specs/2026-06-08-portfolio-allocation-data-design.md
+++ b/docs/superpowers/specs/2026-06-08-portfolio-allocation-data-design.md
@@ -1,0 +1,137 @@
+# Portfolio Allocation Data — Design
+
+**Date:** 2026-06-08
+**Status:** Approved-pending-review (brainstorm)
+**Prerequisite for:** `docs/superpowers/plans/2026-06-08-report-freshness-and-portfolio-posture.md`
+(enables true allocation-weighted strategic posture, replacing the interim count-based weighting)
+
+## Problem
+
+Holdings carry no position size, so the portfolio has no weights. Input CSVs
+(`data/stock.csv`, `data/etf.csv`, `data/crypto.csv`) have only `Name,Ticker,Currency,Active`
+(crypto lacks `Currency`), and `RawHolding` / `HoldingDecision` / `PortfolioReview` carry no
+quantity/value/weight. The CSV `Currency` column is also **unreliable** — mostly `USD` even
+for Swiss/EU tickers (`Yahoo:AEEM.PA` labelled USD; `Yahoo:AUUSI.SW` labelled USD). Without
+weights, the report can't represent the portfolio by allocation.
+
+Tickers are source-prefixed: `Yahoo:AAPL`, `Yahoo:AEEM.PA`; crypto is bare (`BTC`).
+
+## Goals / Non-goals
+
+**Goals**
+- Each holding carries a position **Quantity** (units/shares) from the CSV.
+- Compute each holding's market value in its **native currency** (from the price API) and
+  convert to a **EUR** base via **live FX**, yielding a portfolio **weight** (`% of total EUR value`).
+- Surface `quantity`, `native_currency`, `native_value`, `eur_value`, `weight` on the holding model.
+- Provide an explicit `make fix-currencies` that rewrites the CSV `Currency` column from the
+  authoritative price-API currency (intentional, not per-run).
+- Degrade gracefully: missing/blank quantity or unavailable price/FX → that holding's weight is
+  `None`; the run never crashes and other weights still compute (over the holdings that do have data).
+
+**Non-goals**
+- Cost basis, P&L, tax lots, or historical performance.
+- Rebalancing trade math (separate module already exists).
+- Changing the report-posture plan here (it consumes the new weights; the upgrade is a small
+  follow-up edit to that plan's B2/B4).
+- Auto-mutating input CSVs on every run.
+
+## Decisions (from brainstorm)
+
+- Source of truth: **Quantity** column in the CSVs (units/shares).
+- Base currency: **EUR**.
+- Native currency + price: from the **price API** (yfinance quote currency + last price), authoritative.
+- FX: **live** (yfinance FX pairs, e.g. `CHFEUR=X`), cached per run.
+- CSV Currency correction: **explicit `make fix-currencies`** command (rewrites `data/*.csv` in place).
+- Missing data: weight `None`, graceful.
+
+## Architecture
+
+A new deterministic **valuation** unit takes holdings + quantities, resolves native price &
+currency (price API), resolves FX→EUR (live, cached), and computes per-holding `native_value`,
+`eur_value`, and portfolio `weight`. This is pure Python (AI Minimalism: no AI). It runs once
+during portfolio processing and populates the holding model; weights then flow to the report and
+to the strategic-posture combine.
+
+### Components
+
+1. **CSV schema + ingestion** (`portfolio_holdings_processor.py`, `schemas/portfolio_processing.py`)
+   - Add optional `Quantity` column to `data/stock.csv`, `data/etf.csv`, `data/crypto.csv`
+     (blank allowed). `_read_csv_holdings` parses it into `RawHolding.quantity: float | None`
+     (robust parse: blank/invalid → `None`, logged at debug).
+   - Crypto CSV gains `Quantity` (its `Currency` stays absent → native currency from price API,
+     typically USD).
+
+2. **FX provider** (`src/finwiz/data/fx_rates.py`, new)
+   - `get_fx_rate(from_ccy: str, base: str = "EUR") -> float | None` — live rate via yfinance pair
+     (`f"{from_ccy}{base}=X"`; identity 1.0 when equal; handles GBp→GBP/100 pence quirk). Per-run
+     cache (module singleton dict, reset by the existing test isolation fixture pattern if needed).
+     Best-effort: failure → `None` (caller treats weight as unknown).
+
+3. **Valuation** (`src/finwiz/scoring/portfolio_valuation.py`, new)
+   - `value_holdings(holdings, *, base="EUR", price_fn, fx_fn) -> ValuationResult` — pure, injects
+     price/FX functions for testability. For each holding with a quantity: get `(price, native_ccy)`
+     from `price_fn`; `native_value = quantity * price`; `eur_value = native_value * fx_fn(native_ccy)`.
+     Sum `eur_value` over holdings that resolved → `total_eur`; `weight = eur_value / total_eur`.
+     Holdings missing quantity/price/FX get `weight=None` and are excluded from `total_eur`.
+   - Returns per-ticker `{quantity, native_currency, native_value, eur_value, weight}` + totals +
+     a coverage note (`N of M holdings priced; X% of holdings by count weighted`).
+
+4. **Holding model fields** (`schemas/portfolio_processing.py::RawHolding`,
+   `schemas/portfolio_review.py::HoldingDecision`)
+   - Add optional: `quantity: float | None`, `native_currency: str | None`,
+     `native_value: float | None`, `eur_value: float | None`, `weight: float | None` (0..1).
+     All optional/defaulted → no breaking change; `extra="forbid"` models get explicit fields.
+
+5. **Wiring** (`portfolio_holdings_processor.py` / `portfolio_review_orchestrator.py`)
+   - After holdings are built, run `value_holdings` (using the existing price service as `price_fn`
+     and `fx_rates.get_fx_rate` as `fx_fn`) and stamp the weight fields onto the decisions.
+   - `PortfolioReview` gains an optional `base_currency: str = "EUR"` + `total_value_eur: float | None`
+     for the report header.
+
+6. **`make fix-currencies`** (`scripts/fix_csv_currencies.py`, new + Makefile target)
+   - Reads each CSV, resolves the authoritative currency per ticker from the price API, rewrites the
+     `Currency` column in place (preserving row order and other columns; adds `Currency` to crypto.csv).
+     Prints a diff summary (old→new per ticker). Idempotent. Not invoked by the analysis flow.
+
+### Data flow
+CSV (`Quantity`) → `RawHolding.quantity` → `value_holdings(price_fn, fx_fn)` →
+per-holding `{native_value, eur_value, weight}` + `total_value_eur` → stamped on `HoldingDecision`
+/ `PortfolioReview` → consumed by report renderer + strategic-posture combine.
+
+### Error handling
+- Blank/invalid quantity → `None`, debug log, holding excluded from weighting (still analyzed/rendered).
+- Price or FX unavailable for a holding → its `weight=None`; it's excluded from `total_eur` (weights
+  of the rest still sum to ~1.0 over priced holdings; coverage note states how many were priced).
+- FX provider total failure → all weights `None`; report/posture fall back to count-based (the
+  interim behavior), never crashes. Logged once at WARNING.
+- `make fix-currencies`: per-ticker failure leaves that row's `Currency` unchanged + logs it; never
+  corrupts the file (write to temp, atomic replace).
+
+### Testing
+- `fx_rates`: identity rate; mocked pair lookup; GBp handling; failure→None; per-run cache hit.
+- `value_holdings` (pure, injected fns): full data → correct weights summing ~1.0; missing quantity →
+  weight None + excluded from total; missing price/FX → weight None; empty → no crash; multi-currency
+  mix → correct EUR conversion. (No network — fns injected.)
+- CSV ingestion: `Quantity` parsed (valid/blank/garbage); crypto Quantity parsed.
+- `fix_csv_currencies`: rewrites Currency from a mocked currency resolver; atomic; idempotent;
+  preserves other columns/order; per-ticker failure leaves row intact.
+- The live price/FX calls themselves are network → their direct tests `@pytest.mark.integration`.
+
+## Affected files (reference)
+- `data/stock.csv`, `data/etf.csv`, `data/crypto.csv` — add `Quantity` (+ crypto `Currency` via the fix tool).
+- `src/finwiz/schemas/portfolio_processing.py` — `RawHolding.quantity`.
+- `src/finwiz/schemas/portfolio_review.py` — `HoldingDecision` weight fields; `PortfolioReview.base_currency`/`total_value_eur`.
+- `src/finwiz/orchestrators/portfolio_holdings_processor.py` — parse `Quantity`; invoke valuation.
+- `src/finwiz/orchestrators/portfolio_review_orchestrator.py` — stamp weights/totals (where holdings are finalized).
+- `src/finwiz/data/fx_rates.py` (new) — live FX→EUR.
+- `src/finwiz/scoring/portfolio_valuation.py` (new) — pure valuation/weights.
+- `scripts/fix_csv_currencies.py` (new) + `Makefile` `fix-currencies` target.
+
+## Risks / open items for planning
+- Confirm the existing price service exposes both **price and quote currency** per ticker (yfinance
+  `fast_info.last_price` + `fast_info.currency`); if not, add a thin accessor.
+- Confirm the source-prefixed ticker (`Yahoo:AAPL`) → price-API symbol normalization already done by
+  `normalize_ticker`; reuse it for both price and FX-currency resolution.
+- GBp (pence) vs GBP and any other minor-unit quirks (LSE `.L` often quotes GBp) — valuation must
+  normalize to major units before FX.
+- Decide exact insertion point where decisions are finalized so weights are stamped before report/posture.

--- a/docs/superpowers/specs/2026-06-08-portfolio-allocation-data-design.md
+++ b/docs/superpowers/specs/2026-06-08-portfolio-allocation-data-design.md
@@ -1,7 +1,7 @@
 # Portfolio Allocation Data — Design
 
 **Date:** 2026-06-08
-**Status:** Approved-pending-review (brainstorm)
+**Status:** Approved
 **Prerequisite for:** `docs/superpowers/plans/2026-06-08-report-freshness-and-portfolio-posture.md`
 (enables true allocation-weighted strategic posture, replacing the interim count-based weighting)
 
@@ -85,8 +85,9 @@ to the strategic-posture combine.
 5. **Wiring** (`portfolio_holdings_processor.py` / `portfolio_review_orchestrator.py`)
    - After holdings are built, run `value_holdings` (using the existing price service as `price_fn`
      and `fx_rates.get_fx_rate` as `fx_fn`) and stamp the weight fields onto the decisions.
-   - `PortfolioReview` gains an optional `base_currency: str = "EUR"` + `total_value_eur: float | None`
-     for the report header.
+   - `PortfolioReview` gains an optional `total_value_eur: float | None` for the report header.
+     (`base_currency` keeps its existing default of `"CHF"` for backward compatibility; the EUR
+     valuation is surfaced explicitly via `total_value_eur` rather than by changing that default.)
 
 6. **`make fix-currencies`** (`scripts/fix_csv_currencies.py`, new + Makefile target)
    - Reads each CSV, resolves the authoritative currency per ticker from the price API, rewrites the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "finwiz"
-version = "5.5.1"
+version = "5.6.0"
 description = "finwiz using crewAI"
 authors = [{ name = "Frederic Jacquet", email = "fred.jacquet@gmail.com" }]
 requires-python = ">=3.12,<3.13"

--- a/scripts/fix_csv_currencies.py
+++ b/scripts/fix_csv_currencies.py
@@ -1,0 +1,131 @@
+"""Rewrite the `Currency` column of the portfolio CSVs from the authoritative
+price-API currency. Run explicitly via `make fix-currencies` — never on a normal
+analysis run. Atomic per file (temp + replace); per-ticker failures leave the row
+untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import logging
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from finwiz.schemas.portfolio_processing import AssetClass
+
+logger = logging.getLogger(__name__)
+
+# resolver(normalized_ticker) -> ISO currency code, or None when unresolved.
+CurrencyResolver = Callable[[str], str | None]
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_CSV_FILES = [
+    _PROJECT_ROOT / "data" / "stock.csv",
+    _PROJECT_ROOT / "data" / "etf.csv",
+    _PROJECT_ROOT / "data" / "crypto.csv",
+]
+
+
+def _normalize_ticker(raw: str, asset_class: AssetClass) -> str:
+    """Strip the source prefix (and add -USD for crypto) for price-API lookup."""
+    from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+    return PortfolioHoldingsProcessor().normalize_ticker(raw, asset_class=asset_class)
+
+
+def rewrite_csv_currencies(
+    path: Path,
+    resolve_currency_fn: CurrencyResolver,
+) -> list[tuple[str, str, str]]:
+    """Rewrite `path`'s Currency column using the resolver.
+
+    Returns a list of (normalized_ticker, old_currency, new_currency) for rows
+    that changed. Adds a `Currency` column if absent (e.g. crypto.csv). Atomic.
+    """
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+
+    asset_class: AssetClass = "crypto" if path.stem == "crypto" else ("etf" if path.stem == "etf" else "stock")
+    has_currency = "Currency" in fieldnames
+    if not has_currency:
+        # Insert Currency right after Ticker if present, else append.
+        insert_at = fieldnames.index("Ticker") + 1 if "Ticker" in fieldnames else len(fieldnames)
+        fieldnames.insert(insert_at, "Currency")
+
+    changes: list[tuple[str, str, str]] = []
+    for row in rows:
+        raw_ticker = (row.get("Ticker") or "").strip()
+        if not raw_ticker:
+            row.setdefault("Currency", row.get("Currency", ""))
+            continue
+        norm = _normalize_ticker(raw_ticker, asset_class)
+        old = (row.get("Currency") or "").strip()
+        new = resolve_currency_fn(norm)
+        if new is None:
+            logger.warning("Could not resolve currency for %s; leaving %r", norm, old)
+            row["Currency"] = old
+            continue
+        if new != old:
+            changes.append((norm, old, new))
+        row["Currency"] = new
+
+    # Atomic write: temp file in the same dir, then replace. On any failure,
+    # remove the orphaned temp file rather than leaving it in data/.
+    tmp = NamedTemporaryFile("w", newline="", encoding="utf-8", dir=path.parent, delete=False)
+    tmp_path = Path(tmp.name)
+    try:
+        with tmp:
+            writer = csv.DictWriter(tmp, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow({k: row.get(k, "") for k in fieldnames})
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    return changes
+
+
+def _build_live_resolver() -> CurrencyResolver:
+    """Resolver backed by the live price API (network)."""
+    from finwiz.tools.portfolio_price_service import PortfolioPriceService
+
+    service = PortfolioPriceService()
+
+    def resolve(norm_ticker: str) -> str | None:
+        try:
+            price_data = asyncio.run(service.get_current_price(norm_ticker))
+        except Exception as exc:
+            logger.warning("Price lookup failed for %s: %s", norm_ticker, exc)
+            return None
+        return price_data.currency if price_data is not None else None
+
+    return resolve
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    resolver = _build_live_resolver()
+    for csv_path in _CSV_FILES:
+        if not csv_path.exists():
+            logger.info("skip (missing): %s", csv_path)
+            continue
+        changes = rewrite_csv_currencies(csv_path, resolver)
+        if changes:
+            logger.info("%s: %d currency change(s)", csv_path.name, len(changes))
+            for ticker, old, new in changes:
+                logger.info("  %-14s %s -> %s", ticker, old or "(none)", new)
+        else:
+            logger.info("%s: no changes", csv_path.name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fix_csv_currencies.py
+++ b/scripts/fix_csv_currencies.py
@@ -30,6 +30,11 @@ _CSV_FILES = [
 ]
 
 
+def _asset_class_for(path: Path) -> AssetClass:
+    """Map a CSV filename stem to its asset class (defaults to stock)."""
+    return "crypto" if path.stem == "crypto" else ("etf" if path.stem == "etf" else "stock")
+
+
 def _normalize_ticker(raw: str, asset_class: AssetClass) -> str:
     """Strip the source prefix (and add -USD for crypto) for price-API lookup."""
     from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
@@ -51,7 +56,7 @@ def rewrite_csv_currencies(
         fieldnames = list(reader.fieldnames or [])
         rows = list(reader)
 
-    asset_class: AssetClass = "crypto" if path.stem == "crypto" else ("etf" if path.stem == "etf" else "stock")
+    asset_class: AssetClass = _asset_class_for(path)
     has_currency = "Currency" in fieldnames
     if not has_currency:
         # Insert Currency right after Ticker if present, else append.
@@ -93,26 +98,49 @@ def rewrite_csv_currencies(
     return changes
 
 
-def _build_live_resolver() -> CurrencyResolver:
-    """Resolver backed by the live price API (network)."""
+def _collect_normalized_tickers(csv_files: list[Path]) -> list[str]:
+    """Read each CSV once and return the unique normalized tickers across all files."""
+    tickers: set[str] = set()
+    for path in csv_files:
+        if not path.exists():
+            continue
+        asset_class = _asset_class_for(path)
+        with path.open(newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                raw = (row.get("Ticker") or "").strip()
+                if raw:
+                    tickers.add(_normalize_ticker(raw, asset_class))
+    return sorted(tickers)
+
+
+def _build_live_resolver(csv_files: list[Path]) -> CurrencyResolver:
+    """Resolver backed by ONE batched price-API call (network).
+
+    Pre-fetches every ticker's currency concurrently in a single event loop, then
+    serves lookups from the resulting map — avoiding one event loop per CSV row.
+    """
     from finwiz.tools.portfolio_price_service import PortfolioPriceService
 
-    service = PortfolioPriceService()
+    tickers = _collect_normalized_tickers(csv_files)
+    currency_by_ticker: dict[str, str] = {}
+    if tickers:
+        service = PortfolioPriceService()
+        try:
+            prices = asyncio.run(service.get_current_prices(tickers))
+        except Exception as exc:
+            logger.warning("Batch price lookup failed; currencies left unresolved: %s", exc)
+            prices = {}
+        currency_by_ticker = {ticker: pd.currency for ticker, pd in prices.items() if pd is not None}
 
     def resolve(norm_ticker: str) -> str | None:
-        try:
-            price_data = asyncio.run(service.get_current_price(norm_ticker))
-        except Exception as exc:
-            logger.warning("Price lookup failed for %s: %s", norm_ticker, exc)
-            return None
-        return price_data.currency if price_data is not None else None
+        return currency_by_ticker.get(norm_ticker)
 
     return resolve
 
 
 def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    resolver = _build_live_resolver()
+    resolver = _build_live_resolver(_CSV_FILES)
     for csv_path in _CSV_FILES:
         if not csv_path.exists():
             logger.info("skip (missing): %s", csv_path)

--- a/src/finwiz/data/fx_rates.py
+++ b/src/finwiz/data/fx_rates.py
@@ -22,6 +22,9 @@ _MINOR_UNITS: dict[str, tuple[str, float]] = {
 }
 
 # Per-run cache keyed by (from_ccy, base) -> rate or None. Reset via clear_fx_cache().
+# Not thread-safe by design — the flow runs in a single asyncio thread. Cache keys use
+# the raw (stripped) from_ccy so the case-sensitive minor-unit codes (e.g. "GBp") survive;
+# yfinance returns ISO-cased currencies, so case-variant keys don't occur in practice.
 _FX_CACHE: dict[tuple[str, str], float | None] = {}
 
 

--- a/src/finwiz/data/fx_rates.py
+++ b/src/finwiz/data/fx_rates.py
@@ -1,0 +1,82 @@
+"""Live FX rate provider (yfinance), EUR-based, with a per-run cache.
+
+Best-effort: any failure yields `None` and the caller treats the affected
+weight as unknown. Pure deterministic glue around a network call (AI Minimalism).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import yfinance as yf  # yfinance has no official type stubs
+
+logger = logging.getLogger(__name__)
+
+# Sub-unit (minor) currency codes -> (major ISO code, divisor).
+# e.g. LSE quotes "GBp" (pence); 100 pence = 1 GBP.
+_MINOR_UNITS: dict[str, tuple[str, float]] = {
+    "GBp": ("GBP", 100.0),
+    "GBX": ("GBP", 100.0),
+    "ZAc": ("ZAR", 100.0),
+    "ILA": ("ILS", 100.0),
+}
+
+# Per-run cache keyed by (from_ccy, base) -> rate or None. Reset via clear_fx_cache().
+_FX_CACHE: dict[tuple[str, str], float | None] = {}
+
+
+def clear_fx_cache() -> None:
+    """Clear the per-run FX cache (used by tests and between flow runs)."""
+    _FX_CACHE.clear()
+
+
+def _fetch_pair_rate(from_ccy: str, base: str) -> float | None:
+    """Fetch the spot rate for `<from_ccy><base>=X` from yfinance. Network site."""
+    pair = f"{from_ccy}{base}=X"
+    try:
+        ticker = yf.Ticker(pair)
+        # Primary: fast_info last price.
+        try:
+            rate = ticker.fast_info["lastPrice"]
+        except Exception:
+            rate = getattr(ticker.fast_info, "last_price", None)
+        if rate and float(rate) > 0:
+            return float(rate)
+
+        # Fallback: 1-day history close.
+        hist = ticker.history(period="1d")
+        if not hist.empty and "Close" in hist.columns:
+            close = float(hist["Close"].iloc[-1])
+            if close > 0:
+                return close
+    except Exception as exc:  # best-effort
+        logger.warning("FX lookup failed for %s: %s", pair, exc)
+    return None
+
+
+def get_fx_rate(from_ccy: str, base: str = "EUR") -> float | None:
+    """Return the rate to multiply a `from_ccy` amount by to get `base`.
+
+    Identity (1.0) when currencies match. Minor units (GBp/GBX/ZAc/ILA) are
+    mapped to their major unit and the rate divided by 100. Best-effort: any
+    failure returns None. Results (including None) are cached per run.
+    """
+    raw = (from_ccy or "").strip()
+    base_ccy = (base or "EUR").strip().upper()
+    if not raw or not base_ccy:
+        return None
+
+    cache_key = (raw, base_ccy)
+    if cache_key in _FX_CACHE:
+        return _FX_CACHE[cache_key]
+
+    major, divisor = _MINOR_UNITS.get(raw, (raw.upper(), 1.0))
+
+    if major == base_ccy:
+        result: float | None = 1.0 / divisor
+    else:
+        pair_rate = _fetch_pair_rate(major, base_ccy)
+        result = None if pair_rate is None else pair_rate / divisor
+
+    _FX_CACHE[cache_key] = result
+    return result

--- a/src/finwiz/orchestrators/portfolio_holdings_processor.py
+++ b/src/finwiz/orchestrators/portfolio_holdings_processor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import csv
 import logging
+import math
 import os
 import time
 from collections import Counter
@@ -42,15 +43,19 @@ logger = logging.getLogger(__name__)
 
 
 def _parse_quantity(raw: str | None) -> float | None:
-    """Parse a CSV Quantity cell into a float; blank/invalid -> None (debug-logged)."""
+    """Parse a CSV Quantity cell into a float; blank/invalid/non-finite -> None (debug-logged)."""
     s = (raw or "").strip()
     if not s:
         return None
     try:
-        return float(s)
+        value = float(s)
     except ValueError:
         logger.debug("Ignoring unparseable Quantity value %r", s)
         return None
+    if not math.isfinite(value):
+        logger.debug("Ignoring non-finite Quantity value %r", s)
+        return None
+    return value
 
 
 class PortfolioHoldingsProcessor:

--- a/src/finwiz/orchestrators/portfolio_holdings_processor.py
+++ b/src/finwiz/orchestrators/portfolio_holdings_processor.py
@@ -41,6 +41,18 @@ from finwiz.tools.ticker_validation_tool import TickerExistenceValidationTool
 logger = logging.getLogger(__name__)
 
 
+def _parse_quantity(raw: str | None) -> float | None:
+    """Parse a CSV Quantity cell into a float; blank/invalid -> None (debug-logged)."""
+    s = (raw or "").strip()
+    if not s:
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        logger.debug("Ignoring unparseable Quantity value %r", s)
+        return None
+
+
 class PortfolioHoldingsProcessor:
     """Process ALL portfolio holdings from CSV files with complete transparency."""
 
@@ -148,6 +160,7 @@ class PortfolioHoldingsProcessor:
                     ticker = self.normalize_ticker(row.get("Ticker") or "", asset_class=asset_class)
                     currency = (row.get("Currency") or "").strip()
                     active_raw = (row.get("Active") or "true").strip().lower()
+                    quantity = _parse_quantity(row.get("Quantity"))
 
                     # Log every row we encounter
                     logger.debug(f"CSV line {line_num}: name='{name}', ticker='{ticker}', currency='{currency}', active='{active_raw}', asset_class='{asset_class}'")
@@ -171,6 +184,7 @@ class PortfolioHoldingsProcessor:
                             currency=currency or "USD",
                             source_file=str(path),
                             line_number=line_num,
+                            quantity=quantity,
                         )
                     )
 

--- a/src/finwiz/orchestrators/portfolio_review_orchestrator.py
+++ b/src/finwiz/orchestrators/portfolio_review_orchestrator.py
@@ -173,6 +173,12 @@ async def build_portfolio_review(
     valuation = await _value_portfolio(raw_holdings)
     if valuation is not None:
         total_value_eur = valuation.total_value_eur
+        # per_ticker is keyed by ticker (value_holdings collapses same-ticker
+        # holdings last-wins, see test_duplicate_ticker_collapses_last_wins), and
+        # total_value_eur is derived from that single-count map — so the portfolio
+        # total is never double-counted. The data CSVs hold unique tickers; if two
+        # rows ever shared a ticker, both decisions would be stamped with the same
+        # (collapsed) weight here. Acceptable given the deliberate collapse semantics.
         for decision in decisions:
             hv = valuation.per_ticker.get(decision.ticker)
             if hv is None:
@@ -224,7 +230,7 @@ def save_review_json(
             "excluded_holdings": [{"ticker": ticker, "reason": reason} for ticker, reason in summary.excluded_holdings],
         }
         with open(summary_path, "w") as f:
-            json.dump(summary_data, f, indent=2)
+            json.dump(summary_data, f, indent=2, default=str)
         logger.info(f"Saved processing summary to {summary_path}")
 
     out_path.write_text(json.dumps(output_data, indent=2, default=str), encoding="utf-8")

--- a/src/finwiz/orchestrators/portfolio_review_orchestrator.py
+++ b/src/finwiz/orchestrators/portfolio_review_orchestrator.py
@@ -19,12 +19,17 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from finwiz.data.fx_rates import get_fx_rate
 from finwiz.orchestrators.portfolio_holdings_processor import (
     PortfolioHoldingsProcessor,
     ProcessingSummary,
 )
 from finwiz.orchestrators.portfolio_review.merge import merge_deep_analysis_from_flow_state
+from finwiz.schemas.portfolio_processing import RawHolding
 from finwiz.schemas.portfolio_review import PortfolioReview
+from finwiz.schemas.portfolio_valuation import ValuationResult
+from finwiz.scoring.portfolio_valuation import value_holdings
+from finwiz.tools.portfolio_price_service import PortfolioPriceService
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +80,36 @@ def get_thresholds() -> tuple[float, float, int]:
 # =============================================================================
 # Core Review Building
 # =============================================================================
+
+
+async def _value_portfolio(raw_holdings: list[RawHolding]) -> ValuationResult | None:
+    """Pre-fetch prices and compute EUR weights. Best-effort: None on any failure.
+
+    Short-circuits (no price service, no network) when no holding has a quantity.
+    """
+    tickers = list({h.ticker for h in raw_holdings if h.quantity is not None})
+    if not tickers:
+        return None
+
+    try:
+        service = PortfolioPriceService()
+        prices = await service.get_current_prices(tickers)
+
+        def price_fn(ticker: str) -> tuple[float, str] | None:
+            pd = prices.get(ticker)
+            if pd is None:
+                return None
+            return (pd.price, pd.currency)
+
+        return value_holdings(
+            raw_holdings,
+            base="EUR",
+            price_fn=price_fn,
+            fx_fn=get_fx_rate,
+        )
+    except Exception as exc:  # never break the review over valuation
+        logger.warning("Portfolio valuation failed; weights unavailable this run: %s", exc)
+        return None
 
 
 async def build_portfolio_review(
@@ -134,10 +169,26 @@ async def build_portfolio_review(
         logger.info("Merging deep analysis data from Flow state")
         decisions = merge_deep_analysis_from_flow_state(decisions, flow_state)
 
+    total_value_eur: float | None = None
+    valuation = await _value_portfolio(raw_holdings)
+    if valuation is not None:
+        total_value_eur = valuation.total_value_eur
+        for decision in decisions:
+            hv = valuation.per_ticker.get(decision.ticker)
+            if hv is None:
+                continue
+            decision.quantity = hv.quantity
+            decision.native_currency = hv.native_currency
+            decision.native_value = hv.native_value
+            decision.eur_value = hv.eur_value
+            decision.weight = hv.weight
+        logger.info("Valuation coverage: %s", valuation.coverage_note)
+
     review = PortfolioReview(
         as_of=datetime.now(UTC),
         base_currency=base_currency,
         holdings=decisions,
+        total_value_eur=total_value_eur,
     )
 
     return review, summary

--- a/src/finwiz/reporting/css_styles.py
+++ b/src/finwiz/reporting/css_styles.py
@@ -16,205 +16,290 @@ def get_report_css() -> str:
         grade/badge styling.
     """
     return """
+    :root {
+      --bg: #f5f7fa;
+      --card: #ffffff;
+      --ink: #1e293b;
+      --ink-soft: #475569;
+      --muted: #64748b;
+      --line: #e9eef4;
+      --line-soft: #eef2f7;
+      --accent: #059669;
+      --accent-strong: #047857;
+      --accent-soft: #ecfdf5;
+      --shadow: 0 1px 2px rgba(15,23,42,0.04), 0 8px 24px rgba(15,23,42,0.06);
+      --radius: 14px;
+    }
+    * { box-sizing: border-box; }
     body {
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      font-family: 'Inter', 'Segoe UI', -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
       line-height: 1.6;
-      color: #333;
+      color: var(--ink);
       margin: 0;
-      padding: 20px;
-      background: #f8f9fa;
+      padding: 28px;
+      max-width: 1180px;
+      margin-left: auto;
+      margin-right: auto;
+      background: var(--bg);
+      -webkit-font-smoothing: antialiased;
     }
     header {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      color: white;
-      padding: 30px;
-      border-radius: 12px;
-      margin-bottom: 30px;
-      box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+      background: var(--card);
+      color: var(--ink);
+      padding: 32px 34px;
+      border-radius: var(--radius);
+      margin-bottom: 26px;
+      box-shadow: var(--shadow);
+      border-left: 4px solid var(--accent);
     }
-    h1 { margin: 0 0 10px 0; font-size: 2.2em; }
-    h2 { color: #2c3e50; margin: 30px 0 15px 0; border-bottom: 2px solid #3498db; padding-bottom: 8px; }
-    h3 { color: #34495e; margin: 20px 0 10px 0; }
+    h1 { margin: 0 0 8px 0; font-size: 1.9rem; font-weight: 700; letter-spacing: -0.02em; }
+    h2 {
+      color: var(--ink);
+      margin: 0 0 18px 0;
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--line);
+    }
+    h3 { color: var(--ink-soft); margin: 22px 0 10px 0; font-size: 1.02rem; font-weight: 600; }
+    h4 { color: var(--ink-soft); font-size: 0.9rem; font-weight: 600; }
     .section {
-      background: white;
-      border-radius: 8px;
-      padding: 25px;
-      margin-bottom: 20px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 26px 28px;
+      margin-bottom: 22px;
+      box-shadow: var(--shadow);
     }
-    .muted { color: #7f8c8d; font-size: 0.9em; }
+    .muted { color: var(--muted); font-size: 0.9em; }
     .small { font-size: 0.85em; }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+
     table {
       width: 100%;
       border-collapse: collapse;
-      margin: 15px 0;
-      background: white;
+      margin: 16px 0;
+      background: transparent;
+      font-size: 0.92rem;
     }
     th, td {
-      padding: 12px;
+      padding: 12px 14px;
       text-align: left;
-      border-bottom: 1px solid #ecf0f1;
+      border-bottom: 1px solid var(--line-soft);
+      vertical-align: top;
     }
     th {
-      background: #3498db;
-      color: white;
+      background: #f8fafc;
+      color: var(--muted);
+      font-weight: 600;
+      font-size: 0.72rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      border-bottom: 1px solid var(--line);
+    }
+    tbody tr { transition: background 0.15s ease; }
+    tbody tr:hover { background: var(--accent-soft); }
+    td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+    .grade-a-plus { color: var(--accent-strong); font-weight: 700; }
+    .grade-a { color: var(--accent); font-weight: 700; }
+    .grade-b { color: #ca8a04; font-weight: 700; }
+    .grade-c { color: #d97706; font-weight: 700; }
+    .grade-d { color: #dc2626; font-weight: 700; }
+    .grade-f { color: #b91c1c; font-weight: 700; }
+    .grade-na { color: var(--muted); font-weight: 600; }
+
+    .ticker-link {
+      color: var(--accent-strong);
+      text-decoration: none;
+      border-bottom: 1px dashed #34d39966;
+      transition: all 0.18s ease;
       font-weight: 600;
     }
-    .grade-a-plus { color: #27ae60; font-weight: bold; }
-    .grade-a { color: #2ecc71; font-weight: bold; }
-    .grade-b { color: #f39c12; font-weight: bold; }
-    .grade-c { color: #e67e22; font-weight: bold; }
-    .grade-d { color: #e74c3c; font-weight: bold; }
-    .grade-f { color: #c0392b; font-weight: bold; }
-    .ticker-link {
-      color: #3498db;
-      text-decoration: none;
-      border-bottom: 1px dashed #3498db;
-      transition: all 0.2s ease;
-    }
     .ticker-link:hover {
-      color: #2980b9;
+      color: var(--accent);
       border-bottom-style: solid;
-      background-color: rgba(52, 152, 219, 0.1);
+      background-color: var(--accent-soft);
     }
-    .ticker-link:visited {
-      color: #8e44ad;
-      border-bottom-color: #8e44ad;
-    }
+    .ticker-link:visited { color: var(--accent-strong); border-bottom-color: #34d39966; }
+
     .badge {
       display: inline-block;
-      padding: 4px 12px;
-      border-radius: 20px;
-      font-size: 0.8em;
-      font-weight: bold;
+      padding: 3px 11px;
+      border-radius: 999px;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
       margin: 2px;
+      background: #f1f5f9;
+      color: var(--ink-soft);
     }
-    .badge-buy { background: #d5f4e6; color: #27ae60; }
-    .badge-hold { background: #fef9e7; color: #f39c12; }
-    .badge-sell { background: #fadbd8; color: #e74c3c; }
-    .stats-grid {
+    .badge-buy { background: var(--accent-soft); color: var(--accent-strong); }
+    .badge-hold { background: #fef9c3; color: #a16207; }
+    .badge-sell { background: #fee2e2; color: #b91c1c; }
+    .badge-amber {
+      display: inline-block; margin-left: 6px; padding: 2px 9px;
+      border-radius: 999px; font-size: 0.7rem; font-weight: 600;
+      background: #fef3c7; color: #b45309;
+    }
+
+    .stats-grid, .metrics-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 15px;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 14px;
       margin: 20px 0;
     }
-    .stat-card {
-      background: #ecf0f1;
-      padding: 15px;
-      border-radius: 8px;
+    .stat-card, .metric-card {
+      background: #f8fafc;
+      border: 1px solid var(--line);
+      padding: 18px;
+      border-radius: 12px;
       text-align: center;
     }
-    .stat-number {
-      font-size: 2em;
-      font-weight: bold;
-      color: #2c3e50;
+    .metric-card { text-align: left; }
+    .stat-number, .metric-value {
+      font-size: 1.9rem;
+      font-weight: 700;
+      color: var(--ink);
+      font-variant-numeric: tabular-nums;
+      letter-spacing: -0.02em;
+      margin: 0;
     }
+
+    /* Value hero (total portfolio value) */
+    .value-hero {
+      background: linear-gradient(135deg, var(--accent-soft) 0%, #f0fdf9 100%);
+      border: 1px solid #a7f3d0;
+      border-radius: 14px;
+      padding: 26px 28px;
+      margin: 6px 0 8px;
+    }
+    .hero-meta { color: var(--accent-strong); font-size: 0.86rem; font-weight: 600; letter-spacing: 0.01em; }
+    .hero-value {
+      font-size: 2.8rem;
+      font-weight: 800;
+      color: var(--accent-strong);
+      font-variant-numeric: tabular-nums;
+      letter-spacing: -0.03em;
+      line-height: 1.1;
+      margin: 4px 0 6px;
+    }
+    .hero-value.muted { color: var(--muted); }
+    .alloc-note { color: var(--ink-soft); font-size: 0.92rem; margin: 8px 0 0; }
+    .alloc-note code {
+      background: #ffffff; border: 1px solid #a7f3d0; border-radius: 5px;
+      padding: 1px 6px; font-size: 0.86em; color: var(--accent-strong);
+    }
+
+    /* Allocation breakdown rows */
+    .alloc-list { display: flex; flex-direction: column; gap: 6px; }
+    .alloc-row {
+      display: grid;
+      grid-template-columns: minmax(160px, 1.4fr) 2fr auto auto;
+      align-items: center;
+      gap: 16px;
+      padding: 8px 4px;
+      border-bottom: 1px solid var(--line-soft);
+    }
+    .alloc-row:last-child { border-bottom: none; }
+    .alloc-pct { min-width: 56px; font-weight: 600; }
+    .alloc-value { min-width: 88px; color: var(--ink-soft); }
+
+    /* Rounded weight bars */
+    .weight-bar {
+      position: relative;
+      height: 8px;
+      width: 100%;
+      background: var(--line-soft);
+      border-radius: 999px;
+      overflow: hidden;
+    }
+    .weight-bar-sm { height: 6px; max-width: 120px; }
+    .weight-bar-fill {
+      height: 100%;
+      background: linear-gradient(90deg, var(--accent) 0%, var(--accent-strong) 100%);
+      border-radius: 999px;
+      min-width: 2px;
+    }
+
     .highlight {
-      background: #fff3cd;
-      border: 1px solid #ffeaa7;
-      border-radius: 6px;
-      padding: 15px;
-      margin: 15px 0;
+      background: #f8fafc;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 18px 20px;
+      margin: 16px 0;
     }
     .success {
-      background: #d4edda;
-      border: 1px solid #c3e6cb;
-      color: #155724;
+      background: var(--accent-soft);
+      border: 1px solid #a7f3d0;
+      color: var(--accent-strong);
     }
     .warning {
-      background: #fff3cd;
-      border: 1px solid #ffeaa7;
-      color: #856404;
+      background: #fffbeb;
+      border: 1px solid #fde68a;
+      color: #92400e;
     }
     .danger {
-      background: #f8d7da;
-      border: 1px solid #f5c6cb;
-      color: #721c24;
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      color: #991b1b;
     }
     footer {
       margin-top: 40px;
-      padding: 20px;
+      padding: 24px;
       text-align: center;
-      color: #7f8c8d;
-      border-top: 1px solid #ecf0f1;
+      color: var(--muted);
+      border-top: 1px solid var(--line);
     }
     @media (max-width: 768px) {
-      body { padding: 10px; }
-      header { padding: 20px; }
-      h1 { font-size: 1.8em; }
-      .stats-grid { grid-template-columns: 1fr; }
+      body { padding: 12px; }
+      header { padding: 22px; }
+      h1 { font-size: 1.5rem; }
+      .stats-grid, .metrics-grid { grid-template-columns: 1fr; }
+      .hero-value { font-size: 2.1rem; }
+      .alloc-row { grid-template-columns: 1fr auto; row-gap: 6px; }
+      .alloc-row .weight-bar { grid-column: 1 / -1; order: 3; }
+      table { font-size: 0.84rem; }
+      th, td { padding: 9px 8px; }
     }
 
     /* Dark Mode Support */
     @media (prefers-color-scheme: dark) {
-      body {
-        background: #1a1a1a;
-        color: #e0e0e0;
+      :root {
+        --bg: #0b1120;
+        --card: #111827;
+        --ink: #e5e7eb;
+        --ink-soft: #cbd5e1;
+        --muted: #94a3b8;
+        --line: #1f2937;
+        --line-soft: #1e293b;
+        --accent: #34d399;
+        --accent-strong: #6ee7b7;
+        --accent-soft: #0f2a22;
+        --shadow: 0 1px 2px rgba(0,0,0,0.4), 0 8px 24px rgba(0,0,0,0.5);
       }
-      h2 {
-        color: #a8c0db;
-        border-bottom-color: #5a7fa0;
+      header { border-left-color: var(--accent); }
+      th { background: #0f172a; color: var(--muted); }
+      tbody tr:hover { background: #132a23; }
+      .stat-card, .metric-card, .highlight { background: #0f172a; }
+      .badge { background: #1f2937; color: var(--ink-soft); }
+      .badge-buy { background: var(--accent-soft); color: var(--accent-strong); }
+      .badge-hold { background: #3a2f0b; color: #fbbf24; }
+      .badge-sell { background: #3a1414; color: #fca5a5; }
+      .value-hero {
+        background: linear-gradient(135deg, #0f2a22 0%, #0d1f1a 100%);
+        border-color: #14532d;
       }
-      h3 {
-        color: #b8c9da;
-      }
-      .section {
-        background: #2d2d2d;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-      }
-      table {
-        background: #2d2d2d;
-      }
-      th {
-        background: #3a5a7a;
-      }
-      th, td {
-        border-bottom-color: #404040;
-      }
-      .stat-card {
-        background: #383838;
-      }
-      .stat-number {
-        color: #a8c0db;
-      }
-      .muted {
-        color: #999;
-      }
-      .highlight {
-        background: #3d3520;
-        border-color: #5a4d28;
-      }
-      .success {
-        background: #1e3a28;
-        border-color: #2d5a3d;
-        color: #8bc98d;
-      }
-      .warning {
-        background: #3d3520;
-        border-color: #5a4d28;
-        color: #f1c40f;
-      }
-      .danger {
-        background: #3a1f1f;
-        border-color: #5a3030;
-        color: #e79b9b;
-      }
-      footer {
-        color: #999;
-        border-top-color: #404040;
-      }
-      .ticker-link {
-        color: #5dade2;
-        border-bottom-color: #5dade2;
-      }
-      .ticker-link:hover {
-        color: #85c1e9;
-        background-color: rgba(93, 173, 226, 0.15);
-      }
-      .ticker-link:visited {
-        color: #bb8fce;
-        border-bottom-color: #bb8fce;
-      }
+      .hero-value, .hero-meta { color: var(--accent-strong); }
+      .alloc-note code { background: #0f172a; border-color: #14532d; color: var(--accent-strong); }
+      .weight-bar { background: #1e293b; }
+      .success { background: var(--accent-soft); border-color: #14532d; color: var(--accent-strong); }
+      .warning { background: #3a2f0b; border-color: #5a4d10; color: #fcd34d; }
+      .danger { background: #3a1414; border-color: #5a2020; color: #fca5a5; }
+      footer { border-top-color: var(--line); }
+      .ticker-link { color: var(--accent-strong); border-bottom-color: #34d39966; }
+      .ticker-link:hover { color: var(--accent); background-color: var(--accent-soft); }
     }
 
     /* Traffic-light indicators (Phase 16) */
@@ -230,27 +315,27 @@ def get_report_css() -> str:
     .fear-greed-value { text-align: center; font-size: 2em; font-weight: 700; margin-bottom: 5px; }
 
     /* Macro dashboard grid (Phase 16) */
-    .macro-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; margin-bottom: 20px; }
-    .macro-card { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 15px; text-align: center; }
-    .macro-card h4 { margin: 0 0 8px 0; color: #475569; font-size: 0.9em; }
-    .macro-value { font-size: 1.5em; font-weight: 700; margin: 5px 0; }
+    .macro-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-bottom: 20px; }
+    .macro-card { background: #f8fafc; border: 1px solid var(--line); border-radius: 12px; padding: 16px; text-align: center; }
+    .macro-card h4 { margin: 0 0 8px 0; color: var(--muted); font-size: 0.9em; }
+    .macro-value { font-size: 1.5em; font-weight: 700; margin: 5px 0; color: var(--ink); font-variant-numeric: tabular-nums; }
 
     /* Economic calendar table (Phase 16) */
     .calendar-table { width: 100%; border-collapse: collapse; margin: 15px 0; }
-    .calendar-table th { background: #f1f5f9; padding: 10px; text-align: left; border-bottom: 2px solid #cbd5e1; color: #334155; }
-    .calendar-table td { padding: 8px 10px; border-bottom: 1px solid #e2e8f0; }
-    .calendar-table tr:hover { background: #f8fafc; }
+    .calendar-table th { background: #f8fafc; padding: 11px 14px; text-align: left; border-bottom: 1px solid var(--line); color: var(--muted); text-transform: uppercase; font-size: 0.72rem; letter-spacing: 0.06em; }
+    .calendar-table td { padding: 10px 14px; border-bottom: 1px solid var(--line-soft); }
+    .calendar-table tr:hover { background: var(--accent-soft); }
 
     @media (max-width: 768px) {
       .macro-grid { grid-template-columns: 1fr; }
     }
 
     @media (prefers-color-scheme: dark) {
-      .macro-card { background: #383838; border-color: #404040; }
-      .macro-card h4 { color: #b8c9da; }
-      .calendar-table th { background: #3a5a7a; color: #e0e0e0; border-bottom-color: #5a7fa0; }
-      .calendar-table td { border-bottom-color: #404040; }
-      .calendar-table tr:hover { background: #333; }
-      .fear-greed-marker { background: #e0e0e0; }
+      .macro-card { background: #0f172a; border-color: var(--line); }
+      .macro-card h4 { color: var(--muted); }
+      .calendar-table th { background: #0f172a; color: var(--muted); border-bottom-color: var(--line); }
+      .calendar-table td { border-bottom-color: var(--line-soft); }
+      .calendar-table tr:hover { background: #132a23; }
+      .fear-greed-marker { background: var(--ink); }
     }
         """

--- a/src/finwiz/reporting/python_report_generator.py
+++ b/src/finwiz/reporting/python_report_generator.py
@@ -283,6 +283,8 @@ class PythonReportGenerator:
 
   {self._generate_executive_summary(portfolio_stats, trust_banner_html=trust_banner_html)}
 
+  {self._generate_allocation_section(portfolio_review)}
+
   {self._generate_strategic_posture_section(portfolio_strategic_posture)}
 
   {self._generate_macro_dashboard_section(macro_snapshot)}
@@ -331,6 +333,12 @@ class PythonReportGenerator:
         from finwiz.reporting.section_generators import generate_executive_summary
 
         return generate_executive_summary(portfolio_stats, trust_banner_html=trust_banner_html)
+
+    def _generate_allocation_section(self, portfolio_review: PortfolioReview) -> str:
+        """Generate the EUR allocation hero + weight breakdown (delegates to module)."""
+        from finwiz.reporting.section_generators import generate_allocation_section
+
+        return generate_allocation_section(portfolio_review)
 
     def _generate_portfolio_overview(self, portfolio_review: PortfolioReview, portfolio_stats: dict[str, Any]) -> str:
         """Generate portfolio overview section (delegates to module)."""

--- a/src/finwiz/reporting/section_generators.py
+++ b/src/finwiz/reporting/section_generators.py
@@ -36,6 +36,7 @@ from finwiz.reporting.sections.macro import (
     generate_macro_dashboard_section,
 )
 from finwiz.reporting.sections.portfolio_summary import (
+    generate_allocation_section,
     generate_executive_summary,
     generate_portfolio_overview,
     generate_strategic_posture_section,
@@ -47,6 +48,7 @@ __all__ = [
     "_fact_pack_provenance_footer",
     "_get_recommendation_badge",
     "_render_holding_row",
+    "generate_allocation_section",
     "generate_cost_summary_section",
     "generate_deep_analysis_section",
     "generate_discovery_section",

--- a/src/finwiz/reporting/sections/holdings.py
+++ b/src/finwiz/reporting/sections/holdings.py
@@ -6,7 +6,17 @@ from html import escape
 from typing import Any
 
 from finwiz.reporting.sections.factpack import _fact_pack_provenance_footer
+from finwiz.reporting.sections.portfolio_summary import _fmt_eur
 from finwiz.schemas.portfolio_review import HoldingDecision
+
+
+def _weight_cell(holding: HoldingDecision) -> str:
+    """Render the 'Poids' cell: a compact weight-bar + percent, or '—' when unknown."""
+    weight = holding.weight
+    if weight is None:
+        return '<td class="muted">—</td>'
+    pct = weight * 100
+    return f'<td class="num"><div class="weight-bar weight-bar-sm"><div class="weight-bar-fill" style="width: {pct:.1f}%"></div></div><small>{pct:.1f}%</small></td>'
 
 
 def _get_recommendation_badge(grade: str, recommended_action: str | None) -> str:
@@ -112,6 +122,8 @@ def _render_holding_row(holding: HoldingDecision) -> str:
           <td>{ticker_plain_html}<br><small>{name_safe}</small></td>
           <td>{asset_class}</td>
           <td class="grade-na" title="Deep analysis did not run for this holding"><strong>⏳ Analyse en attente</strong></td>
+          {_weight_cell(holding)}
+          <td class="num muted">{_fmt_eur(holding.eur_value)}</td>
           <td class="muted">—</td>
           <td class="muted">—</td>
           <td><small class="muted">{pending_msg_safe}</small></td>
@@ -139,6 +151,8 @@ def _render_holding_row(holding: HoldingDecision) -> str:
           <td><strong>{ticker_html}</strong><br><small>{name_safe}</small></td>
           <td>{asset_class}</td>
           <td class="{grade_class}"><strong>{grade}</strong>{badge}</td>
+          {_weight_cell(holding)}
+          <td class="num">{_fmt_eur(holding.eur_value)}</td>
           <td>{composite_score:.3f}</td>
           <td>{rec_badge}</td>
           <td><small>{rationale_safe}</small>{fact_pack_footer}</td>
@@ -167,6 +181,8 @@ def generate_holdings_analysis(holdings: list[HoldingDecision]) -> str:
           <th>Ticker / Name</th>
           <th>Class</th>
           <th>Grade</th>
+          <th>Poids</th>
+          <th>Valeur (€)</th>
           <th>Score</th>
           <th>Recommendation</th>
           <th>Rationale</th>

--- a/src/finwiz/reporting/sections/portfolio_summary.py
+++ b/src/finwiz/reporting/sections/portfolio_summary.py
@@ -8,6 +8,84 @@ from typing import Any
 from finwiz.schemas.portfolio_review import PortfolioReview
 
 
+def _fmt_eur(value: float | None) -> str:
+    """Format a EUR amount French-style: space-grouped thousands + euro sign.
+
+    ``None`` → ``"—"`` (never "None"/"0 €") so the UI degrades gracefully when
+    no CSV Quantity resolved. Example: ``53772.0`` → ``"53 772 €"``.
+    """
+    if value is None:
+        return "—"
+    # Round to whole euros, group thousands with a plain space (French convention).
+    grouped = f"{round(value):,}".replace(",", " ")
+    return f"{grouped} €"
+
+
+def generate_allocation_section(portfolio_review: PortfolioReview) -> str:
+    """Render the EUR allocation hero + per-holding weight breakdown.
+
+    Surfaces the already-serialized ``total_value_eur`` and per-holding
+    ``weight`` / ``eur_value`` data. Degrades gracefully: when nothing could be
+    priced (no CSV Quantity), renders the hero shell with a French info note
+    instead of numbers — never "0 €" / "None".
+    """
+    total = portfolio_review.total_value_eur
+    weighted = [h for h in portfolio_review.holdings if h.weight is not None]
+
+    # Graceful path: no priced total or no weighted holding → tasteful info note.
+    if total is None or not weighted:
+        return (
+            """
+  <div class="section">
+    <h2>💰 Allocation du portefeuille</h2>
+    <div class="value-hero">
+      <div class="hero-meta">Valeur totale du portefeuille</div>
+      <div class="hero-value muted">—</div>
+      <p class="alloc-note">💡 Renseignez la colonne <code>Quantity</code> de vos fichiers """
+            + """<code>data/*.csv</code> puis relancez l'analyse pour visualiser l'allocation en euros.</p>
+    </div>
+  </div>
+"""
+        )
+
+    n_positions = len(portfolio_review.holdings)
+    n_classes = len({h.asset_class for h in weighted})
+
+    # Sort by weight desc so the largest exposure leads.
+    rows = sorted(weighted, key=lambda h: h.weight or 0.0, reverse=True)
+    alloc_rows = []
+    for h in rows:
+        pct = (h.weight or 0.0) * 100
+        name_safe = escape(h.name or "Unknown")
+        ticker_safe = escape(h.ticker or "—")
+        alloc_rows.append(
+            f"""
+      <div class="alloc-row">
+        <div class="alloc-label"><strong>{ticker_safe}</strong> <span class="muted small">{name_safe}</span></div>
+        <div class="weight-bar"><div class="weight-bar-fill" style="width: {pct:.1f}%"></div></div>
+        <div class="alloc-pct num">{pct:.1f}%</div>
+        <div class="alloc-value num">{_fmt_eur(h.eur_value)}</div>
+      </div>"""
+        )
+    alloc_html = "".join(alloc_rows)
+
+    return f"""
+  <div class="section">
+    <h2>💰 Allocation du portefeuille</h2>
+    <div class="value-hero">
+      <div class="hero-meta">Valeur totale du portefeuille</div>
+      <div class="hero-value num">{_fmt_eur(total)}</div>
+      <div class="hero-meta">{n_positions} positions · {n_classes} classes d'actifs</div>
+    </div>
+
+    <h3>📊 Répartition par position</h3>
+    <div class="alloc-list">
+      {alloc_html}
+    </div>
+  </div>
+"""
+
+
 def generate_strategic_posture_section(posture: dict | None) -> str:
     """Render the portfolio-wide strategic posture (PESTEL/SWOT/Porter synthesis).
 

--- a/src/finwiz/schemas/portfolio_processing.py
+++ b/src/finwiz/schemas/portfolio_processing.py
@@ -24,6 +24,7 @@ class RawHolding:
     currency: str
     source_file: str
     line_number: int
+    quantity: float | None = None
 
 
 @dataclass

--- a/src/finwiz/schemas/portfolio_review.py
+++ b/src/finwiz/schemas/portfolio_review.py
@@ -180,6 +180,14 @@ class HoldingDecision(BaseModel):
     # 'low' when the upstream qualify stage degraded to a Python fallback (DEGRADED).
     confidence: Literal["high", "low"] = Field(default="high", description="Pipeline confidence: 'low' when qualify stage degraded to Python fallback")
 
+    # Allocation/valuation (deterministic Python; see scoring/portfolio_valuation.py).
+    # All optional — populated only when a CSV Quantity and live price/FX resolve.
+    quantity: float | None = Field(default=None, description="Position size (units/shares) from the CSV")
+    native_currency: str | None = Field(default=None, description="Authoritative quote currency from the price API")
+    native_value: float | None = Field(default=None, description="quantity * native price, in native currency")
+    eur_value: float | None = Field(default=None, description="native_value converted to EUR via live FX")
+    weight: float | None = Field(default=None, ge=0.0, le=1.0, description="Share of total EUR portfolio value (0..1)")
+
 
 class APlusOpportunitySection(BaseModel):
     """A+ opportunities section for portfolio review reports."""
@@ -213,6 +221,7 @@ class PortfolioReview(BaseModel):
     as_of: datetime
     base_currency: str = "CHF"
     holdings: list[HoldingDecision] = Field(default_factory=list)
+    total_value_eur: float | None = Field(default=None, description="Sum of holdings' eur_value (priced holdings only); None when nothing could be priced")
 
     # A+ opportunities integration
     a_plus_opportunities: APlusOpportunitySection = Field(

--- a/src/finwiz/schemas/portfolio_valuation.py
+++ b/src/finwiz/schemas/portfolio_valuation.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class HoldingValuation(BaseModel):
     """Per-holding valuation output. All money fields optional (graceful degradation)."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
     ticker: str
     quantity: float | None = None
@@ -25,7 +25,7 @@ class HoldingValuation(BaseModel):
 class ValuationResult(BaseModel):
     """Portfolio-level valuation: per-ticker breakdown, total EUR, coverage."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
     per_ticker: dict[str, HoldingValuation] = Field(default_factory=dict)
     total_value_eur: float | None = None

--- a/src/finwiz/schemas/portfolio_valuation.py
+++ b/src/finwiz/schemas/portfolio_valuation.py
@@ -1,0 +1,34 @@
+"""Result models for deterministic portfolio valuation.
+
+Produced by `finwiz.scoring.portfolio_valuation.value_holdings`. Pure data —
+no AI, no network. Models live here per the schemas-in-`schemas/` rule.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class HoldingValuation(BaseModel):
+    """Per-holding valuation output. All money fields optional (graceful degradation)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ticker: str
+    quantity: float | None = None
+    native_currency: str | None = None
+    native_value: float | None = None
+    eur_value: float | None = None
+    weight: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class ValuationResult(BaseModel):
+    """Portfolio-level valuation: per-ticker breakdown, total EUR, coverage."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    per_ticker: dict[str, HoldingValuation] = Field(default_factory=dict)
+    total_value_eur: float | None = None
+    priced_count: int = 0
+    total_count: int = 0
+    coverage_note: str = ""

--- a/src/finwiz/scoring/portfolio_valuation.py
+++ b/src/finwiz/scoring/portfolio_valuation.py
@@ -35,18 +35,17 @@ def value_holdings(
     compute native_value = quantity * price, convert to base via fx_fn(native_ccy).
     Holdings missing quantity/price/FX get weight=None and are excluded from the
     base total. Weights are eur_value / total over the holdings that fully resolved.
+
+    `fx_fn` is expected to already convert a native amount into `base`; `base` is
+    not threaded into `fx_fn`. Duplicate tickers collapse last-write-wins.
     """
     per_ticker: dict[str, HoldingValuation] = {}
-    total = 0.0
-    priced = 0
-    total_count = 0
 
     for holding in holdings:
-        total_count += 1
         ticker = holding.ticker
         quantity = holding.quantity
         hv = HoldingValuation(ticker=ticker, quantity=quantity)
-        per_ticker[ticker] = hv
+        per_ticker[ticker] = hv  # duplicate tickers collapse last-write-wins
 
         if quantity is None:
             continue
@@ -64,17 +63,21 @@ def value_holdings(
             continue
 
         hv.eur_value = hv.native_value * rate
-        total += hv.eur_value
-        priced += 1
 
-    total_eur = total if priced > 0 else None
-    if total_eur and total_eur > 0:
-        for hv in per_ticker.values():
-            if hv.eur_value is not None:
-                hv.weight = hv.eur_value / total_eur
+    # Derive aggregates from the final per_ticker map (not from a running sum in the
+    # loop), so duplicate tickers — which collapse last-write-wins above — stay
+    # internally consistent: the total never double-counts a repeated ticker.
+    resolved = [hv for hv in per_ticker.values() if hv.eur_value is not None]
+    total_eur = sum(hv.eur_value or 0.0 for hv in resolved) if resolved else None
+    priced = len(resolved)
+    total_count = len(per_ticker)
+
+    if total_eur is not None and total_eur > 0.0:
+        for hv in resolved:
+            hv.weight = (hv.eur_value or 0.0) / total_eur
 
     pct = (priced / total_count * 100.0) if total_count else 0.0
-    note = f"{priced} of {total_count} holdings priced; {pct:.0f}% of holdings by count weighted"
+    note = f"{priced} of {total_count} holdings priced ({pct:.0f}% by count)"
 
     return ValuationResult(
         per_ticker=per_ticker,

--- a/src/finwiz/scoring/portfolio_valuation.py
+++ b/src/finwiz/scoring/portfolio_valuation.py
@@ -1,0 +1,85 @@
+"""Pure deterministic portfolio valuation: quantities + price/FX -> EUR weights.
+
+No AI, no network — `price_fn` and `fx_fn` are injected for testability and are
+the only I/O boundaries. AI Minimalism: when Python can compute it, Python does.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Protocol
+
+from finwiz.schemas.portfolio_valuation import HoldingValuation, ValuationResult
+
+# price_fn(ticker) -> (price, native_currency) or None when unavailable.
+PriceFn = Callable[[str], tuple[float, str] | None]
+# fx_fn(native_currency) -> rate to multiply by for the base currency, or None.
+FxFn = Callable[[str], float | None]
+
+
+class _HasTickerQuantity(Protocol):
+    ticker: str
+    quantity: float | None
+
+
+def value_holdings(
+    holdings: Iterable[_HasTickerQuantity],
+    *,
+    base: str = "EUR",
+    price_fn: PriceFn,
+    fx_fn: FxFn,
+) -> ValuationResult:
+    """Value each holding and compute portfolio weights.
+
+    For each holding WITH a quantity: resolve (price, native_ccy) via price_fn,
+    compute native_value = quantity * price, convert to base via fx_fn(native_ccy).
+    Holdings missing quantity/price/FX get weight=None and are excluded from the
+    base total. Weights are eur_value / total over the holdings that fully resolved.
+    """
+    per_ticker: dict[str, HoldingValuation] = {}
+    total = 0.0
+    priced = 0
+    total_count = 0
+
+    for holding in holdings:
+        total_count += 1
+        ticker = holding.ticker
+        quantity = holding.quantity
+        hv = HoldingValuation(ticker=ticker, quantity=quantity)
+        per_ticker[ticker] = hv
+
+        if quantity is None:
+            continue
+
+        priced_pair = price_fn(ticker)
+        if priced_pair is None:
+            continue
+
+        price, native_ccy = priced_pair
+        hv.native_currency = native_ccy
+        hv.native_value = quantity * price
+
+        rate = fx_fn(native_ccy)
+        if rate is None:
+            continue
+
+        hv.eur_value = hv.native_value * rate
+        total += hv.eur_value
+        priced += 1
+
+    total_eur = total if priced > 0 else None
+    if total_eur and total_eur > 0:
+        for hv in per_ticker.values():
+            if hv.eur_value is not None:
+                hv.weight = hv.eur_value / total_eur
+
+    pct = (priced / total_count * 100.0) if total_count else 0.0
+    note = f"{priced} of {total_count} holdings priced; {pct:.0f}% of holdings by count weighted"
+
+    return ValuationResult(
+        per_ticker=per_ticker,
+        total_value_eur=total_eur,
+        priced_count=priced,
+        total_count=total_count,
+        coverage_note=note,
+    )

--- a/tests/integration/test_fx_rates_live.py
+++ b/tests/integration/test_fx_rates_live.py
@@ -1,0 +1,14 @@
+"""Live network test for the FX provider. Excluded from default `make test`."""
+
+import pytest
+
+from finwiz.data import fx_rates
+
+
+@pytest.mark.integration
+def test_live_chf_eur_rate_is_plausible():
+    fx_rates.clear_fx_cache()
+    rate = fx_rates.get_fx_rate("CHF", "EUR")
+
+    assert rate is not None
+    assert 0.5 < rate < 2.0  # sanity band, not a precise assertion

--- a/tests/unit/data/test_fx_rates.py
+++ b/tests/unit/data/test_fx_rates.py
@@ -1,0 +1,57 @@
+"""Unit tests for the live FX provider (network mocked)."""
+
+import pytest
+
+from finwiz.data import fx_rates
+
+
+@pytest.fixture(autouse=True)
+def _reset_fx_cache():
+    """Each test starts with an empty per-run FX cache."""
+    fx_rates.clear_fx_cache()
+    yield
+    fx_rates.clear_fx_cache()
+
+
+def test_identity_rate_is_one_without_network(mocker):
+    spy = mocker.patch("finwiz.data.fx_rates._fetch_pair_rate")
+
+    assert fx_rates.get_fx_rate("EUR", "EUR") == 1.0
+    spy.assert_not_called()
+
+
+def test_simple_pair_lookup(mocker):
+    mocker.patch("finwiz.data.fx_rates._fetch_pair_rate", return_value=0.92)
+
+    assert fx_rates.get_fx_rate("CHF", "EUR") == 0.92
+
+
+def test_gbp_pence_divided_by_100(mocker):
+    # GBPEUR is ~1.17; a GBp (pence) amount must convert at rate/100.
+    mocker.patch("finwiz.data.fx_rates._fetch_pair_rate", return_value=1.17)
+
+    rate = fx_rates.get_fx_rate("GBp", "EUR")
+
+    assert rate == pytest.approx(0.0117)
+
+
+def test_failure_returns_none(mocker):
+    mocker.patch("finwiz.data.fx_rates._fetch_pair_rate", return_value=None)
+
+    assert fx_rates.get_fx_rate("CHF", "EUR") is None
+
+
+def test_per_run_cache_hits_once(mocker):
+    spy = mocker.patch("finwiz.data.fx_rates._fetch_pair_rate", return_value=0.92)
+
+    fx_rates.get_fx_rate("CHF", "EUR")
+    fx_rates.get_fx_rate("CHF", "EUR")
+
+    spy.assert_called_once()
+
+
+def test_blank_currency_returns_none(mocker):
+    spy = mocker.patch("finwiz.data.fx_rates._fetch_pair_rate")
+
+    assert fx_rates.get_fx_rate("", "EUR") is None
+    spy.assert_not_called()

--- a/tests/unit/data/test_fx_rates.py
+++ b/tests/unit/data/test_fx_rates.py
@@ -35,6 +35,13 @@ def test_gbp_pence_divided_by_100(mocker):
     assert rate == pytest.approx(0.0117)
 
 
+def test_gbp_pence_to_gbp_is_0_01(mocker):
+    spy = mocker.patch("finwiz.data.fx_rates._fetch_pair_rate")
+
+    assert fx_rates.get_fx_rate("GBp", "GBP") == pytest.approx(0.01)
+    spy.assert_not_called()  # identity path: 1 pence = 0.01 GBP, no fetch
+
+
 def test_failure_returns_none(mocker):
     mocker.patch("finwiz.data.fx_rates._fetch_pair_rate", return_value=None)
 

--- a/tests/unit/orchestrators/test_portfolio_holdings_processor.py
+++ b/tests/unit/orchestrators/test_portfolio_holdings_processor.py
@@ -528,3 +528,64 @@ class TestPortfolioHoldingsProcessor:
 
         # Assert
         assert len(holdings) == 0
+
+
+class TestQuantityIngestion:
+    """CSV `Quantity` column parsing into RawHolding.quantity."""
+
+    def test_parses_valid_quantity(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "stock.csv"
+        csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,Yahoo:AAPL,USD,true,10.5\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "stock")
+
+        assert len(holdings) == 1
+        assert holdings[0].quantity == 10.5
+
+    def test_blank_quantity_is_none(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "stock.csv"
+        csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,Yahoo:AAPL,USD,true,\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "stock")
+
+        assert holdings[0].quantity is None
+
+    def test_garbage_quantity_is_none(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "stock.csv"
+        csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,Yahoo:AAPL,USD,true,abc\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "stock")
+
+        assert holdings[0].quantity is None
+
+    def test_missing_quantity_column_is_none(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "stock.csv"
+        csv.write_text("Name,Ticker,Currency,Active\nApple,Yahoo:AAPL,USD,true\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "stock")
+
+        assert holdings[0].quantity is None
+
+    def test_crypto_quantity_parsed(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        csv = tmp_path / "crypto.csv"
+        csv.write_text("Name,Ticker,Active,Quantity\nBitcoin,BTC,true,0.25\n")
+        processor = PortfolioHoldingsProcessor()
+
+        holdings = processor._read_csv_holdings(csv, "crypto")
+
+        assert holdings[0].quantity == 0.25
+        assert holdings[0].ticker == "BTC-USD"  # crypto normalization still applies

--- a/tests/unit/orchestrators/test_portfolio_holdings_processor.py
+++ b/tests/unit/orchestrators/test_portfolio_holdings_processor.py
@@ -589,3 +589,15 @@ class TestQuantityIngestion:
 
         assert holdings[0].quantity == 0.25
         assert holdings[0].ticker == "BTC-USD"  # crypto normalization still applies
+
+    def test_non_finite_quantity_is_none(self, tmp_path):
+        from finwiz.orchestrators.portfolio_holdings_processor import PortfolioHoldingsProcessor
+
+        for bad in ("inf", "-inf", "nan"):
+            csv = tmp_path / "stock.csv"
+            csv.write_text(f"Name,Ticker,Currency,Active,Quantity\nApple,Yahoo:AAPL,USD,true,{bad}\n")
+            processor = PortfolioHoldingsProcessor()
+
+            holdings = processor._read_csv_holdings(csv, "stock")
+
+            assert holdings[0].quantity is None, f"{bad!r} should parse to None"

--- a/tests/unit/orchestrators/test_portfolio_review.py
+++ b/tests/unit/orchestrators/test_portfolio_review.py
@@ -5,6 +5,8 @@ Unit tests for portfolio review orchestrator.
 import json
 from pathlib import Path
 
+import pytest
+
 from finwiz.orchestrators.portfolio_review_orchestrator import (
     build_portfolio_review,
     get_csv_paths,
@@ -216,3 +218,92 @@ class TestPortfolioReview:
         assert "etf.csv" in str(etf_csv)
         assert "stock.csv" in str(stock_csv)
         assert "crypto.csv" in str(crypto_csv)
+
+
+class TestAllocationWiring:
+    """build_portfolio_review stamps weights and total_value_eur when quantities exist."""
+
+    async def test_weights_stamped_from_quantities(self, tmp_path, mocker):
+        stock_csv = tmp_path / "stock.csv"
+        stock_csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,AAPL,USD,true,10\nMicrosoft,MSFT,USD,true,10\n")
+
+        mock_validator = mocker.patch("finwiz.orchestrators.portfolio_holdings_processor.TickerExistenceValidationTool")
+        mock_validator.return_value._run.return_value = {"valid": True, "meta": {"source": "yahoo"}}
+
+        from finwiz.schemas.rebalancing.core import PriceData
+
+        async def fake_get_current_prices(symbols):
+            return {s: PriceData(symbol=s, price=100.0, currency="EUR") for s in symbols}
+
+        price_service = mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.PortfolioPriceService")
+        price_service.return_value.get_current_prices = fake_get_current_prices
+
+        mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.get_fx_rate", return_value=1.0)
+
+        review, _summary = await build_portfolio_review(stock_csv=stock_csv)
+
+        weights = {h.ticker: h.weight for h in review.holdings}
+        assert weights["AAPL"] == pytest.approx(0.5)
+        assert weights["MSFT"] == pytest.approx(0.5)
+        assert review.total_value_eur == pytest.approx(2000.0)
+        aapl = next(h for h in review.holdings if h.ticker == "AAPL")
+        assert aapl.quantity == 10.0
+        assert aapl.eur_value == pytest.approx(1000.0)
+
+    async def test_no_quantities_means_no_price_fetch_and_none_weights(self, tmp_path, mocker):
+        stock_csv = tmp_path / "stock.csv"
+        stock_csv.write_text("Name,Ticker,Currency,Active\nApple,AAPL,USD,true\n")
+
+        mock_validator = mocker.patch("finwiz.orchestrators.portfolio_holdings_processor.TickerExistenceValidationTool")
+        mock_validator.return_value._run.return_value = {"valid": True, "meta": {"source": "yahoo"}}
+
+        price_service = mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.PortfolioPriceService")
+
+        review, _summary = await build_portfolio_review(stock_csv=stock_csv)
+
+        price_service.assert_not_called()
+        assert review.holdings[0].weight is None
+        assert review.total_value_eur is None
+
+    async def test_valuation_failure_is_graceful(self, tmp_path, mocker):
+        stock_csv = tmp_path / "stock.csv"
+        stock_csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,AAPL,USD,true,10\n")
+
+        mock_validator = mocker.patch("finwiz.orchestrators.portfolio_holdings_processor.TickerExistenceValidationTool")
+        mock_validator.return_value._run.return_value = {"valid": True, "meta": {"source": "yahoo"}}
+
+        price_service = mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.PortfolioPriceService")
+        price_service.return_value.get_current_prices = mocker.AsyncMock(side_effect=RuntimeError("boom"))
+
+        review, _summary = await build_portfolio_review(stock_csv=stock_csv)
+
+        assert len(review.holdings) == 1
+        assert review.holdings[0].weight is None
+        assert review.total_value_eur is None
+
+    async def test_partial_pricing_unpriced_holding_has_none_weight(self, tmp_path, mocker):
+        stock_csv = tmp_path / "stock.csv"
+        stock_csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,AAPL,USD,true,10\nMicrosoft,MSFT,USD,true,10\n")
+
+        mock_validator = mocker.patch("finwiz.orchestrators.portfolio_holdings_processor.TickerExistenceValidationTool")
+        mock_validator.return_value._run.return_value = {"valid": True, "meta": {"source": "yahoo"}}
+
+        from finwiz.schemas.rebalancing.core import PriceData
+
+        async def fake_get_current_prices(symbols):
+            return {"AAPL": PriceData(symbol="AAPL", price=100.0, currency="EUR")}
+
+        price_service = mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.PortfolioPriceService")
+        price_service.return_value.get_current_prices = fake_get_current_prices
+
+        mocker.patch("finwiz.orchestrators.portfolio_review_orchestrator.get_fx_rate", return_value=1.0)
+
+        review, _summary = await build_portfolio_review(stock_csv=stock_csv)
+
+        aapl = next(h for h in review.holdings if h.ticker == "AAPL")
+        msft = next(h for h in review.holdings if h.ticker == "MSFT")
+
+        assert msft.weight is None
+        assert msft.eur_value is None
+        assert aapl.weight == pytest.approx(1.0)
+        assert review.total_value_eur == pytest.approx(aapl.eur_value)

--- a/tests/unit/reporting/test_allocation_rendering.py
+++ b/tests/unit/reporting/test_allocation_rendering.py
@@ -1,0 +1,157 @@
+"""Tests for the EUR allocation hero + holdings allocation columns (modern-fintech redesign).
+
+Covers the newly surfaced per-holding ``weight`` / ``eur_value`` data and the
+portfolio ``total_value_eur`` hero, including the graceful "no Quantity" path.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from finwiz.reporting.sections.holdings import generate_holdings_analysis
+from finwiz.reporting.sections.portfolio_summary import (
+    _fmt_eur,
+    generate_allocation_section,
+)
+from finwiz.schemas.common import RiskAssessmentStandardized
+from finwiz.schemas.portfolio_review import HoldingDecision, PortfolioReview
+
+
+def _make_risk() -> RiskAssessmentStandardized:
+    return RiskAssessmentStandardized(score=2.5, level="Medium")
+
+
+def _make_holding(
+    ticker: str = "TEST",
+    name: str = "Test Company",
+    asset_class: str = "stock",
+    grade: str = "B",
+    composite_score: float = 0.7,
+    weight: float | None = None,
+    eur_value: float | None = None,
+    native_currency: str | None = None,
+) -> HoldingDecision:
+    return HoldingDecision(
+        ticker=ticker,
+        name=name,
+        asset_class=asset_class,
+        currency="USD",
+        decision="KEEP",
+        composite_score=composite_score,
+        grade=grade,
+        grade_description=f"Grade {grade} holding",
+        recommended_action="HOLD",
+        risk=_make_risk(),
+        rationale_bullets=["Solid fundamentals"],
+        weight=weight,
+        eur_value=eur_value,
+        native_currency=native_currency,
+    )
+
+
+def _weighted_review() -> PortfolioReview:
+    holdings = [
+        _make_holding("AAPL", "Apple Inc.", "stock", "A", 0.82, weight=0.3742, eur_value=20120.0, native_currency="USD"),
+        _make_holding("MSFT", "Microsoft Corp.", "stock", "A", 0.80, weight=0.25, eur_value=13443.0, native_currency="USD"),
+        _make_holding("VWCE", "Vanguard FTSE All-World", "etf", "B", 0.70, weight=0.20, eur_value=10754.4, native_currency="EUR"),
+        _make_holding("SAP", "SAP SE", "stock", "B", 0.68, weight=0.10, eur_value=5377.2, native_currency="EUR"),
+        _make_holding("BTC-USD", "Bitcoin", "crypto", "C", 0.55, weight=0.0758, eur_value=4077.4, native_currency="USD"),
+    ]
+    return PortfolioReview(as_of=datetime.now(), holdings=holdings, total_value_eur=53772.0)
+
+
+def _bare_review() -> PortfolioReview:
+    holdings = [
+        _make_holding("AAPL", "Apple Inc.", "stock", "A", 0.82),
+        _make_holding("MSFT", "Microsoft Corp.", "stock", "A", 0.80),
+    ]
+    return PortfolioReview(as_of=datetime.now(), holdings=holdings, total_value_eur=None)
+
+
+class TestFmtEur:
+    def test_formats_with_space_thousands_and_euro(self) -> None:
+        out = _fmt_eur(53772.0)
+        assert "53 772 €" == out
+
+    def test_smaller_value(self) -> None:
+        assert _fmt_eur(4077.4) == "4 077 €"
+
+    def test_none_returns_dash(self) -> None:
+        assert _fmt_eur(None) == "—"
+
+
+class TestGenerateAllocationSection:
+    def test_renders_hero_total(self) -> None:
+        html = generate_allocation_section(_weighted_review())
+        assert "value-hero" in html
+        assert "Valeur totale du portefeuille" in html
+        # The formatted total must appear (digits + euro sign).
+        assert "53 772 €" in html
+        # Meta line: number of positions + asset classes.
+        assert "5 positions" in html
+
+    def test_weight_bars_present_and_top_holding_widest(self) -> None:
+        html = generate_allocation_section(_weighted_review())
+        assert "weight-bar" in html
+        assert "weight-bar-fill" in html
+        # Top holding is AAPL at 0.3742 -> 37.4% fill width.
+        assert "width: 37.4%" in html
+        # eur values present
+        assert "20 120 €" in html
+
+    def test_holdings_sorted_by_weight_desc(self) -> None:
+        html = generate_allocation_section(_weighted_review())
+        # AAPL (37.4%) must appear before MSFT (25%) which appears before BTC (7.6%).
+        assert html.index("AAPL") < html.index("MSFT") < html.index("BTC-USD")
+
+    def test_graceful_when_no_total_or_weights(self) -> None:
+        html = generate_allocation_section(_bare_review())
+        # French info note mentioning the Quantity column.
+        assert "Quantity" in html
+        # No "None" or "0 €" leak.
+        assert "None" not in html
+        assert "0 €" not in html
+        # Hero shell still rendered.
+        assert "value-hero" in html
+
+    def test_no_none_leak_in_weighted_path(self) -> None:
+        html = generate_allocation_section(_weighted_review())
+        assert "None" not in html
+
+
+class TestHoldingsAllocationColumns:
+    def test_weighted_holdings_show_poids_and_valeur(self) -> None:
+        html = generate_holdings_analysis(_weighted_review().holdings)
+        assert "Poids" in html
+        assert "Valeur (€)" in html
+        # Weight bar in the table + eur value.
+        assert "weight-bar" in html
+        assert "20 120 €" in html
+
+    def test_none_allocation_renders_dash(self) -> None:
+        holding = _make_holding("ZZZ", "No Alloc Co", grade="B", weight=None, eur_value=None)
+        html = generate_holdings_analysis([holding])
+        assert "—" in html
+        assert "None" not in html
+
+    def test_thead_and_tbody_column_counts_match(self) -> None:
+        review = _weighted_review()
+        html = generate_holdings_analysis(review.holdings)
+        # Count <th> in the (single) header row.
+        thead = html.split("<thead>")[1].split("</thead>")[0]
+        n_th = thead.count("<th>")
+        # First data row in tbody.
+        tbody = html.split("<tbody>")[1].split("</tbody>")[0]
+        first_row = tbody.split("</tr>")[0]
+        n_td = first_row.count("<td")
+        assert n_th == n_td, f"header cols {n_th} != row cols {n_td}"
+
+    def test_pending_row_column_count_matches_header(self) -> None:
+        pending = _make_holding("PEND", "Pending Co", grade="N/A", composite_score=0.0)
+        html = generate_holdings_analysis([pending])
+        thead = html.split("<thead>")[1].split("</thead>")[0]
+        n_th = thead.count("<th>")
+        tbody = html.split("<tbody>")[1].split("</tbody>")[0]
+        first_row = tbody.split("</tr>")[0]
+        n_td = first_row.count("<td")
+        assert n_th == n_td, f"header cols {n_th} != pending row cols {n_td}"

--- a/tests/unit/schemas/test_portfolio_review_enhancements.py
+++ b/tests/unit/schemas/test_portfolio_review_enhancements.py
@@ -356,3 +356,87 @@ class TestPortfolioReviewEnhancements:
         assert portfolio.holdings[0].position_sizing is not None
         assert portfolio.holdings[0].data_freshness == "fresh"
         assert portfolio.schema_version == "2.1"
+
+
+class TestAllocationFields:
+    """Allocation/valuation fields on HoldingDecision and PortfolioReview."""
+
+    def _risk(self):
+        from finwiz.schemas.common import RiskAssessmentStandardized
+
+        return RiskAssessmentStandardized(score=2.5, level="Medium", risk_factors=[])
+
+    def test_holding_decision_allocation_fields_default_none(self):
+        from finwiz.schemas.portfolio_review import HoldingDecision
+
+        d = HoldingDecision(
+            asset_class="stock",
+            name="Apple",
+            ticker="AAPL",
+            currency="USD",
+            decision="KEEP",
+            composite_score=0.8,
+            grade="A",
+            grade_description="Strong",
+            recommended_action="hold",
+            risk=self._risk(),
+        )
+
+        assert d.quantity is None
+        assert d.native_currency is None
+        assert d.native_value is None
+        assert d.eur_value is None
+        assert d.weight is None
+
+    def test_holding_decision_allocation_fields_assignable(self):
+        from finwiz.schemas.portfolio_review import HoldingDecision
+
+        d = HoldingDecision(
+            asset_class="stock",
+            name="Apple",
+            ticker="AAPL",
+            currency="USD",
+            decision="KEEP",
+            composite_score=0.8,
+            grade="A",
+            grade_description="Strong",
+            recommended_action="hold",
+            risk=self._risk(),
+        )
+        d.quantity = 10.0
+        d.native_currency = "USD"
+        d.native_value = 1500.0
+        d.eur_value = 1380.0
+        d.weight = 0.25
+
+        assert d.weight == 0.25
+
+    def test_weight_must_be_between_0_and_1(self):
+        import pytest
+        from pydantic import ValidationError
+
+        from finwiz.schemas.portfolio_review import HoldingDecision
+
+        with pytest.raises(ValidationError):
+            HoldingDecision(
+                asset_class="stock",
+                name="Apple",
+                ticker="AAPL",
+                currency="USD",
+                decision="KEEP",
+                composite_score=0.8,
+                grade="A",
+                grade_description="Strong",
+                recommended_action="hold",
+                risk=self._risk(),
+                weight=1.5,
+            )
+
+    def test_portfolio_review_total_value_eur_default_none(self):
+        from datetime import UTC, datetime
+
+        from finwiz.schemas.portfolio_review import PortfolioReview
+
+        review = PortfolioReview(as_of=datetime.now(UTC))
+
+        assert review.total_value_eur is None

--- a/tests/unit/schemas/test_portfolio_review_enhancements.py
+++ b/tests/unit/schemas/test_portfolio_review_enhancements.py
@@ -409,10 +409,13 @@ class TestAllocationFields:
         d.eur_value = 1380.0
         d.weight = 0.25
 
+        assert d.quantity == 10.0
+        assert d.native_currency == "USD"
+        assert d.native_value == 1500.0
+        assert d.eur_value == 1380.0
         assert d.weight == 0.25
 
     def test_weight_must_be_between_0_and_1(self):
-        import pytest
         from pydantic import ValidationError
 
         from finwiz.schemas.portfolio_review import HoldingDecision

--- a/tests/unit/schemas/test_portfolio_valuation.py
+++ b/tests/unit/schemas/test_portfolio_valuation.py
@@ -1,0 +1,33 @@
+"""Unit tests for portfolio valuation result schemas."""
+
+from finwiz.schemas.portfolio_valuation import HoldingValuation, ValuationResult
+
+
+def test_holding_valuation_defaults():
+    hv = HoldingValuation(ticker="AAPL")
+
+    assert hv.ticker == "AAPL"
+    assert hv.quantity is None
+    assert hv.native_currency is None
+    assert hv.native_value is None
+    assert hv.eur_value is None
+    assert hv.weight is None
+
+
+def test_holding_valuation_fields_mutable():
+    hv = HoldingValuation(ticker="AAPL")
+    hv.eur_value = 100.0
+    hv.weight = 0.5
+
+    assert hv.eur_value == 100.0
+    assert hv.weight == 0.5
+
+
+def test_valuation_result_defaults():
+    result = ValuationResult()
+
+    assert result.per_ticker == {}
+    assert result.total_value_eur is None
+    assert result.priced_count == 0
+    assert result.total_count == 0
+    assert result.coverage_note == ""

--- a/tests/unit/scoring/test_portfolio_valuation.py
+++ b/tests/unit/scoring/test_portfolio_valuation.py
@@ -128,3 +128,40 @@ def test_coverage_note_reports_counts():
     )
 
     assert "1 of 2" in result.coverage_note
+
+
+def test_duplicate_ticker_collapses_last_wins():
+    holdings = [_H("AAPL", 10.0), _H("AAPL", 5.0)]
+    prices = {"AAPL": (100.0, "EUR")}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: 1.0,
+    )
+
+    # Last entry wins; total is NOT double-counted.
+    assert result.total_count == 1
+    assert result.per_ticker["AAPL"].quantity == 5.0
+    assert result.per_ticker["AAPL"].eur_value == pytest.approx(500.0)
+    assert result.total_value_eur == pytest.approx(500.0)
+    assert result.per_ticker["AAPL"].weight == pytest.approx(1.0)
+
+
+def test_zero_price_no_crash_weight_none():
+    holdings = [_H("AAPL", 10.0)]
+    prices = {"AAPL": (0.0, "EUR")}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: 1.0,
+    )
+
+    hv = result.per_ticker["AAPL"]
+    assert hv.eur_value == pytest.approx(0.0)
+    assert hv.weight is None  # cannot weight against a zero total
+    assert result.total_value_eur == pytest.approx(0.0)
+    assert result.priced_count == 1

--- a/tests/unit/scoring/test_portfolio_valuation.py
+++ b/tests/unit/scoring/test_portfolio_valuation.py
@@ -1,0 +1,130 @@
+"""Unit tests for pure portfolio valuation (price_fn / fx_fn injected, no network)."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from finwiz.scoring.portfolio_valuation import value_holdings
+
+
+@dataclass
+class _H:
+    """Minimal holding stand-in (matches the .ticker/.quantity attributes used)."""
+
+    ticker: str
+    quantity: float | None
+
+
+def test_full_data_weights_sum_to_one():
+    holdings = [_H("AAPL", 10.0), _H("MSFT", 5.0)]
+    prices = {"AAPL": (100.0, "EUR"), "MSFT": (200.0, "EUR")}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: 1.0,
+    )
+
+    # AAPL: 1000 EUR, MSFT: 1000 EUR -> total 2000, each weight 0.5
+    assert result.total_value_eur == pytest.approx(2000.0)
+    assert result.per_ticker["AAPL"].eur_value == pytest.approx(1000.0)
+    assert result.per_ticker["AAPL"].weight == pytest.approx(0.5)
+    assert result.per_ticker["MSFT"].weight == pytest.approx(0.5)
+    total_weight = sum(hv.weight for hv in result.per_ticker.values() if hv.weight is not None)
+    assert total_weight == pytest.approx(1.0)
+
+
+def test_multi_currency_conversion():
+    holdings = [_H("AAPL", 10.0), _H("NESN", 10.0)]
+    prices = {"AAPL": (100.0, "USD"), "NESN": (100.0, "CHF")}
+    fx = {"USD": 0.9, "CHF": 1.0}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: fx.get(c),
+    )
+
+    # AAPL: 10*100*0.9 = 900 EUR; NESN: 10*100*1.0 = 1000 EUR; total 1900
+    assert result.per_ticker["AAPL"].eur_value == pytest.approx(900.0)
+    assert result.per_ticker["NESN"].eur_value == pytest.approx(1000.0)
+    assert result.total_value_eur == pytest.approx(1900.0)
+    assert result.per_ticker["AAPL"].weight == pytest.approx(900.0 / 1900.0)
+
+
+def test_missing_quantity_excluded_and_no_price_call():
+    calls = []
+
+    def price_fn(t):
+        calls.append(t)
+        return (100.0, "EUR")
+
+    holdings = [_H("AAPL", None), _H("MSFT", 5.0)]
+
+    result = value_holdings(holdings, base="EUR", price_fn=price_fn, fx_fn=lambda c: 1.0)
+
+    assert result.per_ticker["AAPL"].weight is None
+    assert result.per_ticker["AAPL"].eur_value is None
+    assert "AAPL" not in calls  # price_fn NOT called for quantity-less holding
+    assert result.per_ticker["MSFT"].weight == pytest.approx(1.0)
+    assert result.priced_count == 1
+    assert result.total_count == 2
+
+
+def test_missing_price_yields_none_weight():
+    holdings = [_H("AAPL", 10.0), _H("MSFT", 5.0)]
+    prices = {"MSFT": (200.0, "EUR")}  # AAPL price unavailable
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: 1.0,
+    )
+
+    assert result.per_ticker["AAPL"].weight is None
+    assert result.per_ticker["AAPL"].native_value is None
+    assert result.per_ticker["MSFT"].weight == pytest.approx(1.0)
+
+
+def test_missing_fx_keeps_native_value_but_none_weight():
+    holdings = [_H("NESN", 10.0)]
+    prices = {"NESN": (100.0, "CHF")}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: None,  # FX unavailable
+    )
+
+    hv = result.per_ticker["NESN"]
+    assert hv.native_value == pytest.approx(1000.0)  # surfaced
+    assert hv.native_currency == "CHF"
+    assert hv.eur_value is None
+    assert hv.weight is None
+    assert result.total_value_eur is None  # nothing priced into EUR
+
+
+def test_empty_holdings_no_crash():
+    result = value_holdings([], base="EUR", price_fn=lambda t: None, fx_fn=lambda c: 1.0)
+
+    assert result.per_ticker == {}
+    assert result.total_value_eur is None
+    assert result.total_count == 0
+
+
+def test_coverage_note_reports_counts():
+    holdings = [_H("AAPL", 10.0), _H("MSFT", None)]
+    prices = {"AAPL": (100.0, "EUR")}
+
+    result = value_holdings(
+        holdings,
+        base="EUR",
+        price_fn=lambda t: prices.get(t),
+        fx_fn=lambda c: 1.0,
+    )
+
+    assert "1 of 2" in result.coverage_note

--- a/tests/unit/scripts/test_fix_csv_currencies.py
+++ b/tests/unit/scripts/test_fix_csv_currencies.py
@@ -1,0 +1,116 @@
+"""Unit tests for the fix-currencies CSV rewrite tool (resolver injected)."""
+
+import csv
+
+from scripts.fix_csv_currencies import rewrite_csv_currencies
+
+
+def _rows(path):
+    with path.open(newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def test_rewrites_currency_from_resolver(tmp_path):
+    csv_path = tmp_path / "etf.csv"
+    csv_path.write_text("Name,Ticker,Currency,Active\nAmundi EM,Yahoo:AEEM.PA,USD,true\nUBS Gold,Yahoo:AUUSI.SW,USD,true\n")
+
+    def resolver(ticker):
+        return {"AEEM.PA": "EUR", "AUUSI.SW": "CHF"}.get(ticker)
+
+    changes = rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    assert rows[0]["Currency"] == "EUR"
+    assert rows[1]["Currency"] == "CHF"
+    assert ("AEEM.PA", "USD", "EUR") in changes
+
+
+def test_preserves_other_columns_and_order(tmp_path):
+    csv_path = tmp_path / "stock.csv"
+    csv_path.write_text("Name,Ticker,Currency,Active\nApple,Yahoo:AAPL,USD,true\nNestle,Yahoo:NESN.SW,USD,true\n")
+
+    def resolver(ticker):
+        return {"AAPL": "USD", "NESN.SW": "CHF"}.get(ticker)
+
+    rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    assert [r["Ticker"] for r in rows] == ["Yahoo:AAPL", "Yahoo:NESN.SW"]
+    assert rows[0]["Active"] == "true"
+    assert list(rows[0].keys()) == ["Name", "Ticker", "Currency", "Active"]
+
+
+def test_adds_currency_column_to_crypto(tmp_path):
+    csv_path = tmp_path / "crypto.csv"
+    csv_path.write_text("Name,Ticker,Active\nBitcoin,BTC,true\n")
+
+    def resolver(ticker):
+        return "USD"
+
+    rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    assert "Currency" in rows[0]
+    assert rows[0]["Currency"] == "USD"
+
+
+def test_per_ticker_failure_leaves_row_unchanged(tmp_path):
+    csv_path = tmp_path / "stock.csv"
+    csv_path.write_text("Name,Ticker,Currency,Active\nApple,Yahoo:AAPL,USD,true\nBroken,Yahoo:BAD,EUR,true\n")
+
+    def resolver(ticker):
+        return "CHF" if ticker == "AAPL" else None  # BAD unresolved
+
+    rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    assert rows[0]["Currency"] == "CHF"
+    assert rows[1]["Currency"] == "EUR"  # untouched
+
+
+def test_idempotent(tmp_path):
+    csv_path = tmp_path / "stock.csv"
+    csv_path.write_text("Name,Ticker,Currency,Active\nApple,Yahoo:AAPL,USD,true\n")
+
+    def resolver(ticker):
+        return "EUR"
+
+    first = rewrite_csv_currencies(csv_path, resolver)
+    second = rewrite_csv_currencies(csv_path, resolver)
+
+    assert first == [("AAPL", "USD", "EUR")]
+    assert second == []  # nothing changed the second time
+
+
+def test_empty_ticker_row_is_skipped(tmp_path):
+    csv_path = tmp_path / "stock.csv"
+    csv_path.write_text("Name,Ticker,Currency,Active\n,,USD,true\nApple,Yahoo:AAPL,EUR,true\n")
+
+    def resolver(ticker):
+        if not ticker:
+            raise AssertionError("resolver must not be called for an empty ticker")
+        return "EUR"
+
+    changes = rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    # Empty-ticker row: Currency preserved, no change recorded for it.
+    assert rows[0]["Ticker"] == ""
+    assert rows[0]["Currency"] == "USD"
+    assert all(norm != "" for norm, _, _ in changes)
+
+
+def test_partial_change_within_one_run(tmp_path):
+    csv_path = tmp_path / "stock.csv"
+    csv_path.write_text("Name,Ticker,Currency,Active\nApple,Yahoo:AAPL,USD,true\nNestle,Yahoo:NESN.SW,USD,true\n")
+
+    def resolver(ticker):
+        return {"AAPL": "USD", "NESN.SW": "CHF"}.get(ticker)
+
+    changes = rewrite_csv_currencies(csv_path, resolver)
+
+    rows = _rows(csv_path)
+    # Only the row that actually changed is recorded.
+    assert changes == [("NESN.SW", "USD", "CHF")]
+    assert rows[0]["Currency"] == "USD"
+    assert rows[1]["Currency"] == "CHF"

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "finwiz"
-version = "5.5.0"
+version = "5.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -962,15 +962,15 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "openai", specifier = ">=2.33.0" },
     { name = "pandas", specifier = ">=2.3.2" },
-    { name = "plotly", specifier = ">=6.7.0" },
+    { name = "plotly", specifier = ">=6.8.0" },
     { name = "psutil", specifier = ">=7.2.2" },
     { name = "pydantic", specifier = ">=2.13.3" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "pyportfolioopt", specifier = ">=1.5.5" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "pyyaml", specifier = ">=6.0.1" },
-    { name = "quantlib", specifier = ">=1.39" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "quantlib", specifier = ">=1.42.1" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "ta-lib", specifier = ">=0.6.8" },
@@ -1000,14 +1000,14 @@ dev = [
     { name = "scipy-stubs", specifier = ">=1.17.1.4" },
     { name = "types-psutil", specifier = ">=7.0.0.20251001" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250822" },
-    { name = "types-requests", specifier = ">=2.32.4.20250913" },
+    { name = "types-requests", specifier = ">=2.33.0.20260518" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-awesome-pages-plugin", specifier = ">=2.10.1" },
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.5.0" },
     { name = "mkdocs-material", specifier = ">=9.6.22" },
-    { name = "mkdocs-mermaid2-plugin", specifier = ">=1.1.1" },
+    { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pymdown-extensions", specifier = ">=10.21.3" },
 ]
@@ -2514,15 +2514,15 @@ wheels = [
 
 [[package]]
 name = "plotly"
-version = "6.7.0"
+version = "6.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "narwhals" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/7f/0f100df1172aadf88a929a9dbb902656b0880ba4b960fe5224867159d8f4/plotly-6.7.0.tar.gz", hash = "sha256:45eea0ff27e2a23ccd62776f77eb43aa1ca03df4192b76036e380bb479b892c6", size = 6911286, upload-time = "2026-04-09T20:36:45.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/fd/d72c292d78aadb93d1a9bcd76bf3c678271040c7cf10abe5788b33040a39/plotly-6.8.0.tar.gz", hash = "sha256:e088e7ddc68d4f70e3d66659224727a45296d71d2b8284181862d3d8f1f0d88f", size = 6915161, upload-time = "2026-06-03T18:33:40.226Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl", hash = "sha256:ac8aca1c25c663a59b5b9140a549264a5badde2e057d79b8c772ae2920e32ff0", size = 9898444, upload-time = "2026-04-09T20:36:39.812Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/14/abe5ce876ab5b66ee3c691bf537fcd43d037aea55d447aacf74630a8f31e/plotly-6.8.0-py3-none-any.whl", hash = "sha256:13c5c4a0f70b74cab1913eda0de49b826df5931708eb6f9c3010040614700ec8", size = 9902055, upload-time = "2026-06-03T18:33:34.26Z" },
 ]
 
 [[package]]
@@ -3646,14 +3646,14 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.33.0.20260503"
+version = "2.33.0.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/b8/57e94268c0d82ac3eaa2fc35aa8ca7bbc2542f726b67dcf90b0b00a3b14d/types_requests-2.33.0.20260503.tar.gz", hash = "sha256:9721b2d9dbee7131f2fb39f20f0ebb1999c18cef4b512c9a7932f3722de7c5f4", size = 23931, upload-time = "2026-05-03T05:20:08.882Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/82/959113a6351f3ca046cd0a8cd2cee071d7ea47473560557a01eeae9a6fe2/types_requests-2.33.0.20260503-py3-none-any.whl", hash = "sha256:02aaa7e3577a13471715bb1bddb693cc985ea514f754b503bf033e6a09a3e528", size = 20736, upload-time = "2026-05-03T05:20:07.858Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "finwiz"
-version = "5.5.1"
+version = "5.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Gives each holding a position **Quantity** (from the portfolio CSVs), values it in its native currency via the price API, converts to a **EUR** base via live FX, and surfaces `quantity / native_currency / native_value / eur_value / weight` on `HoldingDecision` (+ `PortfolioReview.total_value_eur`) so the portfolio can be represented by allocation.

100% deterministic Python — no AI (AI Minimalism). `price_fn`/`fx_fn` are injected, so the core valuation is pure and fully unit-tested with zero network.

### What's included
- **`RawHolding.quantity`** + CSV `Quantity` ingestion (blank/garbage → `None`).
- **Allocation fields** on `HoldingDecision` (`quantity/native_currency/native_value/eur_value/weight`, `weight∈[0,1]`) and `PortfolioReview.total_value_eur`.
- **`schemas/portfolio_valuation.py`** — `HoldingValuation` / `ValuationResult`.
- **`data/fx_rates.py`** — live yfinance FX→EUR with a per-run cache; **GBp/GBX pence** mapped to GBP with a single `/100` (no double-division).
- **`scoring/portfolio_valuation.py`** — pure `value_holdings(...)`: quantity × price × FX → EUR weights; graceful degradation (missing quantity/price/FX → `weight=None`, never crashes); duplicate-ticker-safe totals; weights normalized over the priced-EUR total.
- **`build_portfolio_review` wiring** — `_value_portfolio` pre-fetches prices and stamps weights; short-circuits with **zero** network calls when no holding has a quantity (keeps existing offline tests green); best-effort (any failure → weights unavailable, review still produced).
- **`make fix-currencies`** — explicit, atomic, idempotent CSV `Currency`-column rewrite from the authoritative price API (never runs on a normal analysis).

### Deliberate scope
- Report/HTML rendering of the new fields and the strategic-posture combine are **out of scope** (follow-up, per the plan's self-review notes). Data lands on the model + `portfolio_review.json`.
- The portfolio **data CSVs are gitignored** (user holdings); the empty `Quantity` column was added to the local files only — ingestion handles the column's presence or absence.
- `PortfolioReview.base_currency` default left as-is; valuation is EUR-internal and carries the EUR total explicitly.

## Test Plan
- [x] `make test` (full default unit suite) — green
- [x] New unit suites: valuation schemas, `value_holdings` (7), `fx_rates` (network-mocked, 7), orchestrator wiring (4), `fix_csv_currencies` (7), Quantity ingestion (5)
- [x] `mypy` on all touched modules — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] `check-unittest-mock` — no violations
- [x] `uv.lock` in sync with `pyproject` (`uv lock --check`)
- [ ] Live FX integration test (`-m integration`) — network, run on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portfolio review shows per-holding weights and total portfolio value in EUR; holdings display quantity, native currency/value, and EUR value.
  * Added a `make fix-currencies` command to detect and repair CSV currency entries.

* **Style**
  * Updated report styling and dark-mode theme for a refreshed, variable-driven look.

* **Documentation**
  * New comprehensive portfolio allocation/valuation plan and design spec.

* **Tests**
  * Added unit and integration tests covering FX rates, valuation logic, CSV fixes, ingestion, and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->