### PR TITLE
docs(readme): add standard status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Coverage](https://img.shields.io/badge/coverage-72%25-yellow.svg)](htmlcov/index.html)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-success)](https://pre-commit.com/)
+[![CI](https://github.com/fjacquet/finwiz/actions/workflows/ci.yml/badge.svg)](https://github.com/fjacquet/finwiz/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/fjacquet/finwiz?sort=semver)](https://github.com/fjacquet/finwiz/releases/latest)
 
 FinWiz analyzes portfolios of stocks, ETFs, and crypto using a hybrid approach: deterministic Python scoring ($0, <100ms) for quantitative analysis and CrewAI crews for qualitative insights only. Each holding is graded A+ to F with a composite score (40% fundamental, 30% technical, 30% risk) and an honest trust banner that shows exactly how much of the analysis succeeded.
 


### PR DESCRIPTION
Adds the standard README badge set (CI + latest release + license where applicable) to match the rest of the fleet. Docs-only.