### PR TITLE
feat(release): GHCR Docker image via central python-app-release@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    # Builds wheel/sdist + SBOM, publishes a GitHub Release with those assets,
+    # and pushes a Docker image to ghcr.io/fjacquet/finwiz. No PyPI. See fjacquet/ci.
+    uses: fjacquet/ci/.github/workflows/python-app-release.yml@v1
+    permissions:
+      contents: write
+      packages: write
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.title="finwiz" \
+      org.opencontainers.image.description="finwiz using crewAI — financial research/analysis crew" \
+      org.opencontainers.image.source="https://github.com/fjacquet/finwiz" \
+      org.opencontainers.image.licenses="MIT"
+
+# Fast, reproducible installs with uv.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# README.md is referenced by the hatchling build metadata, so it must be present.
+COPY pyproject.toml README.md uv.lock ./
+COPY src/ src/
+
+# Install the app into the system environment. Resolves the same dependency set
+# as CI (crewai + pydantic>=2.13); no dev/test groups.
+RUN uv pip install --system --no-cache .
+
+# The crew entrypoint (pyproject [project.scripts] kickoff = finwiz.main:kickoff).
+# Runtime config (LLM / data-provider API keys) is supplied via environment
+# variables at `docker run` time, e.g.:
+#   docker run --rm --env-file .env ghcr.io/fjacquet/finwiz
+ENTRYPOINT ["kickoff"]


### PR DESCRIPTION
finwiz had no release pipeline. Adds a uv-based Dockerfile (`kickoff` entrypoint) + a `release.yml` calling `fjacquet/ci python-app-release.yml@v1` on `v*` tags → wheel/sdist + SBOM + GitHub Release + Docker image to `ghcr.io/fjacquet/finwiz`. No PyPI. Modeled on lrc-automation.

The Docker build is exercised when the first `v*` tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)