### PR TITLE
fix(docker): install git so the crewai-custom-tools git dependency resolves

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ LABEL org.opencontainers.image.title="finwiz" \
       org.opencontainers.image.source="https://github.com/fjacquet/finwiz" \
       org.opencontainers.image.licenses="MIT"
 
+# git is needed at install time: crewai-custom-tools is a git+https dependency
+# (see pyproject.toml), and python:*-slim ships without git. Without it the
+# install fails with "Git executable not found".
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+
 # Fast, reproducible installs with uv.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 


### PR DESCRIPTION
The `Release` workflow has been failing at the image build since at least **v5.10.0** — no finwiz image has been published for the last two tags.

```
× Failed to download and build `crewai-custom-tools @ git+https://github.com/fjacquet/crewai-custom-tools.git@v0.6.0`
╰─▶ Git executable not found. Ensure that Git is installed and available.
```

`crewai-custom-tools` is declared as a `git+https` dependency in `pyproject.toml`, but `python:3.13-slim` ships without git, so `uv pip install --system .` cannot fetch it.

Adds a minimal `apt-get install git` layer before the uv install, cleaning the apt lists in the same layer.

Verified locally with `docker build --platform linux/amd64` — the build now completes and exports the image.

Worth re-tagging **v5.10.2** once merged so an image finally ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container builds that install dependencies from Git-based URLs.
  * Improved build reliability by including Git in the image environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->