### PR TITLE
build: fully qualify base image names for Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM docker.io/library/python:3.13-slim
 
 LABEL org.opencontainers.image.title="finwiz" \
       org.opencontainers.image.description="finwiz using crewAI — financial research/analysis crew" \


### PR DESCRIPTION
Preparation for the Docker→Podman move.

Podman resolves unqualified image names via `unqualified-search-registries` in `registries.conf`. On RHEL/Fedora that list does not start with `docker.io`, and under `short-name-mode="enforcing"` an unqualified name fails outright in a non-interactive build. Docker always implies `docker.io/library`.

Every base image is now fully qualified. Already-qualified refs (`ghcr.io/*`, `gcr.io/*`, `registry.access.redhat.com/*`), `FROM scratch`, and inter-stage `FROM <stage>` references are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container’s base image reference for more explicit and reliable image resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->