### PR TITLE
fix(pipeline): recover lost coverage and stop presenting gaps as findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -323,3 +323,7 @@ site/
 .code-review-graph/
 .serena/
 output_baseline_*/
+
+# Git worktrees for isolated implementation workspaces
+.claude/worktrees/
+.superpowers/

--- a/docs/superpowers/plans/2026-08-15-pipeline-coverage.md
+++ b/docs/superpowers/plans/2026-08-15-pipeline-coverage.md
@@ -1,0 +1,1909 @@
+# Pipeline Coverage & Discovery Integrity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a `crewai flow kickoff` run analyze every holding it can, refuse by name the ones it genuinely cannot, and stop discovery from either fabricating opportunities or searching a universe too small to contain any.
+
+**Architecture:** Three independent defect clusters in the deep-analysis pipeline and the discovery pipeline. Cluster 1 (fact_pack) is a resilience gap: one un-retried HTTP call per holding, no backoff, and a `RuntimeError` the retry layer treats as non-transient. Cluster 2 (volatility) is an ordering bug: the critical-field gate runs before the fallback that would fill the field. Cluster 3 (discovery) is a correctness hazard: a hardcoded mock fallback that injects invented A+ tickers, plus a universe of 11 candidates and a factor formula that cannot reach the actionability floor.
+
+**Tech Stack:** Python 3.13, Pydantic v2, httpx (async), pandas, empyrical, pytest + pytest-mock + pytest-socket, uv, ruff.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-report-rethink-design.md` (§4 — Coverage fixes). This plan implements §4 only. §1, §2, §3, §5 (the report rebuild) are Plan B, written after this plan executes.
+
+## Global Constraints
+
+- **Line length 180** — `pyproject.toml:61` `[tool.ruff] line-length = 180`.
+- **New files ≤300 lines** — enforced by `scripts/check_new_file_size.py:15` (`MAX_LINES = 300`) via `make check-file-size`.
+- **`unittest.mock` is BANNED.** Use pytest-mock's `mocker` only. Enforced by ruff `flake8-tidy-imports` (`pyproject.toml:141-147`) and `make check-unittest-mock` (`Makefile:147-157`).
+- **No network in unit tests.** `tests/conftest.py:56-73` installs an autouse pytest-socket guard allowing only `127.0.0.1`, `::1`, `localhost`. Mock the seam; never widen the allow-list.
+- **`json.dumps` always with `default=str`.**
+- **All Pydantic models live in `src/finwiz/schemas/`**, not in domain folders.
+- **AI Minimalism** — every change in this plan is deterministic Python. No task here adds an LLM call.
+- **Test command:** `make test` runs `uv run pytest --cov --cov-report=xml --cov-report=term-missing -m "not integration" -q -n auto --dist=loadscope` (`Makefile:75-76`).
+- **Target Python:** 3.13 (`pyproject.toml:61` `target-version = "py313"`).
+
+## Known-Broken Ground (read before starting)
+
+Verified during planning. Do not be surprised by these; do not fix them in this plan unless a task says so.
+
+- `tests/conftest.py` lines 306-707 (~57% of the file) are **dead** — they import `finwiz.flows.hybrid_analysis_flow`, which does not exist (`ModuleNotFoundError`). Two fixtures also raise `ImportError` on names that no longer exist (`DataQualityMetrics` from `finwiz.schemas.integration.models` at :581; `InvestmentThesis`/`RiskAssessment` from `finwiz.schemas.hybrid_analysis.qualitative` at :617-622). No test requests them. **Do not build on any fixture defined after line 306.** Usable fixtures are lines 119-303.
+- `tests/conftest_unittest_blocker.py` is **never wired in** — no import, no `-p` flag. Project CLAUDE.md claims it blocks `unittest.mock` at runtime; it does not. Enforcement is ruff + the Makefile grep only.
+- **No snapshot-testing library is installed** (no syrupy, pytest-snapshot, approvaltests — confirmed absent from both `pyproject.toml` and `uv.lock`). Plan B will need one; this plan does not.
+- There is **no `fail_under`** anywhere in `pyproject.toml` — `[tool.coverage.run]` at :401-426 has no `[tool.coverage.report]` section. The "65% minimum" in CLAUDE.md is not enforced by config.
+- **`logs/finwiz_error.log` accumulates across runs.** Only 40 of its 226 lines are from the 2026-08-15 run. Always filter by date (`grep "2026-08-15" logs/finwiz_error.log`) before attributing an error to the current run. The spec's §4.5 list was written without this filter and over-attributes two error classes — see Task 15.
+
+**Errors confirmed present in the 2026-08-15 run** (the only ones this plan treats as live):
+
+| Count | Error |
+|---|---|
+| 3 | `HTTP Error 404` — `Quote not found for symbol: XTSLA` |
+| 2+2 | `index N is out of bounds for axis 0 with size N` — `quantitative_comprehensive_analyzer.py`, `backtesting.py` |
+| 1 | `list index out of range` — `quantitative_comprehensive_analyzer.py` |
+| 2 | `Error saving cache metadata: dictionary changed size during iteration` — `data_processors.py` |
+| 2 each | `possibly delisted; no price data found` — XTSLA, UNI-USD, S-USD, POL-USD, IMX-USD, GRT-USD, COMP-USD |
+
+**Errors from the 2026-07-15 run only — do NOT chase these:** `cannot convert float NaN to integer`, `1 validation error for _QualitativeInsightsRaw` (doubled opening brace: `'{\n{"sec_insights": …'`), `JSON repair failed: Expecting property name enclosed in double quotes`. They did not occur on 2026-08-15. The doubled-brace repair rule is already tracked as a separate follow-up.
+
+---
+
+## File Structure
+
+**New files**
+
+| Path | Responsibility |
+|---|---|
+| `src/finwiz/infrastructure/resilience/perplexity_retry.py` | Async retry-with-backoff wrapper around the vendored `perplexity_structured`, plus a process-wide concurrency semaphore. Shared by fact_pack and strategic research. |
+| `tests/unit/infrastructure/test_perplexity_retry.py` | Unit tests for the retry wrapper. |
+| `tests/unit/analysis/test_fact_pack_stage.py` | Unit tests for the fact_pack stage's cache/fetch/refusal behavior. |
+| `tests/unit/scoring/test_volatility_fallback.py` | Unit tests for volatility derivation and scale normalization. |
+| `tests/unit/discovery/test_universe_provider_selection.py` | Unit tests for seed selection, hygiene, and the universe floor. |
+
+**Modified files**
+
+| Path | Change |
+|---|---|
+| `src/finwiz/analysis/fact_pack_research.py:183-189` | Route the Perplexity call through the retry wrapper. |
+| `src/finwiz/analysis/stages/fact_pack.py:74` | Raise a transient-classified error so `@stage(retries=1)` is reachable. |
+| `src/finwiz/analysis/stages/_resilience.py:53-62` | Teach `_is_transient` about the new error type. |
+| `src/finwiz/schemas/hybrid_analysis/fact_pack.py:45-53` | Widen the stale window so an old cache can still serve a rate-limited run. |
+| `src/finwiz/scoring/technical_fallback.py` | Add a volatility branch using the existing `calculate_volatility`. |
+| `src/finwiz/scoring/deep_analysis_scorer.py:96-100` | Run the fallback before the critical-field gate. |
+| `src/finwiz/config/critical_fields_config.py:162` | Normalize percent-scaled volatility instead of rejecting it. |
+| `src/finwiz/discovery/universe_provider.py:71,74` | Fix the operator-precedence bug and the `except (ValueError, Exception)` catch-all; apply ticker hygiene; enforce a universe floor. |
+| `src/finwiz/scoring/etf_analyzer.py`, `stock_analyzer.py`, `crypto_analyzer.py` | Delete the fabricated legacy fallback. |
+| `src/finwiz/tools/alternative_finder_tool.py:179`, `src/finwiz/orchestrators/extraction/engine.py:169,192`, `src/finwiz/infrastructure/json/to_html_converter.py:38-39` | Point at `consolidated_discovery.json`; retire the `discovery_latest.json` name. |
+| `src/finwiz/scoring/discovery/pipeline.py:105,121` | Persist the pre-filter scored list before filtering. |
+
+---
+
+## Task 1: Perplexity retry wrapper
+
+The vendored client at `.venv/.../crewai_custom_tools/tools/web/perplexity_structured.py:148-176` catches every failure and returns `None` — a 429, a timeout, a missing API key and an unparseable body are indistinguishable to the caller. It issues exactly one `client.post` with no retry, no backoff, no jitter.
+
+Because status codes are not observable through that surface, this wrapper retries **by outcome** (`None`), not by status. It fails fast on a missing API key so a misconfiguration does not burn four attempts.
+
+**Files:**
+- Create: `src/finwiz/infrastructure/resilience/perplexity_retry.py`
+- Test: `tests/unit/infrastructure/test_perplexity_retry.py`
+
+**Interfaces:**
+- Consumes: `perplexity_structured` from `crewai_custom_tools` (async, keyword-only: `prompt`, `schema`, `system`, `model`, `search_recency_filter`, `timeout`, `api_key`).
+- Produces: `async def perplexity_with_retry(*, prompt: str, schema: type[T], system: str, search_recency_filter: str | None = "month", timeout: float = 15.0, max_attempts: int = 4, base_delay: float = 1.0) -> T | None` and `PERPLEXITY_CONCURRENCY` / `get_perplexity_semaphore() -> asyncio.Semaphore`. Tasks 2 and 12 consume both.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/infrastructure/test_perplexity_retry.py`:
+
+```python
+"""Tests for the Perplexity retry wrapper."""
+
+import asyncio
+
+import pytest
+from pydantic import BaseModel
+
+from finwiz.infrastructure.resilience.perplexity_retry import (
+    get_perplexity_semaphore,
+    perplexity_with_retry,
+)
+
+
+class _Payload(BaseModel):
+    value: str
+
+
+@pytest.mark.asyncio
+async def test_returns_payload_on_first_success(mocker):
+    inner = mocker.patch(
+        "finwiz.infrastructure.resilience.perplexity_retry.perplexity_structured",
+        new=mocker.AsyncMock(return_value=_Payload(value="ok")),
+    )
+    sleep = mocker.patch("finwiz.infrastructure.resilience.perplexity_retry.asyncio.sleep", new=mocker.AsyncMock())
+
+    result = await perplexity_with_retry(prompt="p", schema=_Payload, system="s")
+
+    assert result == _Payload(value="ok")
+    assert inner.await_count == 1
+    assert sleep.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_retries_until_success_and_backs_off(mocker):
+    inner = mocker.patch(
+        "finwiz.infrastructure.resilience.perplexity_retry.perplexity_structured",
+        new=mocker.AsyncMock(side_effect=[None, None, _Payload(value="late")]),
+    )
+    sleep = mocker.patch("finwiz.infrastructure.resilience.perplexity_retry.asyncio.sleep", new=mocker.AsyncMock())
+    mocker.patch("finwiz.infrastructure.resilience.perplexity_retry.random.uniform", return_value=0.0)
+
+    result = await perplexity_with_retry(prompt="p", schema=_Payload, system="s", base_delay=2.0)
+
+    assert result == _Payload(value="late")
+    assert inner.await_count == 3
+    assert [c.args[0] for c in sleep.await_args_list] == [2.0, 4.0]
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_max_attempts(mocker):
+    inner = mocker.patch(
+        "finwiz.infrastructure.resilience.perplexity_retry.perplexity_structured",
+        new=mocker.AsyncMock(return_value=None),
+    )
+    mocker.patch("finwiz.infrastructure.resilience.perplexity_retry.asyncio.sleep", new=mocker.AsyncMock())
+
+    result = await perplexity_with_retry(prompt="p", schema=_Payload, system="s", max_attempts=3)
+
+    assert result is None
+    assert inner.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_fails_fast_without_retrying(mocker, monkeypatch):
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    monkeypatch.delenv("PPLX_API_KEY", raising=False)
+    inner = mocker.patch(
+        "finwiz.infrastructure.resilience.perplexity_retry.perplexity_structured",
+        new=mocker.AsyncMock(return_value=None),
+    )
+
+    result = await perplexity_with_retry(prompt="p", schema=_Payload, system="s")
+
+    assert result is None
+    assert inner.await_count == 0
+
+
+def test_semaphore_is_a_process_singleton():
+    assert get_perplexity_semaphore() is get_perplexity_semaphore()
+    assert isinstance(get_perplexity_semaphore(), asyncio.Semaphore)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/infrastructure/test_perplexity_retry.py -v -p no:randomly`
+Expected: FAIL — `ModuleNotFoundError: No module named 'finwiz.infrastructure.resilience.perplexity_retry'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/finwiz/infrastructure/resilience/perplexity_retry.py`:
+
+```python
+"""Retry-with-backoff and concurrency control for Perplexity structured calls.
+
+The vendored ``perplexity_structured`` client swallows every failure and returns
+``None`` (see ``crewai_custom_tools/tools/web/perplexity_structured.py``), so a
+429, a timeout and an unparseable body are indistinguishable here. This wrapper
+therefore retries **by outcome**, not by status code, with exponential backoff
+and jitter.
+
+A missing API key is the one failure we can detect up front, so it fails fast
+rather than burning the whole attempt budget on a misconfiguration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+from typing import TypeVar
+
+from crewai_custom_tools import perplexity_structured
+from pydantic import BaseModel
+
+from finwiz.tools.logger import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+# Perplexity rate-limits aggressively; a full portfolio fans out far wider than
+# the account allows. This caps in-flight requests process-wide.
+PERPLEXITY_CONCURRENCY = int(os.getenv("PERPLEXITY_CONCURRENCY", "4"))
+
+_semaphore: asyncio.Semaphore | None = None
+
+
+def get_perplexity_semaphore() -> asyncio.Semaphore:
+    """Return the process-wide Perplexity concurrency semaphore."""
+    global _semaphore
+    if _semaphore is None:
+        _semaphore = asyncio.Semaphore(PERPLEXITY_CONCURRENCY)
+    return _semaphore
+
+
+def _has_api_key() -> bool:
+    return bool(os.getenv("PERPLEXITY_API_KEY") or os.getenv("PPLX_API_KEY"))
+
+
+async def perplexity_with_retry(
+    *,
+    prompt: str,
+    schema: type[T],
+    system: str,
+    search_recency_filter: str | None = "month",
+    timeout: float = 15.0,
+    max_attempts: int = 4,
+    base_delay: float = 1.0,
+) -> T | None:
+    """Call ``perplexity_structured`` with bounded retries and exponential backoff.
+
+    Args:
+        prompt: User prompt forwarded to Perplexity.
+        schema: Pydantic model the response must validate against.
+        system: System prompt forwarded to Perplexity.
+        search_recency_filter: Perplexity recency window, or None to omit.
+        timeout: Per-attempt httpx timeout in seconds.
+        max_attempts: Total attempts, including the first. Must be >= 1.
+        base_delay: Seconds before the second attempt; doubles each retry.
+
+    Returns:
+        The validated model, or None when every attempt failed.
+    """
+    if not _has_api_key():
+        logger.warning(f"Perplexity call for {schema.__name__} skipped: no PERPLEXITY_API_KEY/PPLX_API_KEY configured")
+        return None
+
+    delay = base_delay
+    for attempt in range(1, max_attempts + 1):
+        async with get_perplexity_semaphore():
+            result = await perplexity_structured(
+                prompt=prompt,
+                schema=schema,
+                system=system,
+                search_recency_filter=search_recency_filter,
+                timeout=timeout,
+            )
+        if result is not None:
+            if attempt > 1:
+                logger.info(f"Perplexity call for {schema.__name__} succeeded on attempt {attempt}/{max_attempts}")
+            return result
+
+        if attempt < max_attempts:
+            jittered = delay + random.uniform(0.0, delay * 0.25)
+            logger.warning(f"Perplexity call for {schema.__name__} returned no result (attempt {attempt}/{max_attempts}); retrying in {jittered:.1f}s")
+            await asyncio.sleep(jittered)
+            delay *= 2.0
+
+    logger.warning(f"Perplexity call for {schema.__name__} exhausted {max_attempts} attempts")
+    return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/infrastructure/test_perplexity_retry.py -v -p no:randomly`
+Expected: PASS — 5 passed
+
+Note: the backoff assertion expects `[2.0, 4.0]` because `random.uniform` is patched to return `0.0`, removing jitter.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/infrastructure/resilience/perplexity_retry.py tests/unit/infrastructure/test_perplexity_retry.py
+git commit -m "feat(resilience): add Perplexity retry wrapper with backoff and concurrency cap"
+```
+
+---
+
+## Task 2: Route fact_pack through the retry wrapper
+
+`fact_pack_research.py:183-189` calls `perplexity_structured` directly, exactly once. This is the call that failed 28 times in the 2026-08-15 run (20 transport timeouts, 8 HTTP 429s) and cost 22 holdings.
+
+**Files:**
+- Modify: `src/finwiz/analysis/fact_pack_research.py:15` (import), `:183-189` (call site)
+- Test: `tests/unit/analysis/test_fact_pack_stage.py`
+
+**Interfaces:**
+- Consumes: `perplexity_with_retry` from Task 1.
+- Produces: no signature change — `fetch_fact_pack` and `fetch_fact_pack_sync` keep their exact existing signatures (`fetch_fact_pack_sync(ticker: str, company_name: str, sector: str | None = None, industry: str | None = None, *, timeout: float = 15.0) -> FactPack | None`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/analysis/test_fact_pack_stage.py`:
+
+```python
+"""Tests for fact_pack fetching and stage behavior."""
+
+import pytest
+
+from finwiz.analysis.fact_pack_research import fetch_fact_pack
+
+
+@pytest.mark.asyncio
+async def test_fetch_fact_pack_uses_retry_wrapper(mocker):
+    called = mocker.patch(
+        "finwiz.analysis.fact_pack_research.perplexity_with_retry",
+        new=mocker.AsyncMock(return_value=None),
+    )
+
+    result = await fetch_fact_pack("NVDA", "NVIDIA Corp", "Technology", "Semiconductors")
+
+    assert result is None
+    assert called.await_count == 1
+    assert called.await_args.kwargs["schema"].__name__ == "_FactPackRaw"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/analysis/test_fact_pack_stage.py -v -p no:randomly`
+Expected: FAIL — `AttributeError: <module 'finwiz.analysis.fact_pack_research'> does not have the attribute 'perplexity_with_retry'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/finwiz/analysis/fact_pack_research.py`, replace the import at line 15:
+
+```python
+from finwiz.infrastructure.resilience.perplexity_retry import perplexity_with_retry
+```
+
+(Delete `from crewai_custom_tools import perplexity_structured` if `perplexity_structured` has no other use in the file; keep it otherwise.)
+
+Then replace the call at lines 183-189:
+
+```python
+        raw = await perplexity_with_retry(
+            prompt=prompt,
+            schema=_FactPackRaw,
+            system=_SYSTEM_FR,
+            search_recency_filter="month",
+            timeout=timeout,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/analysis/test_fact_pack_stage.py -v -p no:randomly`
+Expected: PASS — 1 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/analysis/fact_pack_research.py tests/unit/analysis/test_fact_pack_stage.py
+git commit -m "fix(fact_pack): retry Perplexity fetches instead of failing on first error"
+```
+
+---
+
+## Task 3: Make the fact_pack failure retryable at the stage layer
+
+`@stage(name="fact_pack", timeout_s=60, retries=1)` at `fact_pack.py:77` declares one retry, but it is unreachable. `_is_transient` (`_resilience.py:53-62`) returns `False` for `RuntimeError`, and `_fact_pack_inner` raises exactly that at `fact_pack.py:74`. So the stage gives up after one attempt with `retries_used=0` — which is what the ledger recorded for all 22 failures.
+
+Introduce a dedicated exception the resilience layer recognises, so the declared retry actually happens.
+
+**Files:**
+- Modify: `src/finwiz/analysis/stages/fact_pack.py:74`
+- Modify: `src/finwiz/analysis/stages/_resilience.py:46-62`
+- Test: `tests/unit/analysis/test_fact_pack_stage.py` (append)
+
+**Interfaces:**
+- Produces: `class TransientStageError(RuntimeError)` in `src/finwiz/analysis/stages/_resilience.py`, exported for any stage body that wants its declared `retries` to be reachable.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/analysis/test_fact_pack_stage.py`:
+
+```python
+from finwiz.analysis.stages._resilience import TransientStageError, _is_transient
+
+
+def test_transient_stage_error_is_classified_transient():
+    assert _is_transient(TransientStageError("rate limited")) is True
+
+
+def test_plain_runtime_error_is_not_transient():
+    assert _is_transient(RuntimeError("bad state")) is False
+
+
+def test_fact_pack_inner_raises_transient_error_when_no_cache_and_no_fetch(mocker):
+    from finwiz.analysis.stages import fact_pack as fact_pack_module
+
+    cache = mocker.Mock()
+    cache.get.return_value = None
+    mocker.patch.object(fact_pack_module, "_get_cache", return_value=cache)
+    mocker.patch.object(fact_pack_module, "fetch_fact_pack_sync", return_value=None)
+
+    with pytest.raises(TransientStageError, match="fact_pack unavailable for NVDA"):
+        fact_pack_module._fact_pack_inner("NVDA", "NVIDIA Corp", "Technology", "Semiconductors")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/analysis/test_fact_pack_stage.py -v -p no:randomly`
+Expected: FAIL — `ImportError: cannot import name 'TransientStageError' from 'finwiz.analysis.stages._resilience'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/finwiz/analysis/stages/_resilience.py`, add the class after the `_TRANSIENT_HTTP_TYPES` block (after line 50):
+
+```python
+class TransientStageError(RuntimeError):
+    """A stage failure that is worth retrying (rate limit, upstream unavailable).
+
+    Plain RuntimeError stays non-transient: it signals a programming or state
+    error where a retry would only repeat the same wrong thing.
+    """
+```
+
+Then in `_is_transient`, add the check immediately after the `ValidationError`/`AssertionError` guard (after line 55):
+
+```python
+    if isinstance(exc, TransientStageError):
+        return True
+```
+
+In `src/finwiz/analysis/stages/fact_pack.py`, add to the imports at line 14:
+
+```python
+from finwiz.analysis.stages._resilience import StageContext, TransientStageError, stage
+```
+
+and change line 74 from `raise RuntimeError(...)` to:
+
+```python
+    raise TransientStageError(f"fact_pack unavailable for {ticker}: no cache and Perplexity fetch failed")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/analysis/test_fact_pack_stage.py -v -p no:randomly`
+Expected: PASS — 4 passed
+
+- [ ] **Step 5: Verify no stage-contract regression**
+
+Run: `make check-stage-contract && uv run pytest tests/unit/analysis -q`
+Expected: contract check passes; no new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finwiz/analysis/stages/_resilience.py src/finwiz/analysis/stages/fact_pack.py tests/unit/analysis/test_fact_pack_stage.py
+git commit -m "fix(stages): classify fact_pack unavailability as transient so the declared retry runs"
+```
+
+---
+
+## Task 3b: Let an old cache still rescue a rate-limited run
+
+Spec §4.1: "Cache warm survives across runs, so a rate-limited run degrades to stale rather than to nothing."
+
+It currently does not. `FactPack.derive_freshness` (`schemas/hybrid_analysis/fact_pack.py:45-53`) raises `ValueError` beyond 15 days:
+
+```python
+        if age < timedelta(days=3):
+            return "fresh"
+        if age < timedelta(days=7):
+            return "recent"
+        if age < timedelta(days=15):
+            return "stale"
+        raise ValueError(f"FactPack older than 14 days (age={age}); cache should have evicted")
+```
+
+`FactPackCache.get()` catches that at `cache/fact_pack_cache.py:66` and returns `None`. So a 16-day-old cache entry is indistinguishable from no cache at all, and the stale-fallback branch at `stages/fact_pack.py:69-71` never fires. On a rate-limited run that is the difference between a stale answer and a dead holding.
+
+Corporate structure and leadership do not turn over in a fortnight. Widen the stale band and let the payload's own `freshness` label carry the caveat — which is exactly the trust-spine design ("staleness is a payload field, NOT a stage outcome", `fact_pack.py:3-5`).
+
+**Files:**
+- Modify: `src/finwiz/schemas/hybrid_analysis/fact_pack.py:45-53`
+- Test: `tests/unit/analysis/test_fact_pack_stage.py` (append)
+
+**Interfaces:**
+- Produces: `FactPack.derive_freshness(fetched_at: datetime) -> str` — unchanged signature, wider stale band, raising only beyond the new horizon.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/analysis/test_fact_pack_stage.py`:
+
+```python
+from datetime import UTC, datetime, timedelta
+
+from finwiz.schemas.hybrid_analysis.fact_pack import FactPack
+
+
+def _ago(days: int) -> datetime:
+    return datetime.now(UTC) - timedelta(days=days)
+
+
+def test_freshness_bands_at_the_short_end():
+    assert FactPack.derive_freshness(_ago(1)) == "fresh"
+    assert FactPack.derive_freshness(_ago(5)) == "recent"
+    assert FactPack.derive_freshness(_ago(10)) == "stale"
+
+
+def test_month_old_pack_is_stale_not_an_error():
+    assert FactPack.derive_freshness(_ago(30)) == "stale"
+
+
+def test_ancient_pack_still_raises():
+    with pytest.raises(ValueError, match="older than"):
+        FactPack.derive_freshness(_ago(120))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/analysis/test_fact_pack_stage.py -v -p no:randomly -k freshness or month_old or ancient`
+Expected: FAIL on `test_month_old_pack_is_stale_not_an_error` — `ValueError: FactPack older than 14 days (age=30 days...)`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace lines 45-53 of `src/finwiz/schemas/hybrid_analysis/fact_pack.py`:
+
+```python
+        now = datetime.now(UTC)
+        age = now - fetched_at
+        if age < timedelta(days=3):
+            return "fresh"
+        if age < timedelta(days=7):
+            return "recent"
+        # Corporate structure and leadership do not turn over in a fortnight.
+        # A 15-day cliff meant a rate-limited run had no cache to fall back on
+        # and killed the holding outright — worse than a labelled stale answer.
+        # Staleness is a payload field, not a stage outcome (see stages/fact_pack.py).
+        if age < timedelta(days=_STALE_HORIZON_DAYS):
+            return "stale"
+        raise ValueError(f"FactPack older than {_STALE_HORIZON_DAYS} days (age={age}); cache should have evicted")
+```
+
+Add the module constant above the class:
+
+```python
+# Beyond this, a cached fact pack is not merely stale — it predates any
+# reporting cycle we would defend, so the cache evicts rather than serve it.
+_STALE_HORIZON_DAYS = 90
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/analysis/test_fact_pack_stage.py -v -p no:randomly`
+Expected: PASS — 7 passed
+
+- [ ] **Step 5: Check for dependent assertions**
+
+Run: `grep -rn "14 days\|derive_freshness\|days=15" src/ tests/ | grep -v __pycache__`
+Expected: update any test or docstring asserting the old 14/15-day boundary. `cache/fact_pack_cache.py:66` catches `ValueError` generically and needs no change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finwiz/schemas/hybrid_analysis/fact_pack.py tests/unit/analysis/test_fact_pack_stage.py
+git commit -m "fix(fact_pack): widen the stale window so an old cache can still rescue a rate-limited run"
+```
+
+---
+
+## Task 4: Derive volatility in the technical fallback
+
+`technical_fallback.py` fills MA50/MA200/RSI/MACD/beta from `price_history` but has **no volatility branch** (grep for "volatility" in that file returns nothing). Meanwhile `calculate_volatility(returns: pd.Series, annualize: bool = True) -> float` already exists at `quantitative/risk/risk_metrics.py:19`, built on empyrical's `annual_volatility`. `raw_data["price_history"]` is a `pandas.Series` of daily closes set at `deep_analysis_data_collector.py:436`.
+
+**Files:**
+- Modify: `src/finwiz/scoring/technical_fallback.py`
+- Test: `tests/unit/scoring/test_volatility_fallback.py`
+
+**Interfaces:**
+- Consumes: `calculate_volatility` from `finwiz.quantitative.risk.risk_metrics`.
+- Produces: `calculate_missing_technical_indicators(data: dict[str, Any], price_history: pd.Series | None = None) -> dict[str, Any]` — unchanged signature, now also sets `data["volatility"]` when absent and `price_history` has ≥2 points.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/scoring/test_volatility_fallback.py`:
+
+```python
+"""Tests for volatility derivation in the technical fallback."""
+
+import pandas as pd
+
+from finwiz.scoring.technical_fallback import calculate_missing_technical_indicators
+
+
+def _price_series() -> pd.Series:
+    return pd.Series([100.0, 101.5, 99.8, 102.3, 101.1, 103.4, 102.0, 104.2, 103.1, 105.0])
+
+
+def test_derives_volatility_from_price_history_when_missing():
+    data = {"current_price": 105.0}
+
+    result = calculate_missing_technical_indicators(data, _price_series())
+
+    assert "volatility" in result
+    assert 0.0 < result["volatility"] < 5.0
+
+
+def test_does_not_overwrite_existing_volatility():
+    data = {"current_price": 105.0, "volatility": 0.42}
+
+    result = calculate_missing_technical_indicators(data, _price_series())
+
+    assert result["volatility"] == 0.42
+
+
+def test_leaves_volatility_absent_when_no_price_history():
+    data = {"current_price": 105.0}
+
+    result = calculate_missing_technical_indicators(data, None)
+
+    assert "volatility" not in result
+
+
+def test_leaves_volatility_absent_when_history_too_short():
+    data = {"current_price": 105.0}
+
+    result = calculate_missing_technical_indicators(data, pd.Series([100.0]))
+
+    assert "volatility" not in result
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/scoring/test_volatility_fallback.py -v -p no:randomly`
+Expected: FAIL — `AssertionError: assert 'volatility' in {...}` on the first test.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/finwiz/scoring/technical_fallback.py`, add the import near the top:
+
+```python
+from finwiz.quantitative.risk.risk_metrics import calculate_volatility
+```
+
+Add this helper at module level:
+
+```python
+def _fill_volatility(data: dict[str, Any], price_history: pd.Series | None) -> None:
+    """Derive annualized volatility from price history when the quant tool did not supply it.
+
+    Mutates ``data`` in place. Never overwrites a value the quant tool already
+    produced, and stays silent when there is not enough history to be meaningful.
+    """
+    if data.get("volatility") is not None:
+        return
+    if price_history is None or len(price_history) < 2:
+        return
+
+    returns = price_history.pct_change().dropna()
+    if returns.empty:
+        return
+
+    data["volatility"] = calculate_volatility(returns, annualize=True)
+    logger.debug(f"Derived volatility={data['volatility']:.4f} from {len(returns)} return observations")
+```
+
+Call it inside `calculate_missing_technical_indicators`, immediately **before** the `current_price` early-return guard at line 33-37, so a missing price does not also suppress volatility:
+
+```python
+    _fill_volatility(data, price_history)
+
+    current_price = data.get("current_price")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/scoring/test_volatility_fallback.py -v -p no:randomly`
+Expected: PASS — 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/scoring/technical_fallback.py tests/unit/scoring/test_volatility_fallback.py
+git commit -m "feat(scoring): derive volatility from price history in the technical fallback"
+```
+
+---
+
+## Task 5: Run the fallback before the critical-field gate
+
+This is the ordering bug. In `deep_analysis_scorer.calculate_composite_score`:
+
+- line 97 — Step 2: `self._validate_critical_fields(...)` — raises `CriticalFieldError`
+- line 100 — Step 3: `self._calculate_component_scores(...)`, which calls `calculate_missing_technical_indicators` at line 222
+
+So no fallback can ever rescue a critical field: the raise has already fired. This is why `beta` (critical for stocks, `critical_fields_config.py:18`) can never be rescued by the existing `data["beta"] = 1.0` fallback at `technical_fallback.py:50-51` either. Task 4 is inert until this task lands.
+
+**Files:**
+- Modify: `src/finwiz/scoring/deep_analysis_scorer.py:92-100`
+- Test: `tests/unit/scoring/test_volatility_fallback.py` (append)
+
+**Interfaces:**
+- Consumes: `calculate_missing_technical_indicators` (Task 4).
+- Produces: no signature change to `calculate_composite_score`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/scoring/test_volatility_fallback.py`:
+
+```python
+import pytest
+
+from finwiz.config.critical_fields_config import CriticalFieldError
+from finwiz.scoring.deep_analysis_scorer import DeepAnalysisScorer
+
+
+def _etf_data_without_volatility() -> dict:
+    return {
+        "current_price": 105.0,
+        "expense_ratio": 0.07,
+        "price_history": _price_series(),
+    }
+
+
+def test_volatility_is_recovered_before_the_critical_gate():
+    scorer = DeepAnalysisScorer()
+
+    result = scorer.calculate_composite_score(ticker="VUSA.L", asset_class="etf", data=_etf_data_without_volatility())
+
+    assert result.composite_score >= 0.0
+
+
+def test_gate_still_fires_when_nothing_can_be_recovered():
+    scorer = DeepAnalysisScorer()
+
+    with pytest.raises(CriticalFieldError) as exc:
+        scorer.calculate_composite_score(ticker="XTSLA", asset_class="etf", data={"expense_ratio": 0.07})
+
+    assert "current_price" in str(exc.value)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/scoring/test_volatility_fallback.py -v -p no:randomly -k "critical_gate or recovered"`
+Expected: FAIL — `CriticalFieldError: Cannot analyze VUSA.L (etf): Missing critical fields: volatility (missing)` on the first test.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/finwiz/scoring/deep_analysis_scorer.py`, insert a recovery step between Step 1 and Step 2 (between lines 94 and 97):
+
+```python
+            # Step 1b: Recover derivable fields BEFORE the gate.
+            # The gate is fail-fast by design, but failing fast on a field we can
+            # compute from data already in hand is a false negative, not honesty.
+            self._recover_derivable_fields(data)
+```
+
+Add the method next to `_validate_critical_fields` (after line 216):
+
+```python
+    def _recover_derivable_fields(self, data: dict[str, Any]) -> None:
+        """Fill fields derivable from collected data before the critical-field gate runs.
+
+        Only touches fields that are absent; never overwrites collected values.
+        """
+        from finwiz.scoring.technical_fallback import calculate_missing_technical_indicators
+
+        price_history = data.get("price_history")
+        calculate_missing_technical_indicators(data, price_history)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/scoring/test_volatility_fallback.py -v -p no:randomly`
+Expected: PASS — 6 passed
+
+- [ ] **Step 5: Run the full scorer suite for regressions**
+
+Run: `uv run pytest tests/unit/scoring -q`
+Expected: no new failures. `tests/unit/scoring/test_deep_analysis_scorer.py` has 12 `mocker.patch("finwiz.scoring.deep_analysis_scorer.is_feature_enabled", ...)` call sites; none of them patch the new method, so they should be unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finwiz/scoring/deep_analysis_scorer.py tests/unit/scoring/test_volatility_fallback.py
+git commit -m "fix(scoring): recover derivable fields before the critical-field gate"
+```
+
+---
+
+## Task 6: Normalize percent-scaled volatility
+
+Two producers disagree on units. `performance_metrics.py:90` emits fractional volatility (`returns.std() * np.sqrt(252)` → 0.25). `backtesting_performance.py:246` emits percent (`float(annualized_vol * 100)` → 25.0). Both can reach the flat `volatility` key: the explicit block at `deep_analysis_data_collector.py:464-471` takes `performance_metrics.volatility`, but when that is absent or None, `_flatten_recursive` (`:588`, guard `if key not in target` at `:596`) hoists `backtest_result.volatility` instead.
+
+The gate bound is `v > 5.0` (`critical_fields_config.py:162`), so a percent-scaled 25.3 is rejected as `volatility (invalid value: 25.3)` — a units bug reported as missing data.
+
+**Files:**
+- Modify: `src/finwiz/config/critical_fields_config.py`
+- Test: `tests/unit/scoring/test_volatility_fallback.py` (append)
+
+**Interfaces:**
+- Produces: `normalize_volatility(value: float | int | None) -> float | None` in `finwiz.config.critical_fields_config`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/scoring/test_volatility_fallback.py`:
+
+```python
+from finwiz.config.critical_fields_config import normalize_volatility
+
+
+def test_fractional_volatility_passes_through():
+    assert normalize_volatility(0.25) == 0.25
+
+
+def test_percent_scaled_volatility_is_rescaled():
+    assert normalize_volatility(25.3) == pytest.approx(0.253)
+
+
+def test_absurd_volatility_is_rejected():
+    assert normalize_volatility(900.0) is None
+
+
+def test_none_stays_none():
+    assert normalize_volatility(None) is None
+
+
+def test_zero_is_preserved_not_treated_as_missing():
+    assert normalize_volatility(0.0) == 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/scoring/test_volatility_fallback.py -v -p no:randomly -k volatility`
+Expected: FAIL — `ImportError: cannot import name 'normalize_volatility' from 'finwiz.config.critical_fields_config'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/finwiz/config/critical_fields_config.py`, add above the `SANITY_CHECKS` dict:
+
+```python
+# Annualized volatility above this is not a real reading — it is a units error
+# or corrupt data. Below it, values > 5.0 are treated as percent-scaled and
+# divided by 100 (two producers in-tree disagree on units; see
+# quantitative/performance_metrics.py:90 vs quantitative/backtesting_performance.py:246).
+_VOLATILITY_ABSURD_CEILING = 500.0
+
+
+def normalize_volatility(value: float | int | None) -> float | None:
+    """Coerce a volatility reading to the fractional scale, or None if unusable.
+
+    Args:
+        value: Raw volatility, fractional (0.25) or percent-scaled (25.0).
+
+    Returns:
+        Fractional volatility, or None when the value is missing, negative, or absurd.
+    """
+    if value is None:
+        return None
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if v < 0.0 or v > _VOLATILITY_ABSURD_CEILING:
+        return None
+    if v > 5.0:
+        return v / 100.0
+    return v
+```
+
+Then, in the validation loop at lines 172-185, normalize before the sanity check. Replace the loop body's opening with:
+
+```python
+    for field in critical_fields:
+        value = data.get(field)
+
+        if field == "volatility":
+            value = normalize_volatility(value)
+            if value is not None:
+                data[field] = value
+
+        # Check if field is missing or None
+        if field not in data or value is None:
+            missing_fields.append(f"{field} (missing)")
+            continue
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/scoring/test_volatility_fallback.py -v -p no:randomly`
+Expected: PASS — 11 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/config/critical_fields_config.py tests/unit/scoring/test_volatility_fallback.py
+git commit -m "fix(validation): normalize percent-scaled volatility instead of rejecting it"
+```
+
+---
+
+## Task 7: Apply ticker hygiene to the discovery universe
+
+`discovery/ticker_hygiene.py` exists and blocklists `XTSLA` by name at `:30` ("BlackRock cash-sweep placeholder, not a tradable ticker"), exposing `is_tradable()` at `:44` and `sanitize_symbols()` at `:49`. It is applied in `market_data.py:85` and `:175` — but `universe_provider.py`, `breakout_detector.py` and `momentum_scanner.py` contain zero references to it. That is why `XTSLA` entered the universe and produced nine `Quote not found for symbol: XTSLA` errors in the run.
+
+**Files:**
+- Modify: `src/finwiz/discovery/universe_provider.py:87`
+- Test: `tests/unit/discovery/test_universe_provider_selection.py`
+
+**Interfaces:**
+- Consumes: `sanitize_symbols` from `finwiz.discovery.ticker_hygiene`.
+- Produces: `DynamicUniverseProvider.get_universe(asset_class: str, exclude_tickers: list[str] | None = None) -> list[str]` — unchanged signature, now hygiene-filtered.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/discovery/test_universe_provider_selection.py`:
+
+```python
+"""Tests for universe selection, hygiene and the candidate floor."""
+
+from finwiz.discovery.universe_provider import DynamicUniverseProvider
+
+
+def test_untradable_placeholders_are_filtered_out(mocker):
+    provider = DynamicUniverseProvider()
+    mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL", "XTSLA", "MSFT"])
+
+    result = provider.get_universe("etf")
+
+    assert "XTSLA" not in result
+    assert "AAPL" in result
+    assert "MSFT" in result
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/discovery/test_universe_provider_selection.py -v -p no:randomly`
+Expected: FAIL — `AssertionError: assert 'XTSLA' not in ['AAPL', 'MSFT', 'XTSLA']`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/finwiz/discovery/universe_provider.py`, add the import:
+
+```python
+from finwiz.discovery.ticker_hygiene import sanitize_symbols
+```
+
+Replace line 87:
+
+```python
+        result = sorted(set(sanitize_symbols(tickers)) - exclude_set)
+```
+
+`sanitize_symbols` already upper-cases; confirm by reading `ticker_hygiene.py:49` before relying on it. If it does not, keep the `.upper()` in the comprehension.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/discovery/test_universe_provider_selection.py -v -p no:randomly`
+Expected: PASS — 1 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/discovery/universe_provider.py tests/unit/discovery/test_universe_provider_selection.py
+git commit -m "fix(discovery): apply ticker hygiene to the mined universe"
+```
+
+---
+
+## Task 8: Fix the seed-ETF selection bug
+
+`universe_provider.py:71` reads:
+
+```python
+seed_etfs = self._seed_etfs or self.DEFAULT_STOCK_SEED_ETFS if asset_class == "stock" else self.DEFAULT_ETF_SEED_ETFS
+```
+
+Python binds this as `(self._seed_etfs or self.DEFAULT_STOCK_SEED_ETFS) if asset_class == "stock" else self.DEFAULT_ETF_SEED_ETFS`, so the constructor's `seed_etfs` override is **unreachable for ETFs** — the ETF path always uses `DEFAULT_ETF_SEED_ETFS = ["VT", "AOA", "AOR"]`. Line 74's `except (ValueError, Exception)` is also a catch-all whose first member is dead (`ValueError` is an `Exception`).
+
+**Files:**
+- Modify: `src/finwiz/discovery/universe_provider.py:71,74`
+- Test: `tests/unit/discovery/test_universe_provider_selection.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+def test_seed_override_is_honored_for_etfs(mocker):
+    provider = DynamicUniverseProvider(seed_etfs=["SPY"])
+    mine = mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL"])
+
+    provider.get_universe("etf")
+
+    assert mine.call_args.args[0] == ["SPY"]
+
+
+def test_seed_override_is_honored_for_stocks(mocker):
+    provider = DynamicUniverseProvider(seed_etfs=["QQQ"])
+    mine = mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL"])
+
+    provider.get_universe("stock")
+
+    assert mine.call_args.args[0] == ["QQQ"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/discovery/test_universe_provider_selection.py -v -p no:randomly -k seed_override`
+Expected: FAIL on `test_seed_override_is_honored_for_etfs` — `assert ['VT', 'AOA', 'AOR'] == ['SPY']`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace lines 71-80:
+
+```python
+            default_seeds = self.DEFAULT_STOCK_SEED_ETFS if asset_class == "stock" else self.DEFAULT_ETF_SEED_ETFS
+            seed_etfs = self._seed_etfs or default_seeds
+            try:
+                tickers = self._mine_etf_holdings(seed_etfs)
+            except Exception:
+                self._logger.warning(
+                    "Dynamic universe failed for %s, falling back to static",
+                    asset_class,
+                )
+                tickers = self._fallback_static_universe(asset_class)
+                source = "static"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/discovery/test_universe_provider_selection.py -v -p no:randomly`
+Expected: PASS — 3 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/discovery/universe_provider.py tests/unit/discovery/test_universe_provider_selection.py
+git commit -m "fix(discovery): honor seed-ETF override for ETFs and drop the dead catch-all"
+```
+
+---
+
+## Task 9: Enforce a universe floor
+
+Spec §4.3: at least 50 candidates per asset class must survive exclusion, and a shortfall must be logged rather than silently scanned.
+
+Measured on 2026-08-15: `VT`(10) ∪ `AOA`(8) ∪ `AOR`(8) = 18 unique; 7 already held; 11 remained. The static fallback returns far more — `ScreeningUtils().get_screening_universe(...)` yields 50 for `etf`, 66 for `stock`, 39 for `crypto` (verified by execution). So the fix is to union the static universe in when mining falls short, not to replace mining.
+
+**Files:**
+- Modify: `src/finwiz/discovery/universe_provider.py`
+- Test: `tests/unit/discovery/test_universe_provider_selection.py` (append)
+
+**Interfaces:**
+- Produces: module constant `MIN_UNIVERSE_SIZE = 50` in `finwiz.discovery.universe_provider`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+from finwiz.discovery.universe_provider import MIN_UNIVERSE_SIZE
+
+
+def test_static_universe_is_unioned_in_when_mining_falls_short(mocker):
+    provider = DynamicUniverseProvider()
+    mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL", "MSFT"])
+    mocker.patch.object(provider, "_fallback_static_universe", return_value=[f"T{i}" for i in range(MIN_UNIVERSE_SIZE)])
+
+    result = provider.get_universe("etf")
+
+    assert len(result) >= MIN_UNIVERSE_SIZE
+    assert "AAPL" in result
+
+
+def test_shortfall_is_logged_when_floor_cannot_be_met(mocker):
+    provider = DynamicUniverseProvider()
+    mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL"])
+    mocker.patch.object(provider, "_fallback_static_universe", return_value=["MSFT"])
+    warn = mocker.patch.object(provider._logger, "warning")
+
+    result = provider.get_universe("etf")
+
+    assert len(result) == 2
+    assert any("below the floor" in str(c.args[0]) for c in warn.call_args_list)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/discovery/test_universe_provider_selection.py -v -p no:randomly -k "floor or short"`
+Expected: FAIL — `ImportError: cannot import name 'MIN_UNIVERSE_SIZE'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add near the top of `src/finwiz/discovery/universe_provider.py`:
+
+```python
+# A universe smaller than this is not a search. Measured 2026-08-15: mining three
+# seed ETFs yielded 18 unique names, 11 after excluding the portfolio — every one
+# of which graded below the actionability floor. Discovery reported "0
+# opportunities" when the honest statement was "we looked at 11 candidates".
+MIN_UNIVERSE_SIZE = 50
+```
+
+Replace the deduplicate/filter/sort block (line 87, after Task 7's change) with:
+
+```python
+        result = sorted(set(sanitize_symbols(tickers)) - exclude_set)
+
+        if len(result) < MIN_UNIVERSE_SIZE and asset_class != "crypto":
+            static = sanitize_symbols(self._fallback_static_universe(asset_class))
+            result = sorted(set(result) | (set(static) - exclude_set))
+            source = f"{source}+static"
+
+        if len(result) < MIN_UNIVERSE_SIZE:
+            self._logger.warning(
+                "Universe for %s has %d tickers, below the floor of %d — discovery coverage is limited this run",
+                asset_class,
+                len(result),
+                MIN_UNIVERSE_SIZE,
+            )
+```
+
+The `asset_class != "crypto"` guard exists because the crypto branch already goes straight to static at line 68.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/discovery/test_universe_provider_selection.py -v -p no:randomly`
+Expected: PASS — 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/discovery/universe_provider.py tests/unit/discovery/test_universe_provider_selection.py
+git commit -m "feat(discovery): enforce a minimum universe size and log shortfalls"
+```
+
+---
+
+## Task 10: Delete the fabricated legacy discovery fallback
+
+`scoring/etf_analyzer.py:35-38` wraps the whole pipeline in `except Exception` and falls back to `_legacy_etf_analysis`, which returns **hardcoded invented opportunities**: `VTI` grade `A+` score `0.93`, `VXUS` grade `A` `0.86`, `BND` grade `A` `0.82` (lines 46-71), labelled `"method": "python_analysis"` as though computed. `stock_analyzer.py` and `crypto_analyzer.py` have the same shape.
+
+Any pipeline exception therefore injects invented A+ tickers into `a_plus_*.json` and into the family report. This is the single largest correctness hazard in the discovery area, and it is exactly the failure mode the spec exists to eliminate: presenting fabricated output as authoritative.
+
+**Files:**
+- Modify: `src/finwiz/scoring/etf_analyzer.py`, `src/finwiz/scoring/stock_analyzer.py`, `src/finwiz/scoring/crypto_analyzer.py`
+- Test: `tests/unit/scoring/test_discovery_analyzers.py`
+
+**Interfaces:**
+- Produces: `analyze_etf_opportunities(session_id: str) -> dict[str, Any]` (and stock/crypto twins) — unchanged signature. On pipeline failure it now returns an empty, honestly-labelled result instead of invented data.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/scoring/test_discovery_analyzers.py`:
+
+```python
+"""Discovery analyzers must never fabricate opportunities."""
+
+from finwiz.scoring.etf_analyzer import analyze_etf_opportunities
+
+
+def test_pipeline_failure_yields_no_opportunities(mocker):
+    mocker.patch("finwiz.config.features.flags.is_feature_enabled", return_value=True)
+    mocker.patch(
+        "finwiz.scoring.discovery.pipeline.NewcomerDiscoveryPipeline",
+        side_effect=RuntimeError("universe fetch exploded"),
+    )
+
+    result = analyze_etf_opportunities("test-session")
+
+    assert result["opportunities"] == []
+    assert result["performance_metrics"]["opportunities_found"] == 0
+    assert result["performance_metrics"]["method"] == "newcomer_discovery_failed"
+
+
+def test_no_hardcoded_tickers_remain_in_module():
+    import inspect
+
+    from finwiz.scoring import etf_analyzer
+
+    source = inspect.getsource(etf_analyzer)
+    for invented in ("VTI", "VXUS", "BND"):
+        assert invented not in source
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/scoring/test_discovery_analyzers.py -v -p no:randomly`
+Expected: FAIL — the first test gets three fabricated opportunities; the second finds `"VTI"` in the source.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the whole body of `src/finwiz/scoring/etf_analyzer.py` below the imports:
+
+```python
+def analyze_etf_opportunities(session_id: str) -> dict[str, Any]:
+    """Analyze ETF opportunities using pure Python.
+
+    Routes through ``NewcomerDiscoveryPipeline``. A pipeline failure yields an
+    empty, honestly-labelled result — never fabricated candidates. Inventing
+    A-grade tickers to fill a gap is worse than reporting the gap.
+    """
+    start_time = time.time()
+
+    try:
+        logger.info("Using NewcomerDiscoveryPipeline for etf discovery")
+        from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
+
+        pipeline = NewcomerDiscoveryPipeline("etf")
+        result = pipeline.discover(session_id)
+        return pipeline._to_legacy_format(result, start_time)
+    except Exception as e:
+        logger.error("Newcomer discovery pipeline failed for etf: %s", e)
+        return {
+            "opportunities": [],
+            "analysis_summary": f"ETF discovery unavailable this run: {e}",
+            "performance_metrics": {
+                "execution_time_seconds": time.time() - start_time,
+                "opportunities_found": 0,
+                "cost_usd": 0.0,
+                "llm_calls_made": 0,
+                "method": "newcomer_discovery_failed",
+                "error": str(e),
+            },
+        }
+```
+
+Delete `_legacy_etf_analysis` entirely, and delete the now-unused `is_feature_enabled` import. Apply the identical shape to `stock_analyzer.py` and `crypto_analyzer.py`, substituting the asset class in the pipeline constructor, the log messages, and the summary string.
+
+**Note on the removed flag:** the `newcomer_discovery` gate disappears with the fallback, because the only alternative branch was the fabricated one. Per the project rule "remove the switch, not the surface", keep any `newcomer_discovery` entry in `config/features/definitions.py` as a no-op if other code reads it — grep before deleting.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/scoring/test_discovery_analyzers.py -v -p no:randomly`
+Expected: PASS — 2 passed
+
+- [ ] **Step 5: Add the same guard for stock and crypto**
+
+Append to `tests/unit/scoring/test_discovery_analyzers.py`:
+
+```python
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("module_name", "invented"),
+    [
+        ("finwiz.scoring.stock_analyzer", ("AAPL", "MSFT", "NVDA")),
+        ("finwiz.scoring.crypto_analyzer", ("BTC-USD", "ETH-USD")),
+    ],
+)
+def test_other_analyzers_have_no_hardcoded_tickers(module_name, invented):
+    import importlib
+    import inspect
+
+    source = inspect.getsource(importlib.import_module(module_name))
+    hardcoded = [t for t in invented if f'"{t}"' in source]
+    assert hardcoded == []
+```
+
+Run: `uv run pytest tests/unit/scoring/test_discovery_analyzers.py -v -p no:randomly`
+Expected: PASS — 4 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finwiz/scoring/etf_analyzer.py src/finwiz/scoring/stock_analyzer.py src/finwiz/scoring/crypto_analyzer.py tests/unit/scoring/test_discovery_analyzers.py
+git commit -m "fix(discovery): stop fabricating A+ opportunities when the pipeline fails"
+```
+
+---
+
+## Task 11: Retire the `discovery_latest.json` name
+
+Verified: `discovery_latest.json` has **three readers and zero writers** anywhere in the repo. Readers are `tools/alternative_finder_tool.py:179`, `orchestrators/extraction/engine.py:169` and `:192`. `to_html_converter.py:38-39` maps both `discovery_output_*.json` and `discovery_latest.json` to the same output name. Discovery actually writes `consolidated_discovery.json` (`discovery_orchestrator.py:367`).
+
+This is why every holding logged "No discovery crew output found at output/discovery/discovery_latest.json" and alternatives were empty portfolio-wide.
+
+Spec §4.4 resolution: point the readers at the real file, retire the dead name.
+
+**Files:**
+- Modify: `src/finwiz/tools/alternative_finder_tool.py:179,181`
+- Modify: `src/finwiz/orchestrators/extraction/engine.py:169,192`
+- Modify: `src/finwiz/infrastructure/json/to_html_converter.py:38-39`
+- Test: `tests/unit/tools/test_alternative_finder_tool.py` (existing — it fabricates `discovery_latest.json` at :86, :249, :284, :443, :594 and must be updated)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/discovery/test_discovery_paths.py`:
+
+```python
+"""The discovery artifact name must be consistent between writer and readers."""
+
+from pathlib import Path
+
+SRC = Path("src/finwiz")
+
+
+def test_no_source_file_references_the_retired_name():
+    offenders = []
+    for path in SRC.rglob("*.py"):
+        if "discovery_latest.json" in path.read_text(encoding="utf-8"):
+            offenders.append(str(path))
+    assert offenders == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/discovery/test_discovery_paths.py -v -p no:randomly`
+Expected: FAIL — offenders lists `alternative_finder_tool.py`, `extraction/engine.py`, `to_html_converter.py`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/finwiz/tools/alternative_finder_tool.py`, replace line 179:
+
+```python
+        latest_file = self.discovery_output_dir / "consolidated_discovery.json"
+```
+
+and update the warning text at line 181 to name the same file.
+
+In `src/finwiz/orchestrators/extraction/engine.py`, replace both `:169` and `:192`:
+
+```python
+            discovery_file = self.discovery_dir / "consolidated_discovery.json"
+```
+
+In `src/finwiz/infrastructure/json/to_html_converter.py`, delete the dead line 39 (`"discovery_latest.json": "discovery_latest.html",`), keeping the `discovery_output_*.json` glob at line 38.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/discovery/test_discovery_paths.py -v -p no:randomly`
+Expected: PASS — 1 passed
+
+- [ ] **Step 5: Update the existing alternative-finder tests**
+
+`tests/unit/tools/test_alternative_finder_tool.py` writes fixture files named `discovery_latest.json` at lines 86, 249, 284, 443, 594. Rename each to `consolidated_discovery.json`.
+
+Run: `uv run pytest tests/unit/tools/test_alternative_finder_tool.py -q`
+Expected: PASS — no failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finwiz/tools/alternative_finder_tool.py src/finwiz/orchestrators/extraction/engine.py src/finwiz/infrastructure/json/to_html_converter.py tests/unit/discovery/test_discovery_paths.py tests/unit/tools/test_alternative_finder_tool.py
+git commit -m "fix(discovery): read the artifact discovery actually writes"
+```
+
+---
+
+## Task 12: Persist the pre-filter scored candidates
+
+`_filter_actionable` runs at `scoring/discovery/pipeline.py:105`; `_persist_result` runs at `:121`. So `newcomer_*.json` only ever contains post-filter survivors, and the 29/42/10 candidates dropped on 2026-08-15 are unrecoverable from this run's outputs. That contradicts the stated rationale at `candidate_scorer.py:40-42` ("callers that legitimately need the full scored list (diagnostics, tests)") and makes Task 13's calibration unverifiable against real data.
+
+**Files:**
+- Modify: `src/finwiz/scoring/discovery/pipeline.py:105,121`
+- Test: `tests/unit/scoring/discovery/test_pipeline.py` (existing — append)
+
+**Interfaces:**
+- Produces: `output/discovery/scored_{asset_class}.json` with shape `{"asset_class": str, "scored": list[dict], "actionable_count": int}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/scoring/discovery/test_pipeline.py`:
+
+```python
+def test_scored_candidates_are_persisted_before_filtering(tmp_path, mocker, monkeypatch):
+    from finwiz.scoring.discovery import pipeline as pipeline_module
+    from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
+
+    monkeypatch.chdir(tmp_path)
+    mocker.patch.object(NewcomerDiscoveryPipeline, "_load_portfolio_tickers", return_value=None)
+    pipeline = NewcomerDiscoveryPipeline("etf")
+
+    scored = [
+        pipeline_module.NewcomerCandidate(ticker="AAA", composite_score=0.72, grade="C+"),
+        pipeline_module.NewcomerCandidate(ticker="BBB", composite_score=0.40, grade="F"),
+    ]
+    pipeline._persist_scored(scored, actionable_count=1)
+
+    written = json.loads((tmp_path / "output" / "discovery" / "scored_etf.json").read_text(encoding="utf-8"))
+    assert len(written["scored"]) == 2
+    assert written["actionable_count"] == 1
+    assert {c["ticker"] for c in written["scored"]} == {"AAA", "BBB"}
+```
+
+Add `import json` at the top of the test file if absent.
+
+`NewcomerCandidate` requires more than three fields — read `src/finwiz/schemas/newcomer_discovery.py` and supply whatever is mandatory. If constructing one is noisy, use `NewcomerCandidate.model_construct(...)` with just the three fields the assertions read.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/scoring/discovery/test_pipeline.py -v -p no:randomly -k persisted`
+Expected: FAIL — `AttributeError: 'NewcomerDiscoveryPipeline' object has no attribute '_persist_scored'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the method to `NewcomerDiscoveryPipeline` in `src/finwiz/scoring/discovery/pipeline.py`, next to `_persist_result` (line 436). Note the class has **no** `self.discovery_dir` and **no** `self._logger` — `_persist_result` builds the path locally and uses the module-level `logger`. Mirror that exactly:
+
+```python
+    def _persist_scored(self, scored: list[NewcomerCandidate], actionable_count: int) -> None:
+        """Write the full scored candidate list before actionability filtering.
+
+        Without this, every dropped candidate is unrecoverable and "0
+        opportunities" is indistinguishable from "we scored 10 and rejected all
+        10". Diagnostics need the distinction.
+        """
+        try:
+            discovery_dir = Path("output") / "discovery"
+            discovery_dir.mkdir(parents=True, exist_ok=True)
+            out = discovery_dir / f"scored_{self.asset_class}.json"
+            payload = {
+                "asset_class": self.asset_class,
+                "scored": [c.model_dump() for c in scored],
+                "actionable_count": actionable_count,
+            }
+            with open(out, "w") as f:
+                json.dump(payload, f, indent=2, default=str)
+            logger.info("Persisted %d scored %s candidates (%d actionable) to %s", len(scored), self.asset_class, actionable_count, out)
+        except OSError as e:
+            logger.warning("Failed to write scored candidates: %s", e)
+```
+
+Then at line 105, capture the pre-filter list before filtering rebinds `candidates`:
+
+```python
+        scored_before_filter = list(candidates)
+        candidates = self._filter_actionable(candidates)
+        self._persist_scored(scored_before_filter, actionable_count=len(candidates))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/scoring/discovery/test_pipeline.py -v -p no:randomly`
+Expected: PASS — no failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/scoring/discovery/pipeline.py tests/unit/scoring/discovery/test_pipeline.py
+git commit -m "feat(discovery): persist the full scored candidate list before filtering"
+```
+
+---
+
+## Task 13: Calibrate the factor score against the grade ladder
+
+Widening the universe (Task 9) is necessary but not sufficient. `factor_score_from_returns` (`discovery/market_data.py:207-228`) computes `0.7 * logistic(4 * cumulative) + 0.3 * vol_score`, where the logistic is centered at 0.5 for zero cumulative return and `vol_score = 1 - daily_vol * 20`. Typical standalone factors land in 0.50-0.65 — **below** the actionability floor before any portfolio-fit multiplier is applied. The C grade requires ≥0.65 (`grading_system.py:39-90`, effective floor 0.65).
+
+So a genuinely strong candidate cannot currently reach C. That is the real reason all 81 scored candidates were dropped, not the universe size alone.
+
+The floor stays at C — noise stays out, per the project rule that discovery scanners exclude weak signals rather than emitting them with D/F grades. What changes is the formula's dynamic range, so that a strong performer can actually clear the bar.
+
+**Files:**
+- Modify: `src/finwiz/discovery/market_data.py:207-228`
+- Test: `tests/unit/discovery/test_factor_score.py`
+
+**Interfaces:**
+- Produces: `factor_score_from_returns(returns: list[float] | None) -> float | None` — exact current signature at `market_data.py:207`, preserved. It takes a **plain list of floats**, not a pandas Series, and returns `None` for series shorter than 5 points.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/discovery/test_factor_score.py`:
+
+```python
+"""The factor score must be able to reach the actionability floor."""
+
+from finwiz.discovery.market_data import factor_score_from_returns
+from finwiz.scoring.grading_system import score_to_grade
+
+ACTIONABLE_FLOOR = 0.65
+
+
+def _returns(daily: float, days: int = 126) -> list[float]:
+    return [daily] * days
+
+
+def test_strong_low_volatility_performer_clears_the_actionable_floor():
+    # ~+30% over six months with modest daily moves — an unambiguously good candidate.
+    score = factor_score_from_returns(_returns(0.0021))
+
+    assert score is not None
+    assert score >= ACTIONABLE_FLOOR
+    assert score_to_grade(score) in {"C", "C+", "B", "B+", "A", "A+"}
+
+
+def test_flat_performer_stays_below_the_floor():
+    score = factor_score_from_returns(_returns(0.0))
+
+    assert score is not None
+    assert score < ACTIONABLE_FLOOR
+
+
+def test_declining_performer_scores_low():
+    score = factor_score_from_returns(_returns(-0.002))
+
+    assert score is not None
+    assert score < 0.5
+
+
+def test_short_series_returns_none():
+    assert factor_score_from_returns([0.01, 0.01]) is None
+    assert factor_score_from_returns(None) is None
+
+
+def test_score_stays_in_unit_range():
+    for daily in (-0.05, -0.001, 0.0, 0.001, 0.05):
+        score = factor_score_from_returns(_returns(daily))
+        assert score is not None
+        assert 0.0 <= score <= 1.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/discovery/test_factor_score.py -v -p no:randomly`
+Expected: FAIL on `test_strong_low_volatility_performer_clears_the_actionable_floor` — the score lands around 0.6.
+
+- [ ] **Step 3: Write minimal implementation**
+
+The current body (`market_data.py:216-228`) is:
+
+```python
+    if not returns or len(returns) < 5:
+        return None
+
+    import numpy as np
+
+    arr = np.asarray(returns, dtype=float)
+    cumulative = float(np.prod(1.0 + arr) - 1.0)
+    momentum = 1.0 / (1.0 + np.exp(-4.0 * cumulative))  # cumulative 0 -> 0.5
+    daily_vol = float(arr.std())
+    vol_score = max(0.0, min(1.0, 1.0 - daily_vol * 20.0))  # ~5% daily vol -> 0
+    score = 0.7 * momentum + 0.3 * vol_score
+    return max(0.0, min(1.0, float(score)))
+```
+
+With gain 4, a +30% six-month run gives `momentum = 1/(1+e^-1.2) = 0.769`; with a flat-ish `vol_score ≈ 0.96` the blend is `0.7*0.769 + 0.3*0.96 = 0.826` — which does clear 0.65. The compression bites on realistic series, where `vol_score` is far lower: at 2% daily vol, `vol_score = 0.6`, and a +10% run gives `momentum = 0.599`, blending to `0.599*0.7 + 0.6*0.3 = 0.60` — below the floor.
+
+Add module constants above the function and re-center the logistic:
+
+```python
+# Calibration target: a candidate up ~15%+ over the window with ordinary
+# volatility must be able to reach the C floor (0.65, grading_system.py:39-90).
+# The original gain of 4 centered at zero return compressed realistic candidates
+# into 0.50-0.65, so the grade ladder was unreachable and discovery reported
+# "0 opportunities" for a universe it had graded rather than searched.
+# The floor itself stays at C — weak signals are excluded, never low-graded.
+_MOMENTUM_GAIN = 9.0
+_MOMENTUM_CENTER = 0.05
+_VOL_PENALTY = 12.0
+```
+
+and replace the two scoring lines:
+
+```python
+    momentum = 1.0 / (1.0 + np.exp(-_MOMENTUM_GAIN * (cumulative - _MOMENTUM_CENTER)))
+    daily_vol = float(arr.std())
+    vol_score = max(0.0, min(1.0, 1.0 - daily_vol * _VOL_PENALTY))
+```
+
+Run the tests; if `test_flat_performer_stays_below_the_floor` and the strong-performer test cannot both pass, adjust `_MOMENTUM_CENTER` upward (widening the gap) before touching `_MOMENTUM_GAIN`. Record the final values in the constant comment.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/discovery/test_factor_score.py -v -p no:randomly`
+Expected: PASS — 4 passed
+
+- [ ] **Step 5: Check for regressions in dependent tests**
+
+Run: `uv run pytest tests/unit/discovery tests/unit/scoring/discovery -q`
+Expected: no new failures. `tests/unit/scoring/discovery/` has 7 test files; 6 use `mocker`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finwiz/discovery/market_data.py tests/unit/discovery/test_factor_score.py
+git commit -m "fix(discovery): calibrate factor score so strong candidates can reach the actionable floor"
+```
+
+---
+
+## Task 14: Fix the cache-metadata race
+
+`DataProcessor.save_cache_metadata` at `src/finwiz/quantitative/data_processors.py:132-138` serializes a dict it does not own while another thread mutates it:
+
+```python
+    def save_cache_metadata(self, cache_metadata: dict[str, Any], cache_metadata_file: Path) -> None:
+        """Save cache metadata to disk."""
+        try:
+            with open(cache_metadata_file, "w") as f:
+                json.dump(cache_metadata, f, indent=2)
+        except Exception as e:
+            self.logger.error(f"Error saving cache metadata: {e}")
+```
+
+Two occurrences on 2026-08-15. Every one silently loses a cache write — and a cold cache is exactly what turns a Perplexity rate-limit into a dead holding (Tasks 2-3). The `json.dump` also omits `default=str`, violating the project rule.
+
+**Files:**
+- Modify: `src/finwiz/quantitative/data_processors.py:132-138`
+- Test: `tests/unit/quantitative/test_cache_metadata.py`
+
+**Interfaces:**
+- Produces: `DataProcessor.save_cache_metadata(cache_metadata: dict[str, Any], cache_metadata_file: Path) -> None` — unchanged signature.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/quantitative/test_cache_metadata.py`:
+
+```python
+"""Cache metadata saving must tolerate concurrent mutation of the caller's dict."""
+
+import json
+import threading
+
+from finwiz.quantitative.config import QuantConfig
+from finwiz.quantitative.data_processors import DataProcessor
+
+
+def test_save_survives_concurrent_mutation(tmp_path):
+    processor = DataProcessor(QuantConfig())
+    metadata = {f"seed{i}": i for i in range(500)}
+    target = tmp_path / "cache_metadata.json"
+    stop = threading.Event()
+    errors: list[BaseException] = []
+
+    def churn():
+        i = 0
+        while not stop.is_set():
+            metadata[f"k{i}"] = i
+            i += 1
+
+    writer = threading.Thread(target=churn, daemon=True)
+    writer.start()
+    try:
+        for _ in range(50):
+            try:
+                processor.save_cache_metadata(metadata, target)
+            except BaseException as exc:  # noqa: BLE001 - the test is the assertion
+                errors.append(exc)
+    finally:
+        stop.set()
+        writer.join(timeout=2.0)
+
+    assert errors == []
+    assert json.loads(target.read_text(encoding="utf-8"))
+
+
+def test_non_serializable_values_do_not_break_the_save(tmp_path):
+    from datetime import datetime
+
+    processor = DataProcessor(QuantConfig())
+    target = tmp_path / "cache_metadata.json"
+
+    processor.save_cache_metadata({"fetched_at": datetime.now()}, target)
+
+    assert "fetched_at" in json.loads(target.read_text(encoding="utf-8"))
+```
+
+`QuantConfig()` may require arguments — read `src/finwiz/quantitative/config.py` and construct it however that module expects. If it needs a populated config, use the existing `tests/unit/quantitative/conftest.py` (28 lines) fixture instead.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/quantitative/test_cache_metadata.py -v -p no:randomly`
+Expected: FAIL — the first test's `errors` list is non-empty, or the file is truncated; the second raises `TypeError: Object of type datetime is not JSON serializable` (currently swallowed into a log line, leaving no file at all).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace lines 132-138:
+
+```python
+    def save_cache_metadata(self, cache_metadata: dict[str, Any], cache_metadata_file: Path) -> None:
+        """Save cache metadata to disk.
+
+        The caller owns ``cache_metadata`` and may mutate it from another thread,
+        so snapshot before serializing — iterating the live dict raised
+        "dictionary changed size during iteration" and silently dropped the write.
+        """
+        try:
+            snapshot = dict(cache_metadata)
+            with open(cache_metadata_file, "w") as f:
+                json.dump(snapshot, f, indent=2, default=str)
+        except Exception as e:
+            self.logger.error(f"Error saving cache metadata: {e}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/quantitative/test_cache_metadata.py -v -p no:randomly`
+Expected: PASS — 2 passed
+
+Note: `dict(cache_metadata)` is itself an iteration and can still race in principle. It is a single C-level copy rather than an interleaved serialization, which closes the observed window. If the test still flakes, the caller must own a lock — find it via `grep -rn "save_cache_metadata" src/` and add the lock there.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/finwiz/quantitative/data_processors.py tests/unit/quantitative/test_cache_metadata.py
+git commit -m "fix(quantitative): snapshot cache metadata before serializing"
+```
+
+---
+
+## Task 15: Fix the out-of-bounds indexing in quantitative analysis
+
+Confirmed in the 2026-08-15 run: `index N is out of bounds for axis 0 with size N` twice in `tools/quantitative_comprehensive_analyzer.py` and twice in `quantitative/backtesting.py`, plus one `list index out of range`. Each one drops a holding's whole quantitative payload — which is where `volatility` comes from — so these feed the Task 4/5 cluster directly.
+
+`quantitative_comprehensive_analyzer.py:104` catches every one with a bare `except Exception` and logs `Error in comprehensive analysis: {e}`, so the crash site is not in the log. It must be located by reproduction.
+
+**Do not** also chase `cannot convert float NaN to integer` or the `_QualitativeInsightsRaw` failures — those are 2026-07-15 only. See "Known-Broken Ground".
+
+**Files:**
+- Modify: `src/finwiz/tools/quantitative_comprehensive_analyzer.py`, `src/finwiz/quantitative/backtesting.py`
+- Test: `tests/unit/quantitative/test_short_series_handling.py`
+
+- [ ] **Step 1: Reproduce with a real traceback**
+
+The bare `except Exception` hides the frame. Temporarily re-raise to find it:
+
+```bash
+uv run python - <<'EOF'
+import logging, traceback
+logging.basicConfig(level=logging.DEBUG)
+
+from finwiz.quantitative.backtesting import BacktestingEngine
+import pandas as pd
+
+# A frame far shorter than the strategy's lookback window — the shape that
+# produced "index N is out of bounds for axis 0 with size N" in the real run.
+short = pd.DataFrame(
+    {"Open": [1.0, 1.1], "High": [1.2, 1.3], "Low": [0.9, 1.0], "Close": [1.05, 1.15], "Volume": [100, 120]},
+    index=pd.date_range("2026-01-01", periods=2),
+)
+engine = BacktestingEngine()
+try:
+    engine.run_strategy_backtest(data=short, symbol="TEST")
+except Exception:
+    traceback.print_exc()
+EOF
+```
+
+Adjust the `run_strategy_backtest` call to its real signature (read it first). Record the file:line the traceback names — that is the site to guard.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/quantitative/test_short_series_handling.py`, using the file:line found in Step 1 to target the right entry point:
+
+```python
+"""Quantitative analysis must degrade on short series, not crash."""
+
+import pandas as pd
+import pytest
+
+from finwiz.quantitative.backtesting import BacktestingEngine
+
+
+def _frame(rows: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Open": [1.0 + i * 0.01 for i in range(rows)],
+            "High": [1.2 + i * 0.01 for i in range(rows)],
+            "Low": [0.9 + i * 0.01 for i in range(rows)],
+            "Close": [1.05 + i * 0.01 for i in range(rows)],
+            "Volume": [100 + i for i in range(rows)],
+        },
+        index=pd.date_range("2026-01-01", periods=rows),
+    )
+
+
+@pytest.mark.parametrize("rows", [0, 1, 2, 5, 20])
+def test_short_series_returns_a_result_or_none_but_never_raises(rows):
+    engine = BacktestingEngine()
+
+    result = engine.run_strategy_backtest(data=_frame(rows), symbol="TEST")
+
+    assert result is None or hasattr(result, "total_return")
+
+
+def test_sufficient_series_still_produces_a_backtest():
+    engine = BacktestingEngine()
+
+    result = engine.run_strategy_backtest(data=_frame(300), symbol="TEST")
+
+    assert result is not None
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/quantitative/test_short_series_handling.py -v -p no:randomly`
+Expected: FAIL — `IndexError: index N is out of bounds for axis 0 with size N` on the small `rows` cases.
+
+- [ ] **Step 4: Write minimal implementation**
+
+At the site found in Step 1, guard the length before indexing and return `None` when the series is too short:
+
+```python
+        if data is None or len(data) < self.MIN_BARS_FOR_BACKTEST:
+            logger.info("Skipping backtest for %s: %d bars, need %d", symbol, 0 if data is None else len(data), self.MIN_BARS_FOR_BACKTEST)
+            return None
+```
+
+Define `MIN_BARS_FOR_BACKTEST` from the strategy's longest lookback (`SimpleMovingAverageStrategy` uses a slow MA — read its period and use that, plus one bar). Return `None`, never a zero-filled result: a metric that could not be computed must stay absent so the critical-field gate and Plan B's `Evidence` can see the gap.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/quantitative -q`
+Expected: PASS — no failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/finwiz/tools/quantitative_comprehensive_analyzer.py src/finwiz/quantitative/backtesting.py tests/unit/quantitative/test_short_series_handling.py
+git commit -m "fix(quantitative): skip backtests on series shorter than the strategy lookback"
+```
+
+---
+
+## Task 16: Full-run verification
+
+Everything above is unit-tested against fixtures. This task proves it on the real pipeline — the only way to verify the coverage claim.
+
+- [ ] **Step 1: Run the full quality gate**
+
+Run: `make check`
+Expected: lint, tests, unittest.mock check, docs validation, complexity and dead-code all pass.
+
+Note: `make check` invokes the docs-validation hook, which runs `uv sync` and can drop the `docs` dependency group. If `mkdocs` then fails with `No module named 'mermaid2'`, restore with `uv sync --group docs`.
+
+- [ ] **Step 2: Run the real flow**
+
+Run: `crewai flow kickoff`
+Expected: completes without an unhandled exception.
+
+- [ ] **Step 3: Verify coverage from the ledger, not from the report**
+
+```bash
+python3 - <<'EOF'
+import json, glob, os, collections
+f = max(glob.glob('output/run_ledger/*.jsonl'), key=os.path.getmtime)
+rows = [json.loads(l) for l in open(f) if l.strip()]
+print(f, len(rows))
+print(collections.Counter((r['stage'], r['outcome']) for r in rows))
+failed = {r['ticker'] for r in rows if r['outcome'] == 'failed'}
+print('failed tickers:', len(failed), sorted(failed))
+EOF
+```
+
+Expected: `('emit', 'ok')` count equals the total ticker count minus genuinely-delisted names. The 2026-08-15 baseline was 39 emitted of 64, with 25 failed. Any remaining failure must be a delisted ticker (`XTSLA`, `UNI-USD`, `POL-USD`, `S-USD`, `IMX-USD`, `GRT-USD`, `COMP-USD`) and must appear by name.
+
+- [ ] **Step 4: Verify discovery actually searched**
+
+```bash
+grep -E "Universe for (stock|etf|crypto)|filter_actionable_candidates" logs/finwiz.log | tail -10
+cat output/discovery/scored_etf.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d['scored']), 'scored,', d['actionable_count'], 'actionable')"
+```
+
+Expected: each universe ≥50 tickers (or a logged shortfall). `scored_*.json` exists and is non-empty. A zero actionable count is now an honest finding backed by a visible scored list — not an unexplained "0".
+
+- [ ] **Step 5: Verify no fabricated tickers reached the artifacts**
+
+```bash
+grep -l "VTI\|VXUS\|BND" output/discovery/a_plus_*.json || echo "clean: no fabricated tickers"
+```
+
+Expected: `clean: no fabricated tickers`.
+
+- [ ] **Step 6: Commit the verification evidence**
+
+```bash
+git add -A
+git commit -m "chore: record full-run coverage verification for the pipeline plan"
+```
+
+---
+
+## Done when
+
+- `make check` passes.
+- A real `crewai flow kickoff` emits for every ticker except genuinely-delisted ones, and those are named.
+- No `TransientStageError: fact_pack unavailable` for a ticker with a reachable Perplexity endpoint and any cache entry under 90 days old.
+- No `Error saving cache metadata` and no `index N is out of bounds` in `grep "$(date +%Y-%m-%d)" logs/finwiz_error.log`.
+- No `CriticalFieldError` naming `volatility` for any ticker whose `price_history` is present.
+- Every asset class searched a universe of ≥50 candidates, or logged why it could not.
+- `output/discovery/scored_*.json` exists, so a zero-opportunity result is backed by a visible scored list.
+- `grep -r "discovery_latest.json" src/` returns nothing.
+- `grep -r "VTI\|VXUS\|BND" src/finwiz/scoring/*_analyzer.py` returns nothing.
+
+## Not in this plan
+
+Spec §1, §2, §3 and §5 — the two-artifact split, view models and `Evidence`, the qualitative `verdict`/`detail` contract, and cost truth — are Plan B. Plan B is written after this plan executes, so its fixtures come from a full-coverage run rather than the degraded 39/64 one.

--- a/docs/superpowers/plans/2026-08-15-pipeline-coverage.md
+++ b/docs/superpowers/plans/2026-08-15-pipeline-coverage.md
@@ -83,12 +83,14 @@ The vendored client at `.venv/.../crewai_custom_tools/tools/web/perplexity_struc
 Because status codes are not observable through that surface, this wrapper retries **by outcome** (`None`), not by status. It fails fast on a missing API key so a misconfiguration does not burn four attempts.
 
 **Files:**
+
 - Create: `src/finwiz/infrastructure/resilience/perplexity_retry.py`
 - Test: `tests/unit/infrastructure/test_perplexity_retry.py`
 
 **Interfaces:**
+
 - Consumes: `perplexity_structured` from `crewai_custom_tools` (async, keyword-only: `prompt`, `schema`, `system`, `model`, `search_recency_filter`, `timeout`, `api_key`).
-- Produces: `async def perplexity_with_retry(*, prompt: str, schema: type[T], system: str, search_recency_filter: str | None = "month", timeout: float = 15.0, max_attempts: int = 4, base_delay: float = 1.0) -> T | None` and `PERPLEXITY_CONCURRENCY` / `get_perplexity_semaphore() -> asyncio.Semaphore`. Tasks 2 and 12 consume both.
+- Produces: `async def perplexity_with_retry(*, prompt: str, schema: type[T], system: str, search_recency_filter: str | None = "month", timeout: float = 15.0, max_attempts: int = 4, base_delay: float = 1.0) -> T | None` and `PERPLEXITY_CONCURRENCY` / `get_perplexity_semaphore() -> threading.BoundedSemaphore`. Tasks 2 and 12 consume both.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -174,8 +176,16 @@ async def test_missing_api_key_fails_fast_without_retrying(mocker, monkeypatch):
 
 def test_semaphore_is_a_process_singleton():
     assert get_perplexity_semaphore() is get_perplexity_semaphore()
-    assert isinstance(get_perplexity_semaphore(), asyncio.Semaphore)
 ```
+
+> **Corrected 2026-08-16.** This test originally asserted
+> `isinstance(get_perplexity_semaphore(), asyncio.Semaphore)` — the exact
+> property that made the throttle broken. Production runs one holding per
+> `ThreadPoolExecutor` worker, a worker has no running loop, so each holding
+> gets a fresh event loop; an `asyncio.Semaphore` binds to the first loop that
+> contends on it and raises on every other. Measured at production numbers,
+> 5 of 10 holdings were lost with no rate limit involved. The throttle must be
+> a loop-agnostic `threading.BoundedSemaphore`; do not assert the asyncio type.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -219,15 +229,20 @@ T = TypeVar("T", bound=BaseModel)
 # the account allows. This caps in-flight requests process-wide.
 PERPLEXITY_CONCURRENCY = int(os.getenv("PERPLEXITY_CONCURRENCY", "4"))
 
-_semaphore: asyncio.Semaphore | None = None
+_throttle: threading.BoundedSemaphore | None = None
 
 
-def get_perplexity_semaphore() -> asyncio.Semaphore:
-    """Return the process-wide Perplexity concurrency semaphore."""
-    global _semaphore
-    if _semaphore is None:
-        _semaphore = asyncio.Semaphore(PERPLEXITY_CONCURRENCY)
-    return _semaphore
+def get_perplexity_semaphore() -> threading.BoundedSemaphore:
+    """Return the process-wide Perplexity concurrency throttle.
+
+    A threading primitive, not an asyncio one: production gives each holding
+    its own event loop (one holding per ThreadPoolExecutor worker), and an
+    asyncio.Semaphore binds to the first loop that contends on it.
+    """
+    global _throttle
+    if _throttle is None:
+        _throttle = threading.BoundedSemaphore(PERPLEXITY_CONCURRENCY)
+    return _throttle
 
 
 def _has_api_key() -> bool:
@@ -308,10 +323,12 @@ git commit -m "feat(resilience): add Perplexity retry wrapper with backoff and c
 `fact_pack_research.py:183-189` calls `perplexity_structured` directly, exactly once. This is the call that failed 28 times in the 2026-08-15 run (20 transport timeouts, 8 HTTP 429s) and cost 22 holdings.
 
 **Files:**
+
 - Modify: `src/finwiz/analysis/fact_pack_research.py:15` (import), `:183-189` (call site)
 - Test: `tests/unit/analysis/test_fact_pack_stage.py`
 
 **Interfaces:**
+
 - Consumes: `perplexity_with_retry` from Task 1.
 - Produces: no signature change — `fetch_fact_pack` and `fetch_fact_pack_sync` keep their exact existing signatures (`fetch_fact_pack_sync(ticker: str, company_name: str, sector: str | None = None, industry: str | None = None, *, timeout: float = 15.0) -> FactPack | None`).
 
@@ -389,11 +406,13 @@ git commit -m "fix(fact_pack): retry Perplexity fetches instead of failing on fi
 Introduce a dedicated exception the resilience layer recognises, so the declared retry actually happens.
 
 **Files:**
+
 - Modify: `src/finwiz/analysis/stages/fact_pack.py:74`
 - Modify: `src/finwiz/analysis/stages/_resilience.py:46-62`
 - Test: `tests/unit/analysis/test_fact_pack_stage.py` (append)
 
 **Interfaces:**
+
 - Produces: `class TransientStageError(RuntimeError)` in `src/finwiz/analysis/stages/_resilience.py`, exported for any stage body that wants its declared `retries` to be reachable.
 
 - [ ] **Step 1: Write the failing test**
@@ -501,10 +520,12 @@ It currently does not. `FactPack.derive_freshness` (`schemas/hybrid_analysis/fac
 Corporate structure and leadership do not turn over in a fortnight. Widen the stale band and let the payload's own `freshness` label carry the caveat — which is exactly the trust-spine design ("staleness is a payload field, NOT a stage outcome", `fact_pack.py:3-5`).
 
 **Files:**
+
 - Modify: `src/finwiz/schemas/hybrid_analysis/fact_pack.py:45-53`
 - Test: `tests/unit/analysis/test_fact_pack_stage.py` (append)
 
 **Interfaces:**
+
 - Produces: `FactPack.derive_freshness(fetched_at: datetime) -> str` — unchanged signature, wider stale band, raising only beyond the new horizon.
 
 - [ ] **Step 1: Write the failing test**
@@ -593,10 +614,12 @@ git commit -m "fix(fact_pack): widen the stale window so an old cache can still 
 `technical_fallback.py` fills MA50/MA200/RSI/MACD/beta from `price_history` but has **no volatility branch** (grep for "volatility" in that file returns nothing). Meanwhile `calculate_volatility(returns: pd.Series, annualize: bool = True) -> float` already exists at `quantitative/risk/risk_metrics.py:19`, built on empyrical's `annual_volatility`. `raw_data["price_history"]` is a `pandas.Series` of daily closes set at `deep_analysis_data_collector.py:436`.
 
 **Files:**
+
 - Modify: `src/finwiz/scoring/technical_fallback.py`
 - Test: `tests/unit/scoring/test_volatility_fallback.py`
 
 **Interfaces:**
+
 - Consumes: `calculate_volatility` from `finwiz.quantitative.risk.risk_metrics`.
 - Produces: `calculate_missing_technical_indicators(data: dict[str, Any], price_history: pd.Series | None = None) -> dict[str, Any]` — unchanged signature, now also sets `data["volatility"]` when absent and `price_history` has ≥2 points.
 
@@ -716,10 +739,12 @@ This is the ordering bug. In `deep_analysis_scorer.calculate_composite_score`:
 So no fallback can ever rescue a critical field: the raise has already fired. This is why `beta` (critical for stocks, `critical_fields_config.py:18`) can never be rescued by the existing `data["beta"] = 1.0` fallback at `technical_fallback.py:50-51` either. Task 4 is inert until this task lands.
 
 **Files:**
+
 - Modify: `src/finwiz/scoring/deep_analysis_scorer.py:92-100`
 - Test: `tests/unit/scoring/test_volatility_fallback.py` (append)
 
 **Interfaces:**
+
 - Consumes: `calculate_missing_technical_indicators` (Task 4).
 - Produces: no signature change to `calculate_composite_score`.
 
@@ -815,10 +840,12 @@ Two producers disagree on units. `performance_metrics.py:90` emits fractional vo
 The gate bound is `v > 5.0` (`critical_fields_config.py:162`), so a percent-scaled 25.3 is rejected as `volatility (invalid value: 25.3)` — a units bug reported as missing data.
 
 **Files:**
+
 - Modify: `src/finwiz/config/critical_fields_config.py`
 - Test: `tests/unit/scoring/test_volatility_fallback.py` (append)
 
 **Interfaces:**
+
 - Produces: `normalize_volatility(value: float | int | None) -> float | None` in `finwiz.config.critical_fields_config`.
 
 - [ ] **Step 1: Write the failing test**
@@ -924,10 +951,12 @@ git commit -m "fix(validation): normalize percent-scaled volatility instead of r
 `discovery/ticker_hygiene.py` exists and blocklists `XTSLA` by name at `:30` ("BlackRock cash-sweep placeholder, not a tradable ticker"), exposing `is_tradable()` at `:44` and `sanitize_symbols()` at `:49`. It is applied in `market_data.py:85` and `:175` — but `universe_provider.py`, `breakout_detector.py` and `momentum_scanner.py` contain zero references to it. That is why `XTSLA` entered the universe and produced nine `Quote not found for symbol: XTSLA` errors in the run.
 
 **Files:**
+
 - Modify: `src/finwiz/discovery/universe_provider.py:87`
 - Test: `tests/unit/discovery/test_universe_provider_selection.py`
 
 **Interfaces:**
+
 - Consumes: `sanitize_symbols` from `finwiz.discovery.ticker_hygiene`.
 - Produces: `DynamicUniverseProvider.get_universe(asset_class: str, exclude_tickers: list[str] | None = None) -> list[str]` — unchanged signature, now hygiene-filtered.
 
@@ -998,6 +1027,7 @@ seed_etfs = self._seed_etfs or self.DEFAULT_STOCK_SEED_ETFS if asset_class == "s
 Python binds this as `(self._seed_etfs or self.DEFAULT_STOCK_SEED_ETFS) if asset_class == "stock" else self.DEFAULT_ETF_SEED_ETFS`, so the constructor's `seed_etfs` override is **unreachable for ETFs** — the ETF path always uses `DEFAULT_ETF_SEED_ETFS = ["VT", "AOA", "AOR"]`. Line 74's `except (ValueError, Exception)` is also a catch-all whose first member is dead (`ValueError` is an `Exception`).
 
 **Files:**
+
 - Modify: `src/finwiz/discovery/universe_provider.py:71,74`
 - Test: `tests/unit/discovery/test_universe_provider_selection.py` (append)
 
@@ -1068,10 +1098,12 @@ Spec §4.3: at least 50 candidates per asset class must survive exclusion, and a
 Measured on 2026-08-15: `VT`(10) ∪ `AOA`(8) ∪ `AOR`(8) = 18 unique; 7 already held; 11 remained. The static fallback returns far more — `ScreeningUtils().get_screening_universe(...)` yields 50 for `etf`, 66 for `stock`, 39 for `crypto` (verified by execution). So the fix is to union the static universe in when mining falls short, not to replace mining.
 
 **Files:**
+
 - Modify: `src/finwiz/discovery/universe_provider.py`
 - Test: `tests/unit/discovery/test_universe_provider_selection.py` (append)
 
 **Interfaces:**
+
 - Produces: module constant `MIN_UNIVERSE_SIZE = 50` in `finwiz.discovery.universe_provider`.
 
 - [ ] **Step 1: Write the failing test**
@@ -1164,10 +1196,12 @@ git commit -m "feat(discovery): enforce a minimum universe size and log shortfal
 Any pipeline exception therefore injects invented A+ tickers into `a_plus_*.json` and into the family report. This is the single largest correctness hazard in the discovery area, and it is exactly the failure mode the spec exists to eliminate: presenting fabricated output as authoritative.
 
 **Files:**
+
 - Modify: `src/finwiz/scoring/etf_analyzer.py`, `src/finwiz/scoring/stock_analyzer.py`, `src/finwiz/scoring/crypto_analyzer.py`
 - Test: `tests/unit/scoring/test_discovery_analyzers.py`
 
 **Interfaces:**
+
 - Produces: `analyze_etf_opportunities(session_id: str) -> dict[str, Any]` (and stock/crypto twins) — unchanged signature. On pipeline failure it now returns an empty, honestly-labelled result instead of invented data.
 
 - [ ] **Step 1: Write the failing test**
@@ -1307,6 +1341,7 @@ This is why every holding logged "No discovery crew output found at output/disco
 Spec §4.4 resolution: point the readers at the real file, retire the dead name.
 
 **Files:**
+
 - Modify: `src/finwiz/tools/alternative_finder_tool.py:179,181`
 - Modify: `src/finwiz/orchestrators/extraction/engine.py:169,192`
 - Modify: `src/finwiz/infrastructure/json/to_html_converter.py:38-39`
@@ -1381,10 +1416,12 @@ git commit -m "fix(discovery): read the artifact discovery actually writes"
 `_filter_actionable` runs at `scoring/discovery/pipeline.py:105`; `_persist_result` runs at `:121`. So `newcomer_*.json` only ever contains post-filter survivors, and the 29/42/10 candidates dropped on 2026-08-15 are unrecoverable from this run's outputs. That contradicts the stated rationale at `candidate_scorer.py:40-42` ("callers that legitimately need the full scored list (diagnostics, tests)") and makes Task 13's calibration unverifiable against real data.
 
 **Files:**
+
 - Modify: `src/finwiz/scoring/discovery/pipeline.py:105,121`
 - Test: `tests/unit/scoring/discovery/test_pipeline.py` (existing — append)
 
 **Interfaces:**
+
 - Produces: `output/discovery/scored_{asset_class}.json` with shape `{"asset_class": str, "scored": list[dict], "actionable_count": int}`.
 
 - [ ] **Step 1: Write the failing test**
@@ -1480,10 +1517,12 @@ So a genuinely strong candidate cannot currently reach C. That is the real reaso
 The floor stays at C — noise stays out, per the project rule that discovery scanners exclude weak signals rather than emitting them with D/F grades. What changes is the formula's dynamic range, so that a strong performer can actually clear the bar.
 
 **Files:**
+
 - Modify: `src/finwiz/discovery/market_data.py:207-228`
 - Test: `tests/unit/discovery/test_factor_score.py`
 
 **Interfaces:**
+
 - Produces: `factor_score_from_returns(returns: list[float] | None) -> float | None` — exact current signature at `market_data.py:207`, preserved. It takes a **plain list of floats**, not a pandas Series, and returns `None` for series shorter than 5 points.
 
 - [ ] **Step 1: Write the failing test**
@@ -1624,10 +1663,12 @@ git commit -m "fix(discovery): calibrate factor score so strong candidates can r
 Two occurrences on 2026-08-15. Every one silently loses a cache write — and a cold cache is exactly what turns a Perplexity rate-limit into a dead holding (Tasks 2-3). The `json.dump` also omits `default=str`, violating the project rule.
 
 **Files:**
+
 - Modify: `src/finwiz/quantitative/data_processors.py:132-138`
 - Test: `tests/unit/quantitative/test_cache_metadata.py`
 
 **Interfaces:**
+
 - Produces: `DataProcessor.save_cache_metadata(cache_metadata: dict[str, Any], cache_metadata_file: Path) -> None` — unchanged signature.
 
 - [ ] **Step 1: Write the failing test**
@@ -1736,6 +1777,7 @@ Confirmed in the 2026-08-15 run: `index N is out of bounds for axis 0 with size 
 **Do not** also chase `cannot convert float NaN to integer` or the `_QualitativeInsightsRaw` failures — those are 2026-07-15 only. See "Known-Broken Ground".
 
 **Files:**
+
 - Modify: `src/finwiz/tools/quantitative_comprehensive_analyzer.py`, `src/finwiz/quantitative/backtesting.py`
 - Test: `tests/unit/quantitative/test_short_series_handling.py`
 

--- a/docs/superpowers/plans/2026-08-15-pipeline-coverage.md
+++ b/docs/superpowers/plans/2026-08-15-pipeline-coverage.md
@@ -1259,6 +1259,13 @@ Expected: PASS — 2 passed
 
 Append to `tests/unit/scoring/test_discovery_analyzers.py`:
 
+> **Corrected 2026-08-15.** This test originally listed `AAPL`, `BTC-USD` and
+> `ETH-USD` — tickers that never appeared in these modules. Written that way it
+> passes against fully intact fabrication, certifying the exact thing this task
+> removes. The three invented sets genuinely differ (etf `VTI`/`VXUS`/`BND`,
+> stock `MSFT`/`NVDA`/`GOOGL`, crypto `BTC`/`ETH`); read each module and pin its
+> own list rather than assuming they match.
+
 ```python
 import pytest
 
@@ -1266,8 +1273,8 @@ import pytest
 @pytest.mark.parametrize(
     ("module_name", "invented"),
     [
-        ("finwiz.scoring.stock_analyzer", ("AAPL", "MSFT", "NVDA")),
-        ("finwiz.scoring.crypto_analyzer", ("BTC-USD", "ETH-USD")),
+        ("finwiz.scoring.stock_analyzer", ("MSFT", "NVDA", "GOOGL")),
+        ("finwiz.scoring.crypto_analyzer", ("BTC", "ETH")),
     ],
 )
 def test_other_analyzers_have_no_hardcoded_tickers(module_name, invented):

--- a/docs/superpowers/specs/2026-08-15-report-rethink-design.md
+++ b/docs/superpowers/specs/2026-08-15-report-rethink-design.md
@@ -1,0 +1,269 @@
+# Report Rethink — Design
+
+**Date:** 2026-08-15
+**Status:** Approved design, ready for implementation planning
+**Scope:** `src/finwiz/reporting/`, `src/finwiz/analysis/stages/`, `src/finwiz/schemas/hybrid_analysis/strategic.py`, `src/finwiz/analysis/strategic_research.py`, `src/finwiz/discovery/`, `src/finwiz/infrastructure/monitoring/litellm_callback.py`
+
+## Problem
+
+The run of 2026-08-15 09:34 produced `output/finwiz_family_financial_plan.html` (435 KB). It presents partial data with full authority, mixes two languages, and contradicts itself inside a single page.
+
+### Observed defects
+
+| # | Location | Symptom |
+|---|---|---|
+| 1 | `reporting/sections/portfolio_summary.py:127` | 700-word AI essay with raw markdown (`**bold**`, `- ` bullets) and unresolved citation markers (`[3]`, `[8]`, `[VAHN JSON]`) rendered via `escape()` into one `<p>` |
+| 2 | `reporting/sections/portfolio_summary.py:117` | Section titled "Posture Stratégique **du Portefeuille**" synthesized from 3 holdings (ORCL, VAHN, TSLA) |
+| 3 | `reporting/sections/analysis.py:41-55` | "45 Successful Analyses / 0 Failed / 100.0% Success Rate" on the same page as "Couverture: 39/64 (25 échoués)" |
+| 4 | `reporting/sections/analysis.py:84-102` | "0 LLM Calls / 0.0s Total Time / $0.00" — `metrics` dict never populated |
+| 5 | `reporting/sections/insights.py:197-206` | `cost_total_and_calls()` discards the monitor's `cost_known` flag, so `$0.00 sur 781 appels LLM` prints as fact over 11.4M unpriced tokens |
+| 6 | `reporting/sections/discovery.py:220` | "0 New Opportunities Identified" presented as a finding |
+| 7 | `tools/alternative_finder_tool.py:179`, `orchestrators/extraction/engine.py:169,192` | All three read `output/discovery/discovery_latest.json`, which nothing writes |
+| 8 | `analysis/stages/fact_pack.py:74` | `RuntimeError` kills 22 of 64 holdings on Perplexity 429 / transport timeout |
+| 9 | `scoring/deep_analysis_scorer.py:445` | `CriticalFieldError: Missing critical fields: volatility` kills 3 more holdings |
+| 10 | `discovery/universe_provider.py:89` | ETF universe = 11 tickers after excluding 71 holdings |
+| 11 | Report structure | 15 sections, 7 English headings / 8 French |
+
+### Evidence
+
+Run ledger `output/run_ledger/4ac8188848aa.jsonl`, 306 rows, 64 tickers:
+
+```
+collect    ok 64
+quantify   ok 61   failed 3    (CriticalFieldError: volatility)
+fact_pack  ok 39   failed 22   (RuntimeError: Perplexity fetch failed)
+qualify    ok 39
+synthesize ok 39
+emit       ok 39
+```
+
+Perplexity failures, `logs/finwiz.log`:
+
+```
+20  Perplexity transport error for _FactPackRaw:
+ 3  Perplexity HTTP 429 for SwotAnalysis
+ 2  Perplexity HTTP 429 for PestelAnalysis
+ 2  Perplexity HTTP 429 for _FactPackRaw
+ 1  Perplexity transport error for SwotAnalysis:
+ 1  Perplexity HTTP 429 for FiveForcesAnalysis
+```
+
+Cost, `logs/finwiz.log:6352`:
+
+```
+LLM Cost Summary (estimated from CrewAI usage metrics):
+  deep_analysis_stock:  cost n/a (unpriced model) (138 calls, 1946467 tokens)
+  deep_analysis_crypto: cost n/a (unpriced model) (39 calls, 564654 tokens)
+  deep_analysis_etf:    cost n/a (unpriced model) (604 calls, 8916020 tokens)
+  TOTAL: ~$0.0000 estimated across 781 calls
+```
+
+Discovery, `logs/finwiz.log:5944-5956`:
+
+```
+Universe for etf: 11 tickers (source=dynamic, excluded=71)
+Portfolio-aware scoring produced 10 scored etf candidates
+filter_actionable_candidates: 10 scored -> 0 actionable (dropped 10 grade<C)
+```
+
+The grade filter behaved correctly — weak signals are excluded rather than emitted as D/F. The defect is upstream: a universe of 11 candidates is not a search.
+
+### Root cause
+
+Two roots, not eleven:
+
+1. **No section knows its own evidence base.** Each section reads raw dicts independently and renders at full confidence regardless of what it received. Defects 1-6 are all instances of this.
+2. **A rate-limited dependency fails closed.** One Perplexity 429 destroys an entire holding rather than degrading it. Defects 8 and 10 share this.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Audience | Family, non-technical. Plain French. |
+| Partial data | Pipeline's job to reach full coverage; document refuses only what it genuinely lacks |
+| Qualitative rendering | Two layers — one-sentence verdict, detail behind `<details>` |
+| Machinery content | Relocated to a second artifact, not deleted |
+| Architecture | Section contract + view models (rejected: patch-in-place; rejected: Jinja2 swap) |
+
+Rejected approaches and why:
+
+- **Patch each site.** Fastest, but the defect class recurs — nothing prevents the next section from printing an unbacked number.
+- **Jinja2 template swap.** Better long-term ergonomics, but lands a second large change alongside the semantic one. The f-string path in `python_report_generator.py` is the one production renders; churning it while changing semantics doubles blast radius.
+
+## Design
+
+### 1. Two artifacts, one run
+
+`FinwizFlow` Phase 6 emits both from the same view models.
+
+| | `finwiz_family_financial_plan.html` | `finwiz_run_report.html` |
+|---|---|---|
+| Reader | family | maintainer |
+| Language | French only | French, technical terms kept |
+| Positions | verdict + short reason | full detail, all fields |
+| Qualitative | verdict; `<details>` for reasoning | full PESTEL/SWOT/Porter + sources |
+| Numbers | grades as words ("solide", "fragile") | scores, components, weights |
+| Coverage | one line: "39 des 64 positions analysées" | per-stage ledger, failures named with reason |
+| Cost | absent | tokens, calls, per-crew, "non chiffrable" where true |
+| Machinery | absent | success rate, timings, retries, fallbacks |
+
+Split rule: **family answers "what do we do"; run report answers "can we trust it and what did it cost"**. Every existing section lands in exactly one. Nothing is dropped.
+
+Because both render from the same view models, the defect-3 contradiction becomes structurally impossible.
+
+### 2. Section contract + view models
+
+```
+enrichment.py (raw dicts, crew exports, ledger)
+        │
+        ▼  builders/     pure Python, no AI, no HTML
+   view_models/          typed, carry their own evidence
+        │
+        ├──▶ renderers/family/     → finwiz_family_financial_plan.html
+        └──▶ renderers/technical/  → finwiz_run_report.html
+```
+
+Every view model embeds evidence as a mandatory field:
+
+```python
+class Evidence(BaseModel):
+    covered: int              # items this section actually used
+    total: int                # items it claims to describe
+    basis: list[str] = []     # tickers or sources behind it
+    known: bool = True        # False = measured but not trustworthy
+    missing: list[str] = []   # named gaps
+```
+
+Renderers enforce it; sections cannot opt out:
+
+- `covered < total` → scope line printed before the content (fixes defects 2, 3)
+- `known is False` → renders "non chiffrable", never `$0.00` (fixes defect 5)
+- `covered == 0` → renders a refusal, not an empty table under a confident heading (fixes defect 6)
+
+**New modules**
+
+| Path | Role |
+|---|---|
+| `reporting/view_models/*.py` | one Pydantic model per section, plus `Evidence` |
+| `reporting/builders/*.py` | raw → view model; deterministic, testable without HTML |
+| `reporting/renderers/family/*.py` | word-grades, verdict-only, French |
+| `reporting/renderers/technical/*.py` | full numbers, ledger, cost |
+
+**Changed modules**
+
+| Path | Change |
+|---|---|
+| `reporting/python_report_generator.py` | stays production entry; orchestrates builders + two renderers instead of holding f-strings |
+| `reporting/sections/*.py` (9 files) | logic moves to builders, markup to renderers; thin re-export shims remain |
+| `reporting/css_styles.py` | shared; family gets a reduced sheet |
+| `reporting/section_generators.py` | re-export shim, kept so imports outside `reporting/` keep working |
+
+### 3. Qualitative contract
+
+```python
+class QualitativeBlock(BaseModel):
+    verdict: str              # 1 sentence, plain French, <=30 words
+    detail: str               # reasoning, plain French prose, <=200 words
+    sources: list[str] = []   # resolved URLs/titles, not [3] markers
+```
+
+Validators make the essay structurally impossible rather than cleaned up after the fact:
+
+- `verdict`: reject `**`, `- `, `#`, newlines; enforce the 30-word cap
+- both fields: reject unresolved `[n]` and `[TICKER JSON]` markers — they move to `sources` or are stripped
+- `detail`: enforce the 200-word cap; markdown bullets convert to a real list at build time
+
+`PortfolioStrategicPosture` (`schemas/hybrid_analysis/strategic.py:158`) changes:
+
+| Field | Now | After |
+|---|---|---|
+| `macro_environment_summary` | `str` | `QualitativeBlock` |
+| `competitive_landscape_summary` | `str` | `QualitativeBlock` |
+| `overall_assessment` | `str` | `QualitativeBlock` |
+| `portfolio_strengths` / `_weaknesses` / `_opportunities` / `_threats` | `list[str]` | unchanged |
+| `dominant_themes` | `list[str]` | unchanged |
+| `strategic_score`, `confidence` | AI-rated | unchanged — the AI rates its own analysis |
+| — | — | **new** `basis: list[str]` — tickers the synthesis actually used |
+
+`basis` feeds `Evidence.basis`, so the posture section self-labels its real scope instead of claiming the whole portfolio.
+
+Prompt changes at `analysis/strategic_research.py:100`: request `verdict` and `detail` as separate fields, ban markdown explicitly, forbid citing the input payload (source of `[VAHN JSON]`), state the word caps. Structured output already uses Perplexity's native schema path, so the model is constrained rather than merely asked.
+
+Rendering: family shows `verdict` plain with `detail` inside `<details><summary>Pourquoi</summary>`; the run report shows both open plus `sources` and `basis`.
+
+**Migration:** a `mode="before"` validator promotes a bare `str` to `QualitativeBlock(verdict=<first sentence>, detail=<rest>)`, so cached exports under `output/` still load.
+
+### 4. Coverage fixes
+
+**4.1 fact_pack — 22 failures.** `analysis/stages/fact_pack.py:74`. The stale-cache fallback at line 68 is correct but never fired: these tickers had no cache at all, and live fetch died on 20 transport timeouts plus 8 HTTP 429s.
+
+- Exponential backoff with jitter on 429, honoring `Retry-After`
+- Concurrency throttle on Perplexity so a run stops inflicting 429s on itself. Per-item caps only — no aggregate `wait_for` around a gather, which discards completed work
+- Cache warm survives across runs, so a rate-limited run degrades to stale rather than to nothing
+- `@stage(retries=1)` at line 76 retries after backoff, not immediately
+
+**4.2 volatility — 3 failures.** `scoring/deep_analysis_scorer.py:445` lists `volatility` among critical fields. The collect stage already pulls price history, from which volatility is derivable. Compute it in collect rather than failing in quantify. Where history genuinely does not exist (`XTSLA`, `UNI-USD`, `POL-USD`, `S-USD`, `IMX-USD`, `GRT-USD`, `COMP-USD` — all confirmed delisted in the log), the position is legitimately unanalyzable and is refused by name.
+
+**4.3 Discovery universe.** `discovery/universe_provider.py:89` returned 11 ETF tickers after excluding 71 holdings. Widen the dynamic universe so that **at least 50 candidates per asset class survive exclusion**; a universe that cannot meet that floor logs the shortfall rather than silently scanning a handful. The grade-C actionability threshold stays unchanged — noise stays out, and a genuinely empty result after a real search is a valid finding.
+
+**4.4 `discovery_latest.json`.** Written by nothing; read by `tools/alternative_finder_tool.py:179` and `orchestrators/extraction/engine.py:169,192`. Discovery writes `consolidated_discovery.json` instead. Consequence: "No discovery crew output found" on every holding and empty alternatives portfolio-wide. **Resolution: point the three readers at `consolidated_discovery.json` and retire the `discovery_latest.json` name**, rather than adding a fourth writer. `infrastructure/json/to_html_converter.py:38-39` maps both names and needs the dead entry removed.
+
+**4.5 Secondary errors, folded in because they feed coverage:**
+
+- `data_processors.py` — `dictionary changed size during iteration` on cache metadata save; a concurrency bug that silently loses cache writes, which feeds 4.1
+- `quantitative_comprehensive_analyzer.py`, `backtesting.py` — `cannot convert float NaN to integer`, `index N is out of bounds for axis 0`
+- `_QualitativeInsightsRaw` — 6 OpenAI validation failures, 3 JSON repair failures
+
+Target: coverage 64/64 minus genuinely delisted tickers, which are named.
+
+### 5. Cost truth
+
+`litellm.cost_per_token` cannot price `openrouter/*` models, so `record_usage` (`litellm_callback.py:104-110`) sets `cost = None` for all three crews.
+
+Three layers, first hit wins:
+
+1. `litellm.cost_per_token` — works for `openai/*`
+2. OpenRouter's models endpoint, which publishes per-token prompt and completion prices. Cached to disk, refreshed daily. A direct `httpx` call and parse — not a crew, since it is one API call plus parsing
+3. Still unknown → `cost_known=False`; renderer prints token counts plus "coût non chiffrable", never `$0.00`
+
+Layer 3 already exists in the monitor and is discarded downstream. `Evidence.known` from §2 is where it is honored, so header, footer and cost section cannot diverge.
+
+`Performance Metrics` (`sections/analysis.py:84-102`) reads a different object than the monitor, hence `0 LLM Calls / 0.0s`. It is fed from the same view model as everything else.
+
+The run report surfaces the per-crew split: `deep_analysis_etf` consumed 604 calls and 8.9M tokens against `deep_analysis_stock`'s 138 calls and 1.9M — visible rather than buried in a total.
+
+### 6. Testing
+
+pytest-mock only; `unittest.mock` is banned and enforced by `make check-unittest-mock`.
+
+- **Builders:** unit tests with no HTML. The 39/64 run becomes a fixture; assert `Evidence(covered=39, total=64, missing=[...])`
+- **Renderers:** snapshot tests, one per artifact
+- **Regression:** assert `$0.00` never renders when `known is False`; assert no `**` or `[3]` survives into output
+- Coverage gates stay off AI and LLM paths — crews and prompts are excluded, never mock-covered
+
+### 7. Risks
+
+- **The §2 refactor touches 9 section files.** Mitigate by moving one section at a time, builders first, with the old path still rendering until its replacement passes snapshot
+- **§4.1 and §4.3 contend for the same Perplexity quota.** Widening the discovery universe adds load to the dependency whose rate limit caused the 25 failures. The throttle must account for discovery load, not fact_pack alone
+- **Prompt changes (§3) cannot be unit-tested for quality**, only for schema conformance. Verification requires a real `crewai flow kickoff`
+
+## Implementation order
+
+The spec is large. Phases are ordered so each is independently verifiable and none blocks on a later one.
+
+1. **Coverage (§4.1, §4.2, §4.5)** — pipeline only, no report changes. Verifiable by ledger: failures drop from 25 toward 0. Lands first because every later phase wants a full-coverage run to test against.
+2. **Cost truth (§5)** — monitor only, narrow blast radius. Verifiable from the log's cost summary alone.
+3. **View models + builders (§2, first half)** — new code beside the old path, nothing rendered differently yet. Verifiable by unit tests on the 39/64 fixture.
+4. **Renderers + two artifacts (§1, §2 second half)** — one section at a time, old path rendering until each replacement passes snapshot.
+5. **Qualitative contract (§3)** — schema, validators, prompt. Last, because it needs a real kickoff to verify and its output feeds renderers built in phase 4.
+6. **Discovery universe (§4.3, §4.4)** — after phase 1's throttle exists, since widening the universe adds load to the same quota.
+
+## Done when
+
+A full `crewai flow kickoff` produces both artifacts, with:
+
+- coverage at 64/64 minus named delisted tickers
+- no section rendering a number it cannot back
+- no `$0.00` where cost is unknown
+- no raw markdown or unresolved citation markers in either artifact
+- family artifact in French throughout, carrying no numbers beyond the coverage line

--- a/docs/superpowers/specs/2026-08-15-report-rethink-design.md
+++ b/docs/superpowers/specs/2026-08-15-report-rethink-design.md
@@ -12,7 +12,7 @@ The run of 2026-08-15 09:34 produced `output/finwiz_family_financial_plan.html` 
 
 | # | Location | Symptom |
 |---|---|---|
-| 1 | `reporting/sections/portfolio_summary.py:127` | 700-word AI essay with raw markdown (`**bold**`, `- ` bullets) and unresolved citation markers (`[3]`, `[8]`, `[VAHN JSON]`) rendered via `escape()` into one `<p>` |
+| 1 | `reporting/sections/portfolio_summary.py:127` | 700-word AI essay with raw markdown (`**bold**`, `-` bullets) and unresolved citation markers (`[3]`, `[8]`, `[VAHN JSON]`) rendered via `escape()` into one `<p>` |
 | 2 | `reporting/sections/portfolio_summary.py:117` | Section titled "Posture Stratégique **du Portefeuille**" synthesized from 3 holdings (ORCL, VAHN, TSLA) |
 | 3 | `reporting/sections/analysis.py:41-55` | "45 Successful Analyses / 0 Failed / 100.0% Success Rate" on the same page as "Couverture: 39/64 (25 échoués)" |
 | 4 | `reporting/sections/analysis.py:84-102` | "0 LLM Calls / 0.0s Total Time / $0.00" — `metrics` dict never populated |
@@ -169,7 +169,7 @@ class QualitativeBlock(BaseModel):
 
 Validators make the essay structurally impossible rather than cleaned up after the fact:
 
-- `verdict`: reject `**`, `- `, `#`, newlines; enforce the 30-word cap
+- `verdict`: reject `**`, `-`, `#`, newlines; enforce the 30-word cap
 - both fields: reject unresolved `[n]` and `[TICKER JSON]` markers — they move to `sources` or are stripped
 - `detail`: enforce the 200-word cap; markdown bullets convert to a real list at build time
 

--- a/src/finwiz/analysis/fact_pack_research.py
+++ b/src/finwiz/analysis/fact_pack_research.py
@@ -1,7 +1,7 @@
 """Fact pack fetcher (v5.2) — verified corporate facts via Perplexity.
 
-Mirrors strategic_research.py's pattern: direct httpx call via
-perplexity_structured(), sync wrapper for non-async callers.
+Calls Perplexity via ``perplexity_with_retry`` (retry + backoff wrapper
+around ``perplexity_structured``), with a sync wrapper for non-async callers.
 """
 
 from __future__ import annotations
@@ -12,10 +12,10 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from crewai_custom_tools import perplexity_structured
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from finwiz.analysis._helpers import _today_french
+from finwiz.infrastructure.resilience.perplexity_retry import perplexity_with_retry
 from finwiz.schemas.hybrid_analysis.fact_pack import FactPack
 
 if TYPE_CHECKING:
@@ -180,7 +180,7 @@ async def fetch_fact_pack(
     """
     prompt = _build_prompt(ticker, company_name, sector, industry)
     try:
-        raw = await perplexity_structured(
+        raw = await perplexity_with_retry(
             prompt=prompt,
             schema=_FactPackRaw,
             system=_SYSTEM_FR,

--- a/src/finwiz/analysis/stages/_resilience.py
+++ b/src/finwiz/analysis/stages/_resilience.py
@@ -50,9 +50,19 @@ if httpcore is not None:  # pragma: no branch
     _TRANSIENT_HTTP_TYPES = (*_TRANSIENT_HTTP_TYPES, httpcore.RemoteProtocolError)
 
 
+class TransientStageError(RuntimeError):
+    """A stage failure that is worth retrying (rate limit, upstream unavailable).
+
+    Plain RuntimeError stays non-transient: it signals a programming or state
+    error where a retry would only repeat the same wrong thing.
+    """
+
+
 def _is_transient(exc: BaseException) -> bool:
     if isinstance(exc, (ValidationError, AssertionError)):
         return False
+    if isinstance(exc, TransientStageError):
+        return True
     if isinstance(exc, _TRANSIENT_EXC):
         return True
     if isinstance(exc, httpx.HTTPStatusError):

--- a/src/finwiz/analysis/stages/fact_pack.py
+++ b/src/finwiz/analysis/stages/fact_pack.py
@@ -11,7 +11,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from finwiz.analysis.fact_pack_research import fetch_fact_pack_sync
-from finwiz.analysis.stages._resilience import StageContext, stage
+from finwiz.analysis.stages._resilience import StageContext, TransientStageError, stage
 from finwiz.cache.fact_pack_cache import FactPackCache
 from finwiz.schemas.hybrid_analysis.fact_pack import FactPack
 
@@ -47,7 +47,7 @@ def _fact_pack_inner(
            live fetch fails    → return cached (freshness=stale)
       3. Cache miss:
            live fetch succeeds → cache.put(new); return new
-           live fetch fails    → raise RuntimeError → @stage records FAILED
+           live fetch fails    → raise TransientStageError → @stage retries once, then records FAILED
 
     The freshness label on the returned payload is the only signal — the stage
     outcome is always OK or FAILED.
@@ -70,8 +70,10 @@ def _fact_pack_inner(
         logger.warning(f"fact_pack live fetch failed for {ticker}; using stale cache (fetched_at={cached.fetched_at})")
         return cached
 
-    # No cache and no live data — caller's @stage decorator records FAILED
-    raise RuntimeError(f"fact_pack unavailable for {ticker}: no cache and Perplexity fetch failed")
+    # No cache and no live data — TransientStageError (not plain RuntimeError) so the
+    # @stage decorator's declared retry can actually reach this failure; see
+    # _resilience._is_transient. Still recorded as FAILED once retries are exhausted.
+    raise TransientStageError(f"fact_pack unavailable for {ticker}: no cache and Perplexity fetch failed")
 
 
 @stage(name="fact_pack", timeout_s=60, retries=1)

--- a/src/finwiz/cache/fact_pack_cache.py
+++ b/src/finwiz/cache/fact_pack_cache.py
@@ -43,8 +43,9 @@ class FactPackCache:
         """Return cached FactPack if valid (any age — caller checks freshness).
 
         Returns None if file missing, corrupted, or schema version mismatched.
-        Returns FactPack even if 7-14d old (marked stale via freshness derivation).
-        Returns None if older than 14d (cache invalid).
+        Returns FactPack even if 7-90d old (marked stale via freshness derivation) —
+        a stale-but-labelled answer beats no cache at all on a rate-limited run.
+        Returns None if older than 90d (cache invalid).
         """
         path = self._path(ticker)
         if not path.exists():

--- a/src/finwiz/config/CLAUDE.md
+++ b/src/finwiz/config/CLAUDE.md
@@ -50,7 +50,7 @@ ANTHROPIC_API_KEY=...        # Optional
 BATCH_PREFETCH_ENABLED=true
 DEEP_ANALYSIS_BATCH_SIZE=5
 MAX_RETRIES=3
-FF_NEWCOMER_DISCOVERY=false  # Feature flags use FF_ prefix
+FF_PORTFOLIO_AWARE_DISCOVERY=false  # Feature flags use FF_ prefix
 ```
 
 ## Usage
@@ -60,7 +60,7 @@ from finwiz.config.settings import get_settings
 from finwiz.config.features.flags import is_feature_enabled
 
 settings = get_settings()
-if is_feature_enabled("newcomer_discovery"):
+if is_feature_enabled("portfolio_aware_discovery"):
     time_budget = settings.max_batch_processing_time_seconds
 ```
 

--- a/src/finwiz/config/critical_fields_config.py
+++ b/src/finwiz/config/critical_fields_config.py
@@ -166,6 +166,10 @@ def normalize_volatility(value: float | int | None) -> float | None:
     if v < 0.0 or v >= _VOLATILITY_ABSURD_CEILING:
         return None
     if v > 5.0:
+        # Backstop, not a live path. This rescale existed for percent-scaled volatility
+        # hoisted out of ``backtest_result``; that subtree is no longer flattened into the
+        # scorer's dict, and every remaining in-tree producer is fractional. Keep it: a new
+        # percent-scaled producer would otherwise be rejected as absurd rather than rescaled.
         return v / 100.0
     return v
 

--- a/src/finwiz/config/critical_fields_config.py
+++ b/src/finwiz/config/critical_fields_config.py
@@ -5,6 +5,7 @@ Defines which fields are CRITICAL (must have real data) vs OPTIONAL (can use def
 Missing critical fields should cause analysis to FAIL rather than use fallback values.
 """
 
+import math
 from typing import Any, Literal
 
 # Critical fields by asset class - MUST have real data or analysis fails
@@ -148,7 +149,8 @@ def normalize_volatility(value: float | int | None) -> float | None:
         value: Raw volatility, fractional (0.25) or percent-scaled (25.0).
 
     Returns:
-        Fractional volatility, or None when the value is missing, negative, or absurd.
+        Fractional volatility, or None when the value is missing, non-finite (NaN/inf),
+        negative, or absurd.
 
     """
     if value is None:
@@ -156,6 +158,10 @@ def normalize_volatility(value: float | int | None) -> float | None:
     try:
         v = float(value)
     except (TypeError, ValueError):
+        return None
+    if not math.isfinite(v):
+        # Covers NaN, +inf, and -inf: comparisons against NaN are always False, so the
+        # range checks below would otherwise let it slide through as "valid".
         return None
     if v < 0.0 or v >= _VOLATILITY_ABSURD_CEILING:
         return None

--- a/src/finwiz/config/critical_fields_config.py
+++ b/src/finwiz/config/critical_fields_config.py
@@ -134,6 +134,36 @@ def get_safe_default(field_name: str) -> float | None:
     return SAFE_DEFAULTS.get(field_name)
 
 
+# Annualized volatility above this is not a real reading — it is a units error
+# or corrupt data. Below it, values > 5.0 are treated as percent-scaled and
+# divided by 100 (two producers in-tree disagree on units; see
+# quantitative/performance_metrics.py:90 vs quantitative/backtesting_performance.py:246).
+_VOLATILITY_ABSURD_CEILING = 500.0
+
+
+def normalize_volatility(value: float | int | None) -> float | None:
+    """Coerce a volatility reading to the fractional scale, or None if unusable.
+
+    Args:
+        value: Raw volatility, fractional (0.25) or percent-scaled (25.0).
+
+    Returns:
+        Fractional volatility, or None when the value is missing, negative, or absurd.
+
+    """
+    if value is None:
+        return None
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if v < 0.0 or v > _VOLATILITY_ABSURD_CEILING:
+        return None
+    if v > 5.0:
+        return v / 100.0
+    return v
+
+
 def validate_critical_fields(ticker: str, asset_class: Literal["stock", "etf", "crypto"], data: dict[str, Any]) -> None:
     """
     Validate that all critical fields are present with real data.
@@ -171,6 +201,11 @@ def validate_critical_fields(ticker: str, asset_class: Literal["stock", "etf", "
 
     for field in critical_fields:
         value = data.get(field)
+
+        if field == "volatility":
+            value = normalize_volatility(value)
+            if value is not None:
+                data[field] = value
 
         # Check if field is missing or None
         if field not in data or value is None:

--- a/src/finwiz/config/critical_fields_config.py
+++ b/src/finwiz/config/critical_fields_config.py
@@ -157,7 +157,7 @@ def normalize_volatility(value: float | int | None) -> float | None:
         v = float(value)
     except (TypeError, ValueError):
         return None
-    if v < 0.0 or v > _VOLATILITY_ABSURD_CEILING:
+    if v < 0.0 or v >= _VOLATILITY_ABSURD_CEILING:
         return None
     if v > 5.0:
         return v / 100.0
@@ -189,6 +189,9 @@ def validate_critical_fields(ticker: str, asset_class: Literal["stock", "etf", "
         # These CAN be 0.0 legitimately, so only check for None or extreme values
         "debt_to_equity": lambda v: v is None or v < 0.0 or v > 100.0,
         "revenue_growth": lambda v: v is None or v < -0.95 or v > 10.0,  # -95% to 1000%
+        # Backstop only — normalize_volatility() already rejects/rescales upstream in the
+        # loop below, so a normalized value can never trip this. Kept so the field's
+        # contract doesn't silently depend on the caller remembering to normalize first.
         "volatility": lambda v: v is None or v < 0.0 or v > 5.0,
         "beta": lambda v: v is None or v < -5.0 or v > 10.0,
         # ETF metrics
@@ -203,9 +206,16 @@ def validate_critical_fields(ticker: str, asset_class: Literal["stock", "etf", "
         value = data.get(field)
 
         if field == "volatility":
-            value = normalize_volatility(value)
-            if value is not None:
+            normalized = normalize_volatility(value)
+            if normalized is not None:
+                value = normalized
                 data[field] = value
+            elif value is not None:
+                # Present but unusable (negative or absurd) — a units/data error,
+                # not a missing field. Report it honestly instead of masking it
+                # as "missing".
+                missing_fields.append(f"{field} (invalid value: {value})")
+                continue
 
         # Check if field is missing or None
         if field not in data or value is None:

--- a/src/finwiz/config/features/definitions.py
+++ b/src/finwiz/config/features/definitions.py
@@ -143,7 +143,7 @@ def create_default_flags() -> dict[str, FeatureFlagConfig]:
             enabled=get_env_bool("FF_NEWCOMER_DISCOVERY", True),
             strategy=FeatureFlagStrategy.BOOLEAN,
             fallback_strategy=FallbackStrategy.DEFAULT_VALUES,
-            description="Route stock/etf/crypto analyzers through NewcomerDiscoveryPipeline instead of legacy mocked data",
+            description="Retired: analyzers now always route through NewcomerDiscoveryPipeline unconditionally; this flag is no longer read anywhere",
         ),
         "portfolio_aware_discovery": FeatureFlagConfig(
             name="portfolio_aware_discovery",

--- a/src/finwiz/discovery/market_data.py
+++ b/src/finwiz/discovery/market_data.py
@@ -204,6 +204,21 @@ def get_sectors(tickers: list[str], asset_class: str = "stock") -> dict[str, str
     return out
 
 
+# Calibration target: a candidate up ~12%+ over a 6-month window with ordinary
+# daily volatility (~1.5%) must be able to reach the C floor (0.65,
+# grading_system.py:39-90), while a flat/mediocre/declining candidate at the
+# same volatility must not. The original gain of 4 centered at zero return
+# compressed realistic candidates into 0.50-0.65, so the grade ladder was
+# unreachable and discovery reported "0 opportunities" for a universe it had
+# graded rather than searched. The floor itself stays at C -- weak signals are
+# excluded, never low-graded. Values verified against a grid of representative
+# (cumulative return, daily volatility) pairs, not just the zero-volatility
+# degenerate case: see tests/unit/discovery/test_market_data.py.
+_MOMENTUM_GAIN = 9.0
+_MOMENTUM_CENTER = 0.05
+_VOL_PENALTY = 12.0
+
+
 def factor_score_from_returns(returns: list[float] | None) -> float | None:
     """Standalone quality factor score in ``[0, 1]`` from a daily-return series.
 
@@ -221,9 +236,9 @@ def factor_score_from_returns(returns: list[float] | None) -> float | None:
 
     arr = np.asarray(returns, dtype=float)
     cumulative = float(np.prod(1.0 + arr) - 1.0)
-    momentum = 1.0 / (1.0 + np.exp(-4.0 * cumulative))  # cumulative 0 -> 0.5
+    momentum = 1.0 / (1.0 + np.exp(-_MOMENTUM_GAIN * (cumulative - _MOMENTUM_CENTER)))
     daily_vol = float(arr.std())
-    vol_score = max(0.0, min(1.0, 1.0 - daily_vol * 20.0))  # ~5% daily vol -> 0
+    vol_score = max(0.0, min(1.0, 1.0 - daily_vol * _VOL_PENALTY))
     score = 0.7 * momentum + 0.3 * vol_score
     return max(0.0, min(1.0, float(score)))
 

--- a/src/finwiz/discovery/universe_provider.py
+++ b/src/finwiz/discovery/universe_provider.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar
 import yfinance as yf
 from crewai_custom_tools.tools.analytics.screening_utils import ScreeningUtils
 
+from finwiz.discovery.ticker_hygiene import sanitize_symbols
 from finwiz.tools.logger import get_logger
 
 
@@ -84,7 +85,7 @@ class DynamicUniverseProvider:
                 source = "static"
 
         # Deduplicate, filter exclusions, sort
-        result = sorted({t.upper() for t in tickers} - exclude_set)
+        result = sorted(set(sanitize_symbols(tickers)) - exclude_set)
 
         self._logger.info(
             "Universe for %s: %d tickers (source=%s, excluded=%d)",

--- a/src/finwiz/discovery/universe_provider.py
+++ b/src/finwiz/discovery/universe_provider.py
@@ -15,6 +15,12 @@ from crewai_custom_tools.tools.analytics.screening_utils import ScreeningUtils
 from finwiz.discovery.ticker_hygiene import sanitize_symbols
 from finwiz.tools.logger import get_logger
 
+# A universe smaller than this is not a search. Measured 2026-08-15: mining three
+# seed ETFs yielded 18 unique names, 11 after excluding the portfolio — every one
+# of which graded below the actionability floor. Discovery reported "0
+# opportunities" when the honest statement was "we looked at 11 candidates".
+MIN_UNIVERSE_SIZE = 50
+
 
 class DynamicUniverseProvider:
     """Provides dynamic ticker universes by mining ETF holdings and static lists."""
@@ -87,6 +93,19 @@ class DynamicUniverseProvider:
 
         # Deduplicate, filter exclusions, sort
         result = sorted(set(sanitize_symbols(tickers)) - exclude_set)
+
+        if len(result) < MIN_UNIVERSE_SIZE and asset_class != "crypto":
+            static = sanitize_symbols(self._fallback_static_universe(asset_class))
+            result = sorted(set(result) | (set(static) - exclude_set))
+            source = f"{source}+static"
+
+        if len(result) < MIN_UNIVERSE_SIZE:
+            self._logger.warning(
+                "Universe for %s has %d tickers, below the floor of %d — discovery coverage is limited this run",
+                asset_class,
+                len(result),
+                MIN_UNIVERSE_SIZE,
+            )
 
         self._logger.info(
             "Universe for %s: %d tickers (source=%s, excluded=%d)",

--- a/src/finwiz/discovery/universe_provider.py
+++ b/src/finwiz/discovery/universe_provider.py
@@ -69,10 +69,11 @@ class DynamicUniverseProvider:
             tickers = self._fallback_static_universe("crypto")
             source = "static"
         else:
-            seed_etfs = self._seed_etfs or self.DEFAULT_STOCK_SEED_ETFS if asset_class == "stock" else self.DEFAULT_ETF_SEED_ETFS
+            default_seeds = self.DEFAULT_STOCK_SEED_ETFS if asset_class == "stock" else self.DEFAULT_ETF_SEED_ETFS
+            seed_etfs = self._seed_etfs or default_seeds
             try:
                 tickers = self._mine_etf_holdings(seed_etfs)
-            except (ValueError, Exception):
+            except Exception:
                 self._logger.warning(
                     "Dynamic universe failed for %s, falling back to static",
                     asset_class,

--- a/src/finwiz/infrastructure/json/to_html_converter.py
+++ b/src/finwiz/infrastructure/json/to_html_converter.py
@@ -36,7 +36,6 @@ class JsonToHtmlConverter:
         "deep_analysis_etf_*.json": "enriched_analysis_report.html",
         "deep_analysis_crypto_*.json": "enriched_analysis_report.html",
         "discovery_output_*.json": "discovery_latest.html",
-        "discovery_latest.json": "discovery_latest.html",
         "a_plus_stocks.json": "a_plus_discovery.html",
         "a_plus_etfs.json": "a_plus_discovery.html",
         "a_plus_crypto.json": "a_plus_discovery.html",

--- a/src/finwiz/infrastructure/resilience/perplexity_retry.py
+++ b/src/finwiz/infrastructure/resilience/perplexity_retry.py
@@ -22,9 +22,15 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
 from crewai_custom_tools import perplexity_structured
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
 
 from finwiz.tools.logger import get_logger
 from finwiz.tools.perplexity_errors import PerplexityFallbackManager
@@ -39,15 +45,59 @@ PERPLEXITY_CONCURRENCY = int(os.getenv("PERPLEXITY_CONCURRENCY", "4"))
 # PerplexityFallbackManager.calculate_backoff_delay elsewhere in the codebase.
 _MAX_BACKOFF_DELAY = 60.0
 
-_semaphore: asyncio.Semaphore | None = None
+# How long a coroutine waits between attempts to claim a throttle slot. Slots are
+# held for the duration of a network call (seconds), so a 10ms poll adds latency
+# that is invisible next to it while keeping the event loop free -- see
+# _throttle_slot() for why the wait cannot simply block.
+_SLOT_POLL_INTERVAL = 0.01
+
+_throttle: threading.BoundedSemaphore | None = None
 
 
-def get_perplexity_semaphore() -> asyncio.Semaphore:
-    """Return the process-wide Perplexity concurrency semaphore."""
-    global _semaphore
-    if _semaphore is None:
-        _semaphore = asyncio.Semaphore(PERPLEXITY_CONCURRENCY)
-    return _semaphore
+def get_perplexity_semaphore() -> threading.BoundedSemaphore:
+    """Return the process-wide Perplexity concurrency throttle.
+
+    Deliberately a ``threading`` primitive, not an ``asyncio`` one. Production
+    runs one holding per ThreadPoolExecutor worker, and a worker has no running
+    loop, so ``fetch_fact_pack_sync`` calls ``asyncio.run`` -- a *fresh event
+    loop per holding, per thread*. An ``asyncio.Semaphore`` binds to the first
+    loop that contends on it and raises ``RuntimeError`` on every other one, so
+    it throttled nothing and instead failed most of the fleet (and could park a
+    thread forever on a future owned by a dead loop). A threading semaphore
+    belongs to no loop, so the cap is genuinely process-wide however the callers
+    are scheduled.
+
+    A per-loop semaphore keyed by the running loop would silence the
+    ``RuntimeError`` but deliver no throttle at all here: each holding owns its
+    own loop, so a per-loop cap of 4 admits 4 x (number of loops) concurrent
+    calls -- precisely the self-inflicted 429 storm the cap exists to prevent.
+    """
+    global _throttle
+    if _throttle is None:
+        _throttle = threading.BoundedSemaphore(PERPLEXITY_CONCURRENCY)
+    return _throttle
+
+
+@asynccontextmanager
+async def _throttle_slot() -> AsyncIterator[None]:
+    """Hold one throttle slot for the duration of the block.
+
+    Acquires without blocking and yields to the event loop between tries.
+    Blocking on ``acquire()`` inside a coroutine would stall the whole loop --
+    and if several Perplexity coroutines were ever gathered on one loop, the
+    slot holders would be tasks on that same stalled loop and could never
+    release: a deadlock of exactly the kind this fix removes.
+
+    The wait is unordered (a thread can in principle be passed over), which is
+    acceptable for a fleet of a few dozen holdings against a cap of 4.
+    """
+    throttle = get_perplexity_semaphore()
+    while not throttle.acquire(blocking=False):
+        await asyncio.sleep(_SLOT_POLL_INTERVAL)
+    try:
+        yield
+    finally:
+        throttle.release()
 
 
 def _has_api_key() -> bool:
@@ -85,7 +135,7 @@ async def perplexity_with_retry[T: BaseModel](
 
     for attempt in range(max_attempts):
         try:
-            async with get_perplexity_semaphore():
+            async with _throttle_slot():
                 result = await perplexity_structured(
                     prompt=prompt,
                     schema=schema,

--- a/src/finwiz/infrastructure/resilience/perplexity_retry.py
+++ b/src/finwiz/infrastructure/resilience/perplexity_retry.py
@@ -39,7 +39,14 @@ logger = get_logger(__name__)
 
 # Perplexity rate-limits aggressively; a full portfolio fans out far wider than
 # the account allows. This caps in-flight requests process-wide.
-PERPLEXITY_CONCURRENCY = int(os.getenv("PERPLEXITY_CONCURRENCY", "4"))
+#
+# Floored at 1: an unfloored 0 would make ``BoundedSemaphore(0).acquire(blocking=False)``
+# always return False, so ``_throttle_slot()``'s poll loop would spin forever with
+# no timeout -- a config typo hanging the whole run instead of failing loudly. A
+# negative value would raise ``ValueError`` out of ``BoundedSemaphore``'s own
+# constructor, which ``perplexity_with_retry``'s broad ``except Exception`` would
+# launder into four generic per-holding failures, hiding the real cause.
+PERPLEXITY_CONCURRENCY = max(1, int(os.getenv("PERPLEXITY_CONCURRENCY", "4")))
 
 # Ceiling for the exponential backoff, matching the default already used by
 # PerplexityFallbackManager.calculate_backoff_delay elsewhere in the codebase.
@@ -52,6 +59,8 @@ _MAX_BACKOFF_DELAY = 60.0
 _SLOT_POLL_INTERVAL = 0.01
 
 _throttle: threading.BoundedSemaphore | None = None
+# Guards _throttle's lazy init below -- see the race note in get_perplexity_semaphore().
+_throttle_init_lock = threading.Lock()
 
 
 def get_perplexity_semaphore() -> threading.BoundedSemaphore:
@@ -71,10 +80,20 @@ def get_perplexity_semaphore() -> threading.BoundedSemaphore:
     ``RuntimeError`` but deliver no throttle at all here: each holding owns its
     own loop, so a per-loop cap of 4 admits 4 x (number of loops) concurrent
     calls -- precisely the self-inflicted 429 storm the cap exists to prevent.
+
+    The lazy init is double-checked-locked rather than a bare check-then-assign.
+    Production drives this from a ThreadPoolExecutor (default 10 workers), so
+    without the lock, two threads racing the cold start could both observe
+    ``_throttle is None``, each construct their own ``BoundedSemaphore``, and
+    each hand its own instance to a caller -- two semaphores each capping
+    ``PERPLEXITY_CONCURRENCY`` concurrent calls is exactly the doubled-cap 429
+    storm this throttle exists to prevent.
     """
     global _throttle
     if _throttle is None:
-        _throttle = threading.BoundedSemaphore(PERPLEXITY_CONCURRENCY)
+        with _throttle_init_lock:
+            if _throttle is None:
+                _throttle = threading.BoundedSemaphore(PERPLEXITY_CONCURRENCY)
     return _throttle
 
 

--- a/src/finwiz/infrastructure/resilience/perplexity_retry.py
+++ b/src/finwiz/infrastructure/resilience/perplexity_retry.py
@@ -1,0 +1,99 @@
+"""Retry-with-backoff and concurrency control for Perplexity structured calls.
+
+The vendored ``perplexity_structured`` client swallows every failure and returns
+``None`` (see ``crewai_custom_tools/tools/web/perplexity_structured.py``), so a
+429, a timeout and an unparseable body are indistinguishable here. This wrapper
+therefore retries **by outcome**, not by status code, delegating the actual
+backoff math to ``PerplexityFallbackManager.calculate_backoff_delay`` -- the
+exponential-backoff-with-jitter helper already used by
+``perplexity_analysis_integration.py`` -- instead of reimplementing it.
+
+A missing API key is the one failure we can detect up front, so it fails fast
+rather than burning the whole attempt budget on a misconfiguration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from crewai_custom_tools import perplexity_structured
+from pydantic import BaseModel
+
+from finwiz.tools.logger import get_logger
+from finwiz.tools.perplexity_errors import PerplexityFallbackManager
+
+logger = get_logger(__name__)
+
+# Perplexity rate-limits aggressively; a full portfolio fans out far wider than
+# the account allows. This caps in-flight requests process-wide.
+PERPLEXITY_CONCURRENCY = int(os.getenv("PERPLEXITY_CONCURRENCY", "4"))
+
+# Ceiling for the exponential backoff, matching the default already used by
+# PerplexityFallbackManager.calculate_backoff_delay elsewhere in the codebase.
+_MAX_BACKOFF_DELAY = 60.0
+
+_semaphore: asyncio.Semaphore | None = None
+
+
+def get_perplexity_semaphore() -> asyncio.Semaphore:
+    """Return the process-wide Perplexity concurrency semaphore."""
+    global _semaphore
+    if _semaphore is None:
+        _semaphore = asyncio.Semaphore(PERPLEXITY_CONCURRENCY)
+    return _semaphore
+
+
+def _has_api_key() -> bool:
+    return bool(os.getenv("PERPLEXITY_API_KEY") or os.getenv("PPLX_API_KEY"))
+
+
+async def perplexity_with_retry[T: BaseModel](
+    *,
+    prompt: str,
+    schema: type[T],
+    system: str,
+    search_recency_filter: str | None = "month",
+    timeout: float = 15.0,
+    max_attempts: int = 4,
+    base_delay: float = 1.0,
+) -> T | None:
+    """Call ``perplexity_structured`` with bounded retries and exponential backoff.
+
+    Args:
+        prompt: User prompt forwarded to Perplexity.
+        schema: Pydantic model the response must validate against.
+        system: System prompt forwarded to Perplexity.
+        search_recency_filter: Perplexity recency window, or None to omit.
+        timeout: Per-attempt httpx timeout in seconds.
+        max_attempts: Total attempts, including the first. Must be >= 1.
+        base_delay: Seconds before the second attempt; doubles each retry.
+
+    Returns:
+        The validated model, or None when every attempt failed.
+    """
+    if not _has_api_key():
+        logger.warning(f"Perplexity call for {schema.__name__} skipped: no PERPLEXITY_API_KEY/PPLX_API_KEY configured")
+        return None
+
+    for attempt in range(max_attempts):
+        async with get_perplexity_semaphore():
+            result = await perplexity_structured(
+                prompt=prompt,
+                schema=schema,
+                system=system,
+                search_recency_filter=search_recency_filter,
+                timeout=timeout,
+            )
+        if result is not None:
+            if attempt > 0:
+                logger.info(f"Perplexity call for {schema.__name__} succeeded on attempt {attempt + 1}/{max_attempts}")
+            return result
+
+        if attempt < max_attempts - 1:
+            delay = PerplexityFallbackManager.calculate_backoff_delay(attempt, base_delay, _MAX_BACKOFF_DELAY)
+            logger.warning(f"Perplexity call for {schema.__name__} returned no result (attempt {attempt + 1}/{max_attempts}); retrying in {delay:.1f}s")
+            await asyncio.sleep(delay)
+
+    logger.warning(f"Perplexity call for {schema.__name__} exhausted {max_attempts} attempts")
+    return None

--- a/src/finwiz/infrastructure/resilience/perplexity_retry.py
+++ b/src/finwiz/infrastructure/resilience/perplexity_retry.py
@@ -1,15 +1,21 @@
 """Retry-with-backoff and concurrency control for Perplexity structured calls.
 
-The vendored ``perplexity_structured`` client swallows every failure and returns
-``None`` (see ``crewai_custom_tools/tools/web/perplexity_structured.py``), so a
-429, a timeout and an unparseable body are indistinguishable here. This wrapper
-therefore retries **by outcome**, not by status code, delegating the actual
-backoff math to ``PerplexityFallbackManager.calculate_backoff_delay`` -- the
+The vendored ``perplexity_structured`` client swallows every failure *except a
+missing API key* into a bare ``None`` return (see
+``crewai_custom_tools/tools/web/perplexity_structured.py``), so a 429, a
+timeout, and an unparseable body are all indistinguishable from each other. A
+missing key is different: ``require_api_key`` raises ``ValueError`` before the
+client's own ``try``/``except`` even starts, so that one failure mode escapes
+as an exception rather than a ``None``. This wrapper pre-empts that specific,
+known case up front via ``_has_api_key()`` (checking the same two env-var
+names), so a misconfiguration fails fast instead of burning the whole attempt
+budget -- and also catches any other exception the call might raise (e.g. if
+the vendored client's accepted key names or internal handling ever changes),
+treating it exactly like a ``None`` result. The whole call is therefore
+retried **by outcome**, not by status code, delegating the actual backoff math
+to ``PerplexityFallbackManager.calculate_backoff_delay`` -- the
 exponential-backoff-with-jitter helper already used by
 ``perplexity_analysis_integration.py`` -- instead of reimplementing it.
-
-A missing API key is the one failure we can detect up front, so it fails fast
-rather than burning the whole attempt budget on a misconfiguration.
 """
 
 from __future__ import annotations
@@ -67,7 +73,8 @@ async def perplexity_with_retry[T: BaseModel](
         search_recency_filter: Perplexity recency window, or None to omit.
         timeout: Per-attempt httpx timeout in seconds.
         max_attempts: Total attempts, including the first. Must be >= 1.
-        base_delay: Seconds before the second attempt; doubles each retry.
+        base_delay: Seconds before the second attempt; doubles each retry,
+            jittered by +/-25% and capped at 60s by the delegated backoff helper.
 
     Returns:
         The validated model, or None when every attempt failed.
@@ -77,14 +84,19 @@ async def perplexity_with_retry[T: BaseModel](
         return None
 
     for attempt in range(max_attempts):
-        async with get_perplexity_semaphore():
-            result = await perplexity_structured(
-                prompt=prompt,
-                schema=schema,
-                system=system,
-                search_recency_filter=search_recency_filter,
-                timeout=timeout,
-            )
+        try:
+            async with get_perplexity_semaphore():
+                result = await perplexity_structured(
+                    prompt=prompt,
+                    schema=schema,
+                    system=system,
+                    search_recency_filter=search_recency_filter,
+                    timeout=timeout,
+                )
+        except Exception as exc:
+            logger.warning(f"Perplexity call for {schema.__name__} raised on attempt {attempt + 1}/{max_attempts}: {exc!r}")
+            result = None
+
         if result is not None:
             if attempt > 0:
                 logger.info(f"Perplexity call for {schema.__name__} succeeded on attempt {attempt + 1}/{max_attempts}")

--- a/src/finwiz/orchestrators/deep_analysis_data_collector.py
+++ b/src/finwiz/orchestrators/deep_analysis_data_collector.py
@@ -586,10 +586,29 @@ class DeepAnalysisDataCollector:
             return None
 
     def _flatten_recursive(self, obj: Any, target: dict[str, Any]) -> None:
-        """Recursively flatten nested dict structures."""
+        """Recursively flatten nested dict structures.
+
+        ``backtest_result`` and ``quantitative_recommendation`` are skipped
+        entirely, not just de-prioritized. Both carry fields that share a
+        name with the sanctioned, fractional-scale source
+        (``performance_metrics``) -- ``max_drawdown``, ``volatility``,
+        ``total_return`` -- but ``backtest_result``'s are percent-scaled
+        (``backtesting_performance.py:246``), and
+        ``quantitative_recommendation.risk_metrics`` mirrors whichever of the
+        two ``generate_recommendation`` picked (currently backtest-only, see
+        Task 15). When ``performance_metrics`` is absent (that sub-analysis
+        failed), "first key wins" would otherwise let one of these
+        percent-scaled duplicates through, and a downstream consumer
+        comparing it against fractional thresholds (``risk_scorer.py``) would
+        silently score, e.g., a -3% drawdown as if it were -300%. Neither
+        section has any field this method is relied on to extract today --
+        volatility/max_drawdown/sharpe_ratio/total_return/beta come from the
+        targeted ``performance_metrics`` extraction above, so skipping these
+        two sections loses nothing. See Task 15 review round 2 (Ruling 30).
+        """
         if isinstance(obj, dict):
             for key, value in obj.items():
-                if key in ["meta", "metadata", "raw_data", "debug_info"]:
+                if key in ["meta", "metadata", "raw_data", "debug_info", "backtest_result", "quantitative_recommendation"]:
                     continue
 
                 if isinstance(value, (int, float, str, bool, type(None))):

--- a/src/finwiz/orchestrators/discovery/extractors/base.py
+++ b/src/finwiz/orchestrators/discovery/extractors/base.py
@@ -43,19 +43,47 @@ class OpportunityExtractor(ABC):
         self.logger.info(f"{field_name} unavailable for this candidate: {self._NO_DATA_REASON}.")
         return {"unavailable": True, "field": field_name, "reason": self._NO_DATA_REASON}
 
+    def _refuse(self, candidate: dict[str, Any], idx: int, reason: str) -> None:
+        """Log and refuse to build an opportunity for this candidate, naming it.
+
+        Returns None so a caller can ``return self._refuse(...)`` directly. Used
+        for a deliberate business-rule refusal -- e.g. a required derived value
+        such as composite_score cannot be computed from any real data, and
+        fabricating one (a "perfect" score synthesised from absent inputs) would
+        be worse than skipping the candidate. This is distinct from extract()'s
+        per-candidate exception handling: that catches an unexpected raise, this
+        is an intentional "we won't guess" decision, so it needs its own log --
+        a bare ``return None`` here is invisible to extract()'s ``if opportunity``
+        check, which skips silently.
+        """
+        identifier = candidate.get("symbol") or candidate.get("ticker") or f"index {idx}"
+        self.logger.warning(f"Refusing to build opportunity for {identifier}: {reason}")
+        return None
+
     @staticmethod
     def _passthrough_rationale(candidate: dict[str, Any], structured_rationale: list[str]) -> list[str]:
         """Append the writer's flat rationale/recommendation onto the structured rationale.
 
         NewcomerDiscoveryPipeline's writer (``_to_legacy_format``) emits a flat
-        ``rationale`` string and a ``recommendation`` string per candidate.
-        Neither is read by the moat/diversification/technology-derived rationale
-        this method receives, so both were silently discarded for every candidate
+        ``rationale`` string and a ``recommendation`` string per candidate; the
+        moat/diversification/technology-derived rationale this method receives
+        never reads either, so both were silently discarded for every candidate
         that only carries this shape (i.e. every candidate this pipeline produces).
 
-        Appended, not replacing: legacy AI-crew-shaped candidates carry their
-        reasoning only in the structured fields and never populate this top-level
-        "rationale"/"recommendation" pair, so this is purely additive for them.
+        Appended, not replacing. NewcomerDiscoveryPipeline-shaped candidates only
+        ever carry reasoning in this flat pair (moat_analysis/diversification/
+        technology are never populated for them), so for them this recovers
+        previously-discarded data outright. Legacy AI-crew-shaped candidates
+        *also* populate a flat top-level "rationale" -- as a list, not a string --
+        because DataParser's wrapper-unwrapping (parsers.py's
+        ``load_and_parse_json``) merges the outer wrapper's ``rationale`` list
+        into the inner candidate dict when the inner dict has no "rationale" key
+        of its own. Appending it here recovers that too (it was discarded before
+        this method existed) without duplicating anything: the structured-field
+        rationale (e.g. moat analysis) and this flat one (e.g. a numeric ROE/CAGR
+        summary) describe different things. "recommendation" has no legacy-wrapper
+        equivalent (the wrapper's field is "recommended_action", never merged
+        under the key "recommendation"), so it remains newcomer-pipeline-only.
         """
         items = list(structured_rationale)
 

--- a/src/finwiz/orchestrators/discovery/extractors/base.py
+++ b/src/finwiz/orchestrators/discovery/extractors/base.py
@@ -23,9 +23,53 @@ class OpportunityExtractor(ABC):
     opportunity building logic.
     """
 
+    # Mirrors ExtractionEngine._NO_PRODUCER_REASON (orchestrators/extraction/engine.py)
+    # -- same convention, so every "we don't have this" marker in this codebase reads
+    # the same way to a downstream consumer, whichever extractor produced it.
+    _NO_DATA_REASON = "writer does not emit this measurement for this candidate's source"
+
     def __init__(self) -> None:
         """Initialize the opportunity extractor."""
         self.logger = logging.getLogger(self.__class__.__name__)
+
+    def _unavailable(self, field_name: str) -> dict[str, Any]:
+        """Marker for a key_metrics value this extractor cannot measure from the candidate.
+
+        A metric that was never measured must never be indistinguishable from one
+        that measured as zero: ``ter: 0.0`` or ``aum_formatted: "$0"`` reads as a
+        real, often flattering data point, not as "we don't know". Use this instead
+        of defaulting an absent field to 0 in ``key_metrics``.
+        """
+        self.logger.info(f"{field_name} unavailable for this candidate: {self._NO_DATA_REASON}.")
+        return {"unavailable": True, "field": field_name, "reason": self._NO_DATA_REASON}
+
+    @staticmethod
+    def _passthrough_rationale(candidate: dict[str, Any], structured_rationale: list[str]) -> list[str]:
+        """Append the writer's flat rationale/recommendation onto the structured rationale.
+
+        NewcomerDiscoveryPipeline's writer (``_to_legacy_format``) emits a flat
+        ``rationale`` string and a ``recommendation`` string per candidate.
+        Neither is read by the moat/diversification/technology-derived rationale
+        this method receives, so both were silently discarded for every candidate
+        that only carries this shape (i.e. every candidate this pipeline produces).
+
+        Appended, not replacing: legacy AI-crew-shaped candidates carry their
+        reasoning only in the structured fields and never populate this top-level
+        "rationale"/"recommendation" pair, so this is purely additive for them.
+        """
+        items = list(structured_rationale)
+
+        writer_rationale = candidate.get("rationale")
+        if isinstance(writer_rationale, str) and writer_rationale:
+            items.append(writer_rationale)
+        elif isinstance(writer_rationale, list):
+            items.extend(str(item) for item in writer_rationale if item)
+
+        recommendation = candidate.get("recommendation")
+        if isinstance(recommendation, str) and recommendation:
+            items.append(f"Recommendation: {recommendation}")
+
+        return items
 
     def extract(self, candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """
@@ -35,6 +79,11 @@ class OpportunityExtractor(ABC):
         1. Iterate through candidates
         2. Check if each candidate should be included (asset-specific)
         3. Build opportunity object for included candidates (asset-specific)
+
+        Each candidate is wrapped in its own try/except: a single malformed
+        candidate (e.g. a field present but the wrong type) is skipped and
+        logged by identity, not allowed to wipe every sibling in the same
+        batch by escaping to a single try around the whole loop.
 
         Args:
             candidates: List of candidate dictionaries from JSON files
@@ -48,8 +97,8 @@ class OpportunityExtractor(ABC):
 
         opportunities = []
 
-        try:
-            for idx, candidate in enumerate(candidates):
+        for idx, candidate in enumerate(candidates):
+            try:
                 # Asset-specific inclusion logic
                 if not self._should_include(candidate):
                     continue
@@ -60,12 +109,13 @@ class OpportunityExtractor(ABC):
                 if opportunity:
                     opportunities.append(opportunity)
 
-            self.logger.info(f"Extracted {len(opportunities)} opportunities")
-            return opportunities
+            except Exception as e:
+                identifier = candidate.get("symbol") or candidate.get("ticker") or f"index {idx}"
+                self.logger.error(f"Skipping malformed candidate {identifier}: {e!s}", exc_info=True)
+                continue
 
-        except Exception as e:
-            self.logger.error(f"Failed to extract opportunities: {e!s}", exc_info=True)
-            return []
+        self.logger.info(f"Extracted {len(opportunities)} opportunities")
+        return opportunities
 
     @abstractmethod
     def _should_include(self, candidate: dict[str, Any]) -> bool:

--- a/src/finwiz/orchestrators/discovery/extractors/crypto_extractor.py
+++ b/src/finwiz/orchestrators/discovery/extractors/crypto_extractor.py
@@ -32,7 +32,9 @@ class CryptoOpportunityExtractor(OpportunityExtractor):
         if grade not in ["A+", "A"]:
             return False
 
-        symbol = candidate.get("symbol", "")
+        # NewcomerDiscoveryPipeline's writer emits "ticker", not "symbol" --
+        # accept either so its payload isn't silently filtered out.
+        symbol = candidate.get("symbol") or candidate.get("ticker", "")
         crypto_name = candidate.get("name", "")
 
         if not (symbol and crypto_name):
@@ -40,7 +42,16 @@ class CryptoOpportunityExtractor(OpportunityExtractor):
 
         # Check market cap threshold
         # Try market_cap_usd first, then market_cap (for test data compatibility)
-        market_cap = candidate.get("market_cap_usd", candidate.get("market_cap", 0))
+        if "market_cap_usd" in candidate:
+            market_cap = candidate["market_cap_usd"]
+        elif "market_cap" in candidate:
+            market_cap = candidate["market_cap"]
+        else:
+            # No market-cap signal at all -- e.g. NewcomerDiscoveryPipeline's
+            # candidates never carry market_cap_usd/market_cap. Defaulting to a
+            # fail-value here would silently exclude every candidate from that
+            # source; not having the signal is not the same as having a bad one.
+            return True
 
         return bool(market_cap >= 10_000_000_000)  # $10B minimum
 
@@ -63,7 +74,7 @@ class CryptoOpportunityExtractor(OpportunityExtractor):
 
         """
         try:
-            symbol = candidate.get("symbol", "")
+            symbol = candidate.get("symbol") or candidate.get("ticker", "")
             crypto_name = candidate.get("name", "")
             grade = candidate.get("grade", "")
 

--- a/src/finwiz/orchestrators/discovery/extractors/crypto_extractor.py
+++ b/src/finwiz/orchestrators/discovery/extractors/crypto_extractor.py
@@ -73,73 +73,89 @@ class CryptoOpportunityExtractor(OpportunityExtractor):
             Crypto opportunity dictionary
 
         """
-        try:
-            symbol = candidate.get("symbol") or candidate.get("ticker", "")
-            crypto_name = candidate.get("name", "")
-            grade = candidate.get("grade", "")
+        symbol = candidate.get("symbol") or candidate.get("ticker", "")
+        crypto_name = candidate.get("name", "")
+        grade = candidate.get("grade", "")
+        has_market_data = "market_cap_usd" in candidate or "volume_24h_usd" in candidate
 
-            # Use pre-calculated composite score if available, otherwise calculate from market metrics
-            if "composite_score" in candidate:
-                composite_score = candidate.get("composite_score", 0.0)
-            else:
-                # Extract market metrics for composite score calculation
-                market_cap = candidate.get("market_cap_usd", 0)
-                volume_24h = candidate.get("volume_24h_usd", 0)
-                # Calculate composite score from market metrics
-                # Higher market cap and volume = higher score
-                market_cap_score = min(market_cap / 100e9, 1.0)  # Normalize to $100B
-                volume_score = min(volume_24h / 10e9, 1.0)  # Normalize to $10B daily volume
-                composite_score = (market_cap_score * 0.6 + volume_score * 0.4) * 0.9  # Max 0.9 for crypto
-
-            # Use pre-calculated confidence if available
-            if "confidence_level" in candidate:
-                confidence = candidate.get("confidence_level", 0.85)
-            else:
-                confidence = 0.85 if grade == "A+" else 0.75
-
-            # Extract market metrics for key metrics. Each field's own absence (not
-            # merely a 0 value) means this candidate's source never measured it --
-            # distinct from an explicit 0 (measured, genuinely zero).
-            market_cap = candidate["market_cap_usd"] if "market_cap_usd" in candidate else None
-            volume_24h = candidate["volume_24h_usd"] if "volume_24h_usd" in candidate else None
-
-            # Extract risk assessment
-            risk_assessment = candidate.get("risk_assessment") or {}
-            risk_score = risk_assessment.get("score", 6.0)  # Crypto typically higher risk
-
-            # Extract technology as rationale using helper method, then append the
-            # writer's flat rationale/recommendation so neither is dropped.
-            from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
-
-            extractor = APlusDataExtractor()
-            technology = candidate.get("technology", {})
-            has_technology = "technology" in candidate
-            consensus, use_case, rationale = extractor._extract_technology_info(technology)
-            rationale = self._passthrough_rationale(candidate, rationale)
-
-            # Build key metrics. An unmeasured metric is marked unavailable rather
-            # than defaulted to 0/"" -- market_cap_usd: 0 reads as a real, tiny
-            # (and gate-failing) measurement, not as "unknown".
-            key_metrics = {
-                "market_cap_usd": market_cap if market_cap is not None else self._unavailable("market_cap_usd"),
-                "volume_24h_usd": volume_24h if volume_24h is not None else self._unavailable("volume_24h_usd"),
-                "consensus_mechanism": consensus if has_technology else self._unavailable("consensus_mechanism"),
-            }
-
-            # Return dict matching APlusOpportunity schema
-            return {
-                "symbol": symbol.replace("-USD", ""),  # Clean symbol
-                "name": crypto_name,
-                "grade": grade,
-                "composite_score": composite_score,
-                "confidence": confidence,
-                "risk_score": risk_score,
-                "allocation_recommendation": technology.get("competitive_advantage", "") if isinstance(technology, dict) else "",
-                "replacement_note": candidate.get("implementation", {}).get("entry_strategy", ""),
-                "rationale": rationale,
-                "key_metrics": key_metrics,
-            }
-
-        except Exception as e:
-            self.logger.error(f"Failed to build crypto opportunity: {e!s}", exc_info=True)
+        # Use pre-calculated composite score if available, otherwise calculate from
+        # market metrics. If neither is available, refuse rather than synthesise a
+        # score from absent inputs -- market_cap/volume both 0 does floor at a
+        # correctly-low 0.0 here, but that's fabricated agreement, not a genuine
+        # "this asset scored zero"; refusing keeps the two indistinguishable cases
+        # (no data vs. a real bottom score) from being merged into one value.
+        if "composite_score" in candidate:
+            composite_score = candidate.get("composite_score", 0.0)
+        elif has_market_data:
+            market_cap = candidate.get("market_cap_usd", 0)
+            volume_24h = candidate.get("volume_24h_usd", 0)
+            # Higher market cap and volume = higher score
+            market_cap_score = min(market_cap / 100e9, 1.0)  # Normalize to $100B
+            volume_score = min(volume_24h / 10e9, 1.0)  # Normalize to $10B daily volume
+            composite_score = (market_cap_score * 0.6 + volume_score * 0.4) * 0.9  # Max 0.9 for crypto
+        else:
+            self._refuse(candidate, idx, "no composite_score and no market data to derive one from")
             return None
+
+        # Use pre-calculated confidence if available, otherwise fall back to a
+        # grade-derived default -- and note that it's a default, not a measurement,
+        # so a reader can't mistake it for one sitting beside real key_metrics.
+        confidence_provenance = None
+        if "confidence_level" in candidate:
+            confidence = candidate.get("confidence_level", 0.85)
+        else:
+            confidence = 0.85 if grade == "A+" else 0.75
+            confidence_provenance = f"Confidence {confidence} derived from grade {grade}, not measured"
+
+        # Extract market metrics for key metrics. Each field's own absence (not
+        # merely a 0 value) means this candidate's source never measured it --
+        # distinct from an explicit 0 (measured, genuinely zero).
+        market_cap = candidate["market_cap_usd"] if "market_cap_usd" in candidate else None
+        volume_24h = candidate["volume_24h_usd"] if "volume_24h_usd" in candidate else None
+
+        # Extract risk assessment, noting when the score is a default rather than
+        # a real measurement (same reasoning as confidence, above).
+        risk_assessment = candidate.get("risk_assessment") or {}
+        risk_provenance = None
+        if isinstance(risk_assessment, dict) and "score" in risk_assessment:
+            risk_score = risk_assessment["score"]
+        else:
+            risk_score = 6.0  # Crypto typically higher risk
+            risk_provenance = f"Risk score {risk_score} is a default, not measured"
+
+        # Extract technology as rationale using helper method, then append the
+        # writer's flat rationale/recommendation so neither is dropped.
+        from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
+
+        extractor = APlusDataExtractor()
+        technology = candidate.get("technology", {})
+        has_technology = "technology" in candidate
+        consensus, use_case, rationale = extractor._extract_technology_info(technology)
+        rationale = self._passthrough_rationale(candidate, rationale)
+        if confidence_provenance:
+            rationale.append(confidence_provenance)
+        if risk_provenance:
+            rationale.append(risk_provenance)
+
+        # Build key metrics. An unmeasured metric is marked unavailable rather
+        # than defaulted to 0/"" -- market_cap_usd: 0 reads as a real, tiny
+        # (and gate-failing) measurement, not as "unknown".
+        key_metrics = {
+            "market_cap_usd": market_cap if market_cap is not None else self._unavailable("market_cap_usd"),
+            "volume_24h_usd": volume_24h if volume_24h is not None else self._unavailable("volume_24h_usd"),
+            "consensus_mechanism": consensus if has_technology else self._unavailable("consensus_mechanism"),
+        }
+
+        # Return dict matching APlusOpportunity schema
+        return {
+            "symbol": symbol.replace("-USD", ""),  # Clean symbol
+            "name": crypto_name,
+            "grade": grade,
+            "composite_score": composite_score,
+            "confidence": confidence,
+            "risk_score": risk_score,
+            "allocation_recommendation": technology.get("competitive_advantage", "") if isinstance(technology, dict) else "",
+            "replacement_note": candidate.get("implementation", {}).get("entry_strategy", ""),
+            "rationale": rationale,
+            "key_metrics": key_metrics,
+        }

--- a/src/finwiz/orchestrators/discovery/extractors/crypto_extractor.py
+++ b/src/finwiz/orchestrators/discovery/extractors/crypto_extractor.py
@@ -97,26 +97,33 @@ class CryptoOpportunityExtractor(OpportunityExtractor):
             else:
                 confidence = 0.85 if grade == "A+" else 0.75
 
-            # Extract market metrics for key metrics (may not exist in all data formats)
-            market_cap = candidate.get("market_cap_usd", 0)
-            volume_24h = candidate.get("volume_24h_usd", 0)
+            # Extract market metrics for key metrics. Each field's own absence (not
+            # merely a 0 value) means this candidate's source never measured it --
+            # distinct from an explicit 0 (measured, genuinely zero).
+            market_cap = candidate["market_cap_usd"] if "market_cap_usd" in candidate else None
+            volume_24h = candidate["volume_24h_usd"] if "volume_24h_usd" in candidate else None
 
             # Extract risk assessment
             risk_assessment = candidate.get("risk_assessment") or {}
             risk_score = risk_assessment.get("score", 6.0)  # Crypto typically higher risk
 
-            # Extract technology as rationale using helper method
+            # Extract technology as rationale using helper method, then append the
+            # writer's flat rationale/recommendation so neither is dropped.
             from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
 
             extractor = APlusDataExtractor()
             technology = candidate.get("technology", {})
+            has_technology = "technology" in candidate
             consensus, use_case, rationale = extractor._extract_technology_info(technology)
+            rationale = self._passthrough_rationale(candidate, rationale)
 
-            # Build key metrics
+            # Build key metrics. An unmeasured metric is marked unavailable rather
+            # than defaulted to 0/"" -- market_cap_usd: 0 reads as a real, tiny
+            # (and gate-failing) measurement, not as "unknown".
             key_metrics = {
-                "market_cap_usd": market_cap,
-                "volume_24h_usd": volume_24h,
-                "consensus_mechanism": consensus,
+                "market_cap_usd": market_cap if market_cap is not None else self._unavailable("market_cap_usd"),
+                "volume_24h_usd": volume_24h if volume_24h is not None else self._unavailable("volume_24h_usd"),
+                "consensus_mechanism": consensus if has_technology else self._unavailable("consensus_mechanism"),
             }
 
             # Return dict matching APlusOpportunity schema

--- a/src/finwiz/orchestrators/discovery/extractors/etf_extractor.py
+++ b/src/finwiz/orchestrators/discovery/extractors/etf_extractor.py
@@ -57,6 +57,15 @@ class ETFOpportunityExtractor(OpportunityExtractor):
 
         return bool(ter <= 0.15)
 
+    @staticmethod
+    def _format_aum(aum: float) -> str:
+        """Format AUM for display, e.g. "$17.5B", "$500.0M", "$50,000"."""
+        if aum >= 1e9:
+            return f"${aum / 1e9:.1f}B"
+        if aum >= 1e6:
+            return f"${aum / 1e6:.1f}M"
+        return f"${aum:,.0f}"
+
     def _build_opportunity(self, candidate: dict[str, Any], idx: int) -> dict[str, Any] | None:
         """
         Build ETF opportunity object.
@@ -75,95 +84,101 @@ class ETFOpportunityExtractor(OpportunityExtractor):
             ETF opportunity dictionary
 
         """
-        try:
-            symbol = candidate.get("symbol") or candidate.get("ticker", "")
-            fund_name = candidate.get("name", "")
-            grade = candidate.get("grade", "")
+        symbol = candidate.get("symbol") or candidate.get("ticker", "")
+        fund_name = candidate.get("name", "")
+        grade = candidate.get("grade", "")
+        has_cost_metrics = "cost_metrics" in candidate
 
-            # Use pre-calculated composite score if available, otherwise calculate from cost metrics
-            if "composite_score" in candidate:
-                composite_score = candidate.get("composite_score", 0.0)
-            else:
-                # Extract cost metrics for composite score calculation
-                cost_metrics = candidate.get("cost_metrics", {})
-                ter = cost_metrics.get("ter", 0.0)
-                aum = cost_metrics.get("aum_usd", 0)
-                tracking_error = cost_metrics.get("tracking_error_3y", 0.0)
-                # Calculate composite score from cost efficiency
-                composite_score = min((1 - ter) * 0.4 + (1 - tracking_error) * 0.4 + 0.2, 1.0)
-
-            # Use pre-calculated confidence if available
-            if "confidence_level" in candidate:
-                confidence = candidate.get("confidence_level", 0.90)
-            else:
-                confidence = 0.90 if grade == "A+" else 0.80
-
-            # Extract cost metrics for key metrics. "cost_metrics" itself being
-            # absent (not merely {}) means this candidate's source never measured
-            # these -- distinct from an explicit {} (measured, found nothing).
-            has_cost_metrics = "cost_metrics" in candidate
-            cost_metrics = candidate.get("cost_metrics", {})
-            ter = cost_metrics.get("ter", 0.0) if has_cost_metrics else None
-            aum = cost_metrics.get("aum_usd", 0) if has_cost_metrics else None
-            tracking_error = cost_metrics.get("tracking_error_3y", 0.0) if has_cost_metrics else None
-
-            # Format AUM for display -- an unmeasured AUM must not render as "$0",
-            # which reads as a real (and oddly tiny) fund size, not as "unknown".
-            if aum is None:
-                aum_str: Any = self._unavailable("aum_formatted")
-            elif aum >= 1e9:
-                aum_str = f"${aum / 1e9:.1f}B"
-            elif aum >= 1e6:
-                aum_str = f"${aum / 1e6:.1f}M"
-            else:
-                aum_str = f"${aum:,.0f}"
-
-            # Extract risk assessment
-            risk_assessment = candidate.get("risk_assessment") or {}
-            risk_score = risk_assessment.get("score", 3.0)
-
-            # Extract diversification as rationale using helper method, then append
-            # the writer's flat rationale/recommendation so neither is dropped.
-            # "diversification" itself being absent (not merely {}) means this
-            # candidate's source never measured it; _extract_diversification_info
-            # treats {} as "measured, found nothing" (its own tested contract), so
-            # the presence check has to happen here, before the call.
-            from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
-
-            extractor = APlusDataExtractor()
-            if "diversification" in candidate:
-                diversification = candidate["diversification"]
-                holdings_count, _top_10_concentration, rationale = extractor._extract_diversification_info(diversification)
-            else:
-                diversification = {}
-                holdings_count, rationale = None, []
-            rationale = self._passthrough_rationale(candidate, rationale)
-
-            # Build key metrics. An unmeasured metric is marked unavailable rather
-            # than defaulted to 0 -- e.g. ter: 0.0 reads as a real, excellent (and
-            # gate-passing) measurement, not as "unknown".
-            key_metrics = {
-                "ter": ter if ter is not None else self._unavailable("ter"),
-                "aum_usd": aum if aum is not None else self._unavailable("aum_usd"),
-                "aum_formatted": aum_str,
-                "tracking_error_3y": tracking_error if tracking_error is not None else self._unavailable("tracking_error_3y"),
-                "holdings_count": holdings_count if holdings_count is not None else self._unavailable("holdings_count"),
-            }
-
-            # Return dict matching APlusOpportunity schema
-            return {
-                "symbol": symbol,
-                "name": fund_name,
-                "grade": grade,
-                "composite_score": composite_score,
-                "confidence": confidence,
-                "risk_score": risk_score,
-                "allocation_recommendation": diversification.get("sector_breakdown", "") if isinstance(diversification, dict) else "",
-                "replacement_note": candidate.get("implementation", {}).get("entry_strategy", ""),
-                "rationale": rationale,
-                "key_metrics": key_metrics,
-            }
-
-        except Exception as e:
-            self.logger.error(f"Failed to build ETF opportunity: {e!s}", exc_info=True)
+        # Use pre-calculated composite score if available, otherwise calculate from
+        # cost metrics. If neither is available, refuse rather than synthesise a
+        # score from absent inputs -- an all-zero cost_metrics fallback would score
+        # a fabricated 1.0 (min((1-0)*0.4 + (1-0)*0.4 + 0.2, 1.0)), the single most
+        # flattering value on the exact axis the TER gate exists to screen.
+        if "composite_score" in candidate:
+            composite_score = candidate.get("composite_score", 0.0)
+        elif has_cost_metrics:
+            cost_metrics = candidate["cost_metrics"]
+            ter = cost_metrics.get("ter", 0.0)
+            tracking_error = cost_metrics.get("tracking_error_3y", 0.0)
+            composite_score = min((1 - ter) * 0.4 + (1 - tracking_error) * 0.4 + 0.2, 1.0)
+        else:
+            self._refuse(candidate, idx, "no composite_score and no cost_metrics to derive one from")
             return None
+
+        # Use pre-calculated confidence if available, otherwise fall back to a
+        # grade-derived default -- and note that it's a default, not a measurement,
+        # so a reader can't mistake it for one sitting beside real key_metrics.
+        confidence_provenance = None
+        if "confidence_level" in candidate:
+            confidence = candidate.get("confidence_level", 0.90)
+        else:
+            confidence = 0.90 if grade == "A+" else 0.80
+            confidence_provenance = f"Confidence {confidence} derived from grade {grade}, not measured"
+
+        # Extract cost metrics for key metrics. "cost_metrics" itself being
+        # absent (not merely {}) means this candidate's source never measured
+        # these -- distinct from an explicit {} (measured, found nothing).
+        cost_metrics = candidate.get("cost_metrics", {})
+        ter = cost_metrics.get("ter", 0.0) if has_cost_metrics else None
+        aum = cost_metrics.get("aum_usd", 0) if has_cost_metrics else None
+        tracking_error = cost_metrics.get("tracking_error_3y", 0.0) if has_cost_metrics else None
+
+        # Format AUM for display -- an unmeasured AUM must not render as "$0",
+        # which reads as a real (and oddly tiny) fund size, not as "unknown".
+        aum_str: Any = self._unavailable("aum_formatted") if aum is None else self._format_aum(aum)
+
+        # Extract risk assessment, noting when the score is a default rather than
+        # a real measurement (same reasoning as confidence, above).
+        risk_assessment = candidate.get("risk_assessment") or {}
+        risk_provenance = None
+        if isinstance(risk_assessment, dict) and "score" in risk_assessment:
+            risk_score = risk_assessment["score"]
+        else:
+            risk_score = 3.0
+            risk_provenance = f"Risk score {risk_score} is a default, not measured"
+
+        # Extract diversification as rationale using helper method, then append
+        # the writer's flat rationale/recommendation so neither is dropped.
+        # "diversification" itself being absent (not merely {}) means this
+        # candidate's source never measured it; _extract_diversification_info
+        # treats {} as "measured, found nothing" (its own tested contract), so
+        # the presence check has to happen here, before the call.
+        from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
+
+        extractor = APlusDataExtractor()
+        if "diversification" in candidate:
+            diversification = candidate["diversification"]
+            holdings_count, _top_10_concentration, rationale = extractor._extract_diversification_info(diversification)
+        else:
+            diversification = {}
+            holdings_count, rationale = None, []
+        rationale = self._passthrough_rationale(candidate, rationale)
+        if confidence_provenance:
+            rationale.append(confidence_provenance)
+        if risk_provenance:
+            rationale.append(risk_provenance)
+
+        # Build key metrics. An unmeasured metric is marked unavailable rather
+        # than defaulted to 0 -- e.g. ter: 0.0 reads as a real, excellent (and
+        # gate-passing) measurement, not as "unknown".
+        key_metrics = {
+            "ter": ter if ter is not None else self._unavailable("ter"),
+            "aum_usd": aum if aum is not None else self._unavailable("aum_usd"),
+            "aum_formatted": aum_str,
+            "tracking_error_3y": tracking_error if tracking_error is not None else self._unavailable("tracking_error_3y"),
+            "holdings_count": holdings_count if holdings_count is not None else self._unavailable("holdings_count"),
+        }
+
+        # Return dict matching APlusOpportunity schema
+        return {
+            "symbol": symbol,
+            "name": fund_name,
+            "grade": grade,
+            "composite_score": composite_score,
+            "confidence": confidence,
+            "risk_score": risk_score,
+            "allocation_recommendation": diversification.get("sector_breakdown", "") if isinstance(diversification, dict) else "",
+            "replacement_note": candidate.get("implementation", {}).get("entry_strategy", ""),
+            "rationale": rationale,
+            "key_metrics": key_metrics,
+        }

--- a/src/finwiz/orchestrators/discovery/extractors/etf_extractor.py
+++ b/src/finwiz/orchestrators/discovery/extractors/etf_extractor.py
@@ -98,14 +98,20 @@ class ETFOpportunityExtractor(OpportunityExtractor):
             else:
                 confidence = 0.90 if grade == "A+" else 0.80
 
-            # Extract cost metrics for key metrics (may not exist in all data formats)
+            # Extract cost metrics for key metrics. "cost_metrics" itself being
+            # absent (not merely {}) means this candidate's source never measured
+            # these -- distinct from an explicit {} (measured, found nothing).
+            has_cost_metrics = "cost_metrics" in candidate
             cost_metrics = candidate.get("cost_metrics", {})
-            ter = cost_metrics.get("ter", 0.0)
-            aum = cost_metrics.get("aum_usd", 0)
-            tracking_error = cost_metrics.get("tracking_error_3y", 0.0)
+            ter = cost_metrics.get("ter", 0.0) if has_cost_metrics else None
+            aum = cost_metrics.get("aum_usd", 0) if has_cost_metrics else None
+            tracking_error = cost_metrics.get("tracking_error_3y", 0.0) if has_cost_metrics else None
 
-            # Format AUM for display
-            if aum >= 1e9:
+            # Format AUM for display -- an unmeasured AUM must not render as "$0",
+            # which reads as a real (and oddly tiny) fund size, not as "unknown".
+            if aum is None:
+                aum_str: Any = self._unavailable("aum_formatted")
+            elif aum >= 1e9:
                 aum_str = f"${aum / 1e9:.1f}B"
             elif aum >= 1e6:
                 aum_str = f"${aum / 1e6:.1f}M"
@@ -116,20 +122,32 @@ class ETFOpportunityExtractor(OpportunityExtractor):
             risk_assessment = candidate.get("risk_assessment") or {}
             risk_score = risk_assessment.get("score", 3.0)
 
-            # Extract diversification as rationale using helper method
+            # Extract diversification as rationale using helper method, then append
+            # the writer's flat rationale/recommendation so neither is dropped.
+            # "diversification" itself being absent (not merely {}) means this
+            # candidate's source never measured it; _extract_diversification_info
+            # treats {} as "measured, found nothing" (its own tested contract), so
+            # the presence check has to happen here, before the call.
             from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
 
             extractor = APlusDataExtractor()
-            diversification = candidate.get("diversification", {})
-            holdings_count, top_10_concentration, rationale = extractor._extract_diversification_info(diversification)
+            if "diversification" in candidate:
+                diversification = candidate["diversification"]
+                holdings_count, _top_10_concentration, rationale = extractor._extract_diversification_info(diversification)
+            else:
+                diversification = {}
+                holdings_count, rationale = None, []
+            rationale = self._passthrough_rationale(candidate, rationale)
 
-            # Build key metrics
+            # Build key metrics. An unmeasured metric is marked unavailable rather
+            # than defaulted to 0 -- e.g. ter: 0.0 reads as a real, excellent (and
+            # gate-passing) measurement, not as "unknown".
             key_metrics = {
-                "ter": ter,
-                "aum_usd": aum,
+                "ter": ter if ter is not None else self._unavailable("ter"),
+                "aum_usd": aum if aum is not None else self._unavailable("aum_usd"),
                 "aum_formatted": aum_str,
-                "tracking_error_3y": tracking_error,
-                "holdings_count": holdings_count,
+                "tracking_error_3y": tracking_error if tracking_error is not None else self._unavailable("tracking_error_3y"),
+                "holdings_count": holdings_count if holdings_count is not None else self._unavailable("holdings_count"),
             }
 
             # Return dict matching APlusOpportunity schema

--- a/src/finwiz/orchestrators/discovery/extractors/etf_extractor.py
+++ b/src/finwiz/orchestrators/discovery/extractors/etf_extractor.py
@@ -32,7 +32,9 @@ class ETFOpportunityExtractor(OpportunityExtractor):
         if grade not in ["A+", "A"]:
             return False
 
-        symbol = candidate.get("symbol", "")
+        # NewcomerDiscoveryPipeline's writer emits "ticker", not "symbol" --
+        # accept either so its payload isn't silently filtered out.
+        symbol = candidate.get("symbol") or candidate.get("ticker", "")
         fund_name = candidate.get("name", "")
 
         if not (symbol and fund_name):
@@ -42,7 +44,16 @@ class ETFOpportunityExtractor(OpportunityExtractor):
         # Try cost_metrics first, then key_metrics (for test data compatibility)
         cost_metrics = candidate.get("cost_metrics", {})
         key_metrics = candidate.get("key_metrics", {})
-        ter = cost_metrics.get("ter", key_metrics.get("ter", 1.0))
+        if "ter" in cost_metrics:
+            ter = cost_metrics["ter"]
+        elif "ter" in key_metrics:
+            ter = key_metrics["ter"]
+        else:
+            # No TER signal at all -- e.g. NewcomerDiscoveryPipeline's candidates
+            # never carry cost_metrics/key_metrics. Defaulting to a fail-value
+            # here would silently exclude every candidate from that source; not
+            # having the signal is not the same as having a bad one.
+            return True
 
         return bool(ter <= 0.15)
 
@@ -65,7 +76,7 @@ class ETFOpportunityExtractor(OpportunityExtractor):
 
         """
         try:
-            symbol = candidate.get("symbol", "")
+            symbol = candidate.get("symbol") or candidate.get("ticker", "")
             fund_name = candidate.get("name", "")
             grade = candidate.get("grade", "")
 

--- a/src/finwiz/orchestrators/discovery/extractors/stock_extractor.py
+++ b/src/finwiz/orchestrators/discovery/extractors/stock_extractor.py
@@ -31,7 +31,9 @@ class StockOpportunityExtractor(OpportunityExtractor):
         if grade not in ["A+", "A"]:
             return False
 
-        symbol = candidate.get("symbol", "")
+        # NewcomerDiscoveryPipeline's writer emits "ticker", not "symbol" --
+        # accept either so its payload isn't silently filtered out.
+        symbol = candidate.get("symbol") or candidate.get("ticker", "")
         company_name = candidate.get("name", "")
 
         return bool(symbol and company_name)
@@ -55,7 +57,7 @@ class StockOpportunityExtractor(OpportunityExtractor):
 
         """
         try:
-            symbol = candidate.get("symbol", "")
+            symbol = candidate.get("symbol") or candidate.get("ticker", "")
             company_name = candidate.get("name", "")
             grade = candidate.get("grade", "")
 

--- a/src/finwiz/orchestrators/discovery/extractors/stock_extractor.py
+++ b/src/finwiz/orchestrators/discovery/extractors/stock_extractor.py
@@ -56,78 +56,92 @@ class StockOpportunityExtractor(OpportunityExtractor):
             Stock opportunity dictionary
 
         """
-        try:
-            symbol = candidate.get("symbol") or candidate.get("ticker", "")
-            company_name = candidate.get("name", "")
-            grade = candidate.get("grade", "")
+        symbol = candidate.get("symbol") or candidate.get("ticker", "")
+        company_name = candidate.get("name", "")
+        grade = candidate.get("grade", "")
+        has_fundamentals = "fundamentals" in candidate
 
-            # Use pre-calculated composite score if available, otherwise calculate from fundamentals
-            if "composite_score" in candidate:
-                composite_score = candidate.get("composite_score", 0.0)
-            else:
-                # Extract fundamentals for composite score calculation
-                fundamentals = candidate.get("fundamentals", {})
-                roe = fundamentals.get("roe_3y_avg", 0)
-                revenue_growth = fundamentals.get("revenue_cagr_5y", 0)
-                debt_ratio = fundamentals.get("debt_to_equity", 0)
-                # Calculate composite score from fundamentals
-                composite_score = min((roe / 20 * 0.4) + (revenue_growth / 15 * 0.4) + ((1 - min(debt_ratio, 1)) * 0.2), 1.0)
-
-            # Use pre-calculated confidence if available
-            if "confidence_level" in candidate:
-                confidence = candidate.get("confidence_level", 0.85)
-            else:
-                confidence = 0.85 if grade == "A+" else 0.75
-
-            # Extract fundamentals for key metrics. "fundamentals" itself being
-            # absent (not merely {}) means this candidate's source never measured
-            # these -- distinct from an explicit {} (measured, found nothing).
-            if "fundamentals" in candidate:
-                fundamentals = candidate["fundamentals"]
-                roe = fundamentals.get("roe_3y_avg", 0)
-                revenue_growth = fundamentals.get("revenue_cagr_5y", 0)
-                debt_ratio = fundamentals.get("debt_to_equity", 0)
-            else:
-                roe = revenue_growth = debt_ratio = None
-
-            # Extract risk assessment
-            risk_assessment = candidate.get("risk_assessment") or {}
-            risk_score = risk_assessment.get("score", 5.0)
-
-            # Extract moat analysis as rationale, then append the writer's flat
-            # rationale/recommendation -- NewcomerDiscoveryPipeline candidates carry
-            # their reasoning there, not in moat_analysis, so neither is dropped.
-            from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
-
-            extractor = APlusDataExtractor()
-            moat_analysis = candidate.get("moat_analysis", {})
-            moat_type, moat_strength, rationale = extractor._extract_moat_info(moat_analysis)
-            rationale = self._passthrough_rationale(candidate, rationale)
-
-            # Extract key metrics from fundamentals. An unmeasured metric is marked
-            # unavailable rather than defaulted to 0 -- a 0 reads as a real, often
-            # flattering measurement (e.g. debt_to_equity: 0), not as "unknown".
-            key_metrics = {
-                "roe_3y_avg": roe if roe is not None else self._unavailable("roe_3y_avg"),
-                "revenue_cagr_5y": revenue_growth if revenue_growth is not None else self._unavailable("revenue_cagr_5y"),
-                "debt_to_equity": debt_ratio if debt_ratio is not None else self._unavailable("debt_to_equity"),
-                "market_cap_usd": candidate["market_cap_usd"] if "market_cap_usd" in candidate else self._unavailable("market_cap_usd"),
-            }
-
-            # Return dict matching APlusOpportunity schema
-            return {
-                "symbol": symbol,
-                "name": company_name,
-                "grade": grade,
-                "composite_score": composite_score,
-                "confidence": confidence,
-                "risk_score": risk_score,
-                "allocation_recommendation": moat_analysis.get("competitive_advantage", "") if isinstance(moat_analysis, dict) else "",
-                "replacement_note": candidate.get("implementation", {}).get("entry_strategy", ""),
-                "rationale": rationale,
-                "key_metrics": key_metrics,
-            }
-
-        except Exception as e:
-            self.logger.error(f"Failed to build stock opportunity: {e!s}", exc_info=True)
+        # Use pre-calculated composite score if available, otherwise calculate from
+        # fundamentals. If neither is available, refuse rather than synthesise a
+        # score from absent inputs -- e.g. an all-zero fundamentals fallback would
+        # score a 0.2, a number that looks computed but means nothing.
+        if "composite_score" in candidate:
+            composite_score = candidate.get("composite_score", 0.0)
+        elif has_fundamentals:
+            fundamentals = candidate["fundamentals"]
+            roe = fundamentals.get("roe_3y_avg", 0)
+            revenue_growth = fundamentals.get("revenue_cagr_5y", 0)
+            debt_ratio = fundamentals.get("debt_to_equity", 0)
+            composite_score = min((roe / 20 * 0.4) + (revenue_growth / 15 * 0.4) + ((1 - min(debt_ratio, 1)) * 0.2), 1.0)
+        else:
+            self._refuse(candidate, idx, "no composite_score and no fundamentals to derive one from")
             return None
+
+        # Use pre-calculated confidence if available, otherwise fall back to a
+        # grade-derived default -- and note that it's a default, not a measurement,
+        # so a reader can't mistake it for one sitting beside real key_metrics.
+        confidence_provenance = None
+        if "confidence_level" in candidate:
+            confidence = candidate.get("confidence_level", 0.85)
+        else:
+            confidence = 0.85 if grade == "A+" else 0.75
+            confidence_provenance = f"Confidence {confidence} derived from grade {grade}, not measured"
+
+        # Extract fundamentals for key metrics. "fundamentals" itself being
+        # absent (not merely {}) means this candidate's source never measured
+        # these -- distinct from an explicit {} (measured, found nothing).
+        if has_fundamentals:
+            fundamentals = candidate["fundamentals"]
+            roe = fundamentals.get("roe_3y_avg", 0)
+            revenue_growth = fundamentals.get("revenue_cagr_5y", 0)
+            debt_ratio = fundamentals.get("debt_to_equity", 0)
+        else:
+            roe = revenue_growth = debt_ratio = None
+
+        # Extract risk assessment, noting when the score is a default rather than
+        # a real measurement (same reasoning as confidence, above).
+        risk_assessment = candidate.get("risk_assessment") or {}
+        risk_provenance = None
+        if isinstance(risk_assessment, dict) and "score" in risk_assessment:
+            risk_score = risk_assessment["score"]
+        else:
+            risk_score = 5.0
+            risk_provenance = f"Risk score {risk_score} is a default, not measured"
+
+        # Extract moat analysis as rationale, then append the writer's flat
+        # rationale/recommendation -- NewcomerDiscoveryPipeline candidates carry
+        # their reasoning there, not in moat_analysis, so neither is dropped.
+        from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
+
+        extractor = APlusDataExtractor()
+        moat_analysis = candidate.get("moat_analysis", {})
+        moat_type, moat_strength, rationale = extractor._extract_moat_info(moat_analysis)
+        rationale = self._passthrough_rationale(candidate, rationale)
+        if confidence_provenance:
+            rationale.append(confidence_provenance)
+        if risk_provenance:
+            rationale.append(risk_provenance)
+
+        # Extract key metrics from fundamentals. An unmeasured metric is marked
+        # unavailable rather than defaulted to 0 -- a 0 reads as a real, often
+        # flattering measurement (e.g. debt_to_equity: 0), not as "unknown".
+        key_metrics = {
+            "roe_3y_avg": roe if roe is not None else self._unavailable("roe_3y_avg"),
+            "revenue_cagr_5y": revenue_growth if revenue_growth is not None else self._unavailable("revenue_cagr_5y"),
+            "debt_to_equity": debt_ratio if debt_ratio is not None else self._unavailable("debt_to_equity"),
+            "market_cap_usd": candidate["market_cap_usd"] if "market_cap_usd" in candidate else self._unavailable("market_cap_usd"),
+        }
+
+        # Return dict matching APlusOpportunity schema
+        return {
+            "symbol": symbol,
+            "name": company_name,
+            "grade": grade,
+            "composite_score": composite_score,
+            "confidence": confidence,
+            "risk_score": risk_score,
+            "allocation_recommendation": moat_analysis.get("competitive_advantage", "") if isinstance(moat_analysis, dict) else "",
+            "replacement_note": candidate.get("implementation", {}).get("entry_strategy", ""),
+            "rationale": rationale,
+            "key_metrics": key_metrics,
+        }

--- a/src/finwiz/orchestrators/discovery/extractors/stock_extractor.py
+++ b/src/finwiz/orchestrators/discovery/extractors/stock_extractor.py
@@ -79,29 +79,39 @@ class StockOpportunityExtractor(OpportunityExtractor):
             else:
                 confidence = 0.85 if grade == "A+" else 0.75
 
-            # Extract fundamentals for key metrics (may not exist in all data formats)
-            fundamentals = candidate.get("fundamentals", {})
-            roe = fundamentals.get("roe_3y_avg", 0)
-            revenue_growth = fundamentals.get("revenue_cagr_5y", 0)
-            debt_ratio = fundamentals.get("debt_to_equity", 0)
+            # Extract fundamentals for key metrics. "fundamentals" itself being
+            # absent (not merely {}) means this candidate's source never measured
+            # these -- distinct from an explicit {} (measured, found nothing).
+            if "fundamentals" in candidate:
+                fundamentals = candidate["fundamentals"]
+                roe = fundamentals.get("roe_3y_avg", 0)
+                revenue_growth = fundamentals.get("revenue_cagr_5y", 0)
+                debt_ratio = fundamentals.get("debt_to_equity", 0)
+            else:
+                roe = revenue_growth = debt_ratio = None
 
             # Extract risk assessment
             risk_assessment = candidate.get("risk_assessment") or {}
             risk_score = risk_assessment.get("score", 5.0)
 
-            # Extract moat analysis as rationale using helper method
+            # Extract moat analysis as rationale, then append the writer's flat
+            # rationale/recommendation -- NewcomerDiscoveryPipeline candidates carry
+            # their reasoning there, not in moat_analysis, so neither is dropped.
             from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
 
             extractor = APlusDataExtractor()
             moat_analysis = candidate.get("moat_analysis", {})
             moat_type, moat_strength, rationale = extractor._extract_moat_info(moat_analysis)
+            rationale = self._passthrough_rationale(candidate, rationale)
 
-            # Extract key metrics from fundamentals
+            # Extract key metrics from fundamentals. An unmeasured metric is marked
+            # unavailable rather than defaulted to 0 -- a 0 reads as a real, often
+            # flattering measurement (e.g. debt_to_equity: 0), not as "unknown".
             key_metrics = {
-                "roe_3y_avg": roe,
-                "revenue_cagr_5y": revenue_growth,
-                "debt_to_equity": debt_ratio,
-                "market_cap_usd": candidate.get("market_cap_usd", 0),
+                "roe_3y_avg": roe if roe is not None else self._unavailable("roe_3y_avg"),
+                "revenue_cagr_5y": revenue_growth if revenue_growth is not None else self._unavailable("revenue_cagr_5y"),
+                "debt_to_equity": debt_ratio if debt_ratio is not None else self._unavailable("debt_to_equity"),
+                "market_cap_usd": candidate["market_cap_usd"] if "market_cap_usd" in candidate else self._unavailable("market_cap_usd"),
             }
 
             # Return dict matching APlusOpportunity schema

--- a/src/finwiz/orchestrators/discovery_orchestrator.py
+++ b/src/finwiz/orchestrators/discovery_orchestrator.py
@@ -58,29 +58,43 @@ class DiscoveryOrchestrator:
             session_id = self.state.session_id or "default"
             crypto_results = analyze_crypto_opportunities(session_id)
 
+            # A pipeline failure is honestly labelled by the analyzer itself
+            # (performance_metrics.method == "newcomer_discovery_failed"). It must
+            # not be reported as a successful zero-opportunity run - the report
+            # this feeds must be able to tell "we ran and found nothing" apart
+            # from "we failed and therefore have nothing".
+            metrics = crypto_results.get("performance_metrics", {})
+            pipeline_failed = metrics.get("method") == "newcomer_discovery_failed"
+
             # Update state with Python results
             result_data = {
-                "crypto_analysis_success": True,
+                "crypto_analysis_success": not pipeline_failed,
                 "crypto_result": crypto_results.get("analysis_summary", "Crypto analysis completed"),
                 "crypto_opportunities": crypto_results.get("opportunities", []),
-                "crypto_performance_metrics": crypto_results.get("performance_metrics", {}),
+                "crypto_performance_metrics": metrics,
             }
+            if pipeline_failed:
+                result_data["crypto_analysis_error"] = metrics.get("error", "Newcomer discovery pipeline failed")
 
             self._update_state_from_dict(result_data)
 
             # Save results to disk
             self._save_discovery_results("crypto", crypto_results)
 
-            # Track successful Python execution
+            # Track actual Python execution outcome (never mark a broken run "available")
             if self.availability_tracker:
                 self.availability_tracker.track_data_source(
                     source="crypto_crew",
-                    status="available",
+                    status="unavailable" if pipeline_failed else "available",
                     last_updated=datetime.now().isoformat(),
                     record_count=len(crypto_results.get("opportunities", [])),
+                    error_message=result_data.get("crypto_analysis_error"),
                 )
 
-            self.logger.info(f"✅ Crypto discovery completed: {len(crypto_results.get('opportunities', []))} opportunities found")
+            if pipeline_failed:
+                self.logger.error(f"❌ Crypto discovery failed: {result_data['crypto_analysis_error']}")
+            else:
+                self.logger.info(f"✅ Crypto discovery completed: {len(crypto_results.get('opportunities', []))} opportunities found")
 
             return {"crypto_analysis_complete": True, "crypto_result": result_data.get("crypto_result", "")}
 
@@ -123,29 +137,43 @@ class DiscoveryOrchestrator:
             session_id = self.state.session_id or "default"
             stock_results = analyze_stock_opportunities(session_id)
 
+            # A pipeline failure is honestly labelled by the analyzer itself
+            # (performance_metrics.method == "newcomer_discovery_failed"). It must
+            # not be reported as a successful zero-opportunity run - the report
+            # this feeds must be able to tell "we ran and found nothing" apart
+            # from "we failed and therefore have nothing".
+            metrics = stock_results.get("performance_metrics", {})
+            pipeline_failed = metrics.get("method") == "newcomer_discovery_failed"
+
             # Update state with Python results
             result_data = {
-                "stock_analysis_success": True,
+                "stock_analysis_success": not pipeline_failed,
                 "stock_result": stock_results.get("analysis_summary", "Stock analysis completed"),
                 "stock_opportunities": stock_results.get("opportunities", []),
-                "stock_performance_metrics": stock_results.get("performance_metrics", {}),
+                "stock_performance_metrics": metrics,
             }
+            if pipeline_failed:
+                result_data["stock_analysis_error"] = metrics.get("error", "Newcomer discovery pipeline failed")
 
             self._update_state_from_dict(result_data)
 
             # Save results to disk
             self._save_discovery_results("stock", stock_results)
 
-            # Track successful Python execution
+            # Track actual Python execution outcome (never mark a broken run "available")
             if self.availability_tracker:
                 self.availability_tracker.track_data_source(
                     source="stock_crew",
-                    status="available",
+                    status="unavailable" if pipeline_failed else "available",
                     last_updated=datetime.now().isoformat(),
                     record_count=len(stock_results.get("opportunities", [])),
+                    error_message=result_data.get("stock_analysis_error"),
                 )
 
-            self.logger.info(f"✅ Stock discovery completed: {len(stock_results.get('opportunities', []))} opportunities found")
+            if pipeline_failed:
+                self.logger.error(f"❌ Stock discovery failed: {result_data['stock_analysis_error']}")
+            else:
+                self.logger.info(f"✅ Stock discovery completed: {len(stock_results.get('opportunities', []))} opportunities found")
 
             return {"stock_analysis_complete": True, "stock_result": result_data.get("stock_result", "")}
 
@@ -188,29 +216,43 @@ class DiscoveryOrchestrator:
             session_id = self.state.session_id or "default"
             etf_results = analyze_etf_opportunities(session_id)
 
+            # A pipeline failure is honestly labelled by the analyzer itself
+            # (performance_metrics.method == "newcomer_discovery_failed"). It must
+            # not be reported as a successful zero-opportunity run - the report
+            # this feeds must be able to tell "we ran and found nothing" apart
+            # from "we failed and therefore have nothing".
+            metrics = etf_results.get("performance_metrics", {})
+            pipeline_failed = metrics.get("method") == "newcomer_discovery_failed"
+
             # Update state with Python results
             result_data = {
-                "etf_analysis_success": True,
+                "etf_analysis_success": not pipeline_failed,
                 "etf_result": etf_results.get("analysis_summary", "ETF analysis completed"),
                 "etf_opportunities": etf_results.get("opportunities", []),
-                "etf_performance_metrics": etf_results.get("performance_metrics", {}),
+                "etf_performance_metrics": metrics,
             }
+            if pipeline_failed:
+                result_data["etf_analysis_error"] = metrics.get("error", "Newcomer discovery pipeline failed")
 
             self._update_state_from_dict(result_data)
 
             # Save results to disk
             self._save_discovery_results("etf", etf_results)
 
-            # Track successful Python execution
+            # Track actual Python execution outcome (never mark a broken run "available")
             if self.availability_tracker:
                 self.availability_tracker.track_data_source(
                     source="etf_crew",
-                    status="available",
+                    status="unavailable" if pipeline_failed else "available",
                     last_updated=datetime.now().isoformat(),
                     record_count=len(etf_results.get("opportunities", [])),
+                    error_message=result_data.get("etf_analysis_error"),
                 )
 
-            self.logger.info(f"✅ ETF discovery completed: {len(etf_results.get('opportunities', []))} opportunities found")
+            if pipeline_failed:
+                self.logger.error(f"❌ ETF discovery failed: {result_data['etf_analysis_error']}")
+            else:
+                self.logger.info(f"✅ ETF discovery completed: {len(etf_results.get('opportunities', []))} opportunities found")
 
             return {"etf_analysis_complete": True, "etf_result": result_data.get("etf_result", "")}
 

--- a/src/finwiz/orchestrators/extraction/engine.py
+++ b/src/finwiz/orchestrators/extraction/engine.py
@@ -5,7 +5,6 @@ This module orchestrates the extraction of A+ investment opportunities from
 discovery crew outputs, coordinating data parsing and opportunity extraction.
 """
 
-import json
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -163,79 +162,27 @@ class ExtractionEngine:
         self.logger.info(f"Extracted {len(opportunities)} crypto A+ opportunities")
         return opportunities
 
+    # `market_context` and `validation_results` were written against the raw
+    # CrewAI discovery-crew kickoff shape (a `{"pydantic": {...}}` result). The
+    # pipeline actually wired into DiscoveryOrchestrator today is the
+    # deterministic NewcomerDiscoveryPipeline, whose only output file
+    # (consolidated_discovery.json) never carries either key — there is no
+    # file anywhere in this pipeline that has this data (task-11, Ruling 23).
+    # Returning None here would be indistinguishable from the "ran and found
+    # nothing" meaning None already carries elsewhere in this module, so an
+    # explicit, named marker is returned instead: callers can tell "this input
+    # does not exist in this pipeline" apart from "this input was empty".
+    _NO_PRODUCER_REASON = "no producer emits this field in the current discovery pipeline"
+
+    def _unavailable(self, field_name: str) -> dict[str, Any]:
+        """Build the 'no producer for this field' marker and log why."""
+        self.logger.info(f"{field_name} extraction skipped: {self._NO_PRODUCER_REASON}.")
+        return {"unavailable": True, "field": field_name, "reason": self._NO_PRODUCER_REASON}
+
     def _extract_market_context(self) -> dict[str, Any] | None:
-        """Extract market context from discovery_latest.json."""
-        try:
-            discovery_file = self.discovery_dir / "discovery_latest.json"
-            if not discovery_file.exists():
-                return None
-
-            content = discovery_file.read_text(encoding="utf-8")
-            # Fix Python-style numeric literals
-            content = self.parser.clean_json_content(content)
-            data = json.loads(content)
-
-            # Extract market context if available
-            market_context: dict[str, Any] = data.get("market_context", {})
-            if market_context:
-                self.logger.info("Market context extracted from discovery results")
-                return market_context
-
-            return None
-        except Exception as e:
-            self.logger.warning(f"Could not extract market context: {e}")
-            return None
+        """market_context has no producer in the current discovery pipeline."""
+        return self._unavailable("market_context")
 
     def _extract_backtesting_metrics(self) -> dict[str, Any] | None:
-        """Extract backtesting metrics from discovery_latest.json."""
-        try:
-            discovery_file = self.discovery_dir / "discovery_latest.json"
-            if not discovery_file.exists():
-                return None
-
-            content = discovery_file.read_text(encoding="utf-8")
-            # Fix Python-style numeric literals
-            content = self.parser.clean_json_content(content)
-            data = json.loads(content)
-
-            # Extract validation results which contain backtesting data
-            validation_results = data.get("validation_results", [])
-            if validation_results:
-                # Aggregate backtesting metrics
-                metrics = {
-                    "total_candidates_tested": len(validation_results),
-                    "candidates_with_backtests": sum(1 for v in validation_results if v.get("backtest_results")),
-                    "avg_sharpe_ratio": None,
-                    "avg_annual_return": None,
-                    "avg_max_drawdown": None,
-                }
-
-                # Calculate averages if backtest data exists
-                sharpe_ratios = []
-                annual_returns = []
-                max_drawdowns = []
-
-                for result in validation_results:
-                    backtest = result.get("backtest_results", {})
-                    if backtest:
-                        if "sharpe_ratio" in backtest:
-                            sharpe_ratios.append(backtest["sharpe_ratio"])
-                        if "annual_return" in backtest:
-                            annual_returns.append(backtest["annual_return"])
-                        if "max_drawdown" in backtest:
-                            max_drawdowns.append(backtest["max_drawdown"])
-
-                if sharpe_ratios:
-                    metrics["avg_sharpe_ratio"] = sum(sharpe_ratios) / len(sharpe_ratios)
-                if annual_returns:
-                    metrics["avg_annual_return"] = sum(annual_returns) / len(annual_returns)
-                if max_drawdowns:
-                    metrics["avg_max_drawdown"] = sum(max_drawdowns) / len(max_drawdowns)
-
-                self.logger.info(f"Backtesting metrics extracted: {metrics['candidates_with_backtests']} candidates with backtests")
-                return metrics
-
-            return None
-        except Exception as e:
-            self.logger.warning(f"Could not extract backtesting metrics: {e}")
-            return None
+        """backtesting_metrics (validation_results) has no producer in the current discovery pipeline."""
+        return self._unavailable("backtesting_metrics")

--- a/src/finwiz/orchestrators/extraction/parsers.py
+++ b/src/finwiz/orchestrators/extraction/parsers.py
@@ -119,9 +119,12 @@ class DataParser:
             # Case 1: data is already a list of candidates
             if isinstance(data, list):
                 candidates = data
-            # Case 2: data is a dict with "candidates" or "a_plus_candidates" key
+            # Case 2: data is a dict with "candidates", "a_plus_candidates", or
+            # "opportunities" key. "opportunities" is the key NewcomerDiscoveryPipeline's
+            # _to_legacy_format() emits (see scoring/discovery/pipeline.py) -- without it,
+            # a_plus_{stocks,etfs,crypto}.json is silently read as empty.
             elif isinstance(data, dict):
-                candidates = data.get("candidates") or data.get("a_plus_candidates") or []
+                candidates = data.get("candidates") or data.get("a_plus_candidates") or data.get("opportunities") or []
             else:
                 self.logger.error(f"Unexpected data type in {file_path.name}: {type(data)}")
                 return []

--- a/src/finwiz/quantitative/backtesting.py
+++ b/src/finwiz/quantitative/backtesting.py
@@ -82,7 +82,7 @@ class BacktestingEngine:
         end_date: datetime,
         strategy_params: dict[str, Any] | None = None,
         benchmark_symbol: str | None = None,
-    ) -> BacktestResult:
+    ) -> BacktestResult | None:
         """
         Execute comprehensive backtesting workflow with professional-grade tools.
 
@@ -95,7 +95,12 @@ class BacktestingEngine:
             benchmark_symbol: Optional benchmark symbol for comparison
 
         Returns:
-            Comprehensive backtest result
+            Comprehensive backtest result, or ``None`` when the fetched series
+            is shorter than the strategy's lookback window plus warm-up
+            buffer. That is a legitimate refusal, not an error: backtrader
+            would never reach ``minperiod`` for the strategy's indicators, so
+            the caller must treat ``None`` as "cannot backtest this series",
+            not as a bug to retry or paper over.
 
         """
         self.logger.info(f"Starting backtest for {strategy_class.__name__} on {symbol}")
@@ -113,10 +118,19 @@ class BacktestingEngine:
             if data.empty:
                 raise ValueError(f"No data available for {symbol}")
 
-            # Check if we have enough data for the strategy
+            # Check if we have enough data for the strategy's lookback window.
+            # A short series is a legitimate input, not an error -- refuse by
+            # returning None rather than raising. Raising here used to
+            # propagate out through the comprehensive analyzer's shared
+            # try/except and discard technical and performance analysis that
+            # had already succeeded independently (see
+            # tools/quantitative_comprehensive_analyzer.py, Task 15).
             min_data_points = strategy_params.get("long_period", strategy_params.get("period", 50)) + 10
             if len(data) < min_data_points:
-                raise ValueError(f"Insufficient data for {symbol}: got {len(data)} rows, need at least {min_data_points} for strategy parameters")
+                self.logger.info(
+                    f"Skipping backtest for {symbol}: {len(data)} bars, need at least {min_data_points} (strategy lookback + warm-up buffer). Short series, not an error.",
+                )
+                return None
 
             # Convert to Backtrader data feed
             bt_data = create_backtrader_datafeed(data, symbol)
@@ -219,7 +233,8 @@ class BacktestingEngine:
         for strategy_class, params in strategies:
             try:
                 result = self.run_strategy_backtest(strategy_class, symbol, start_date, end_date, params)
-                results.append(result)
+                if result is not None:
+                    results.append(result)
             except Exception as e:
                 self.logger.error(f"Error backtesting {strategy_class.__name__}: {e}")
                 continue

--- a/src/finwiz/quantitative/backtesting.py
+++ b/src/finwiz/quantitative/backtesting.py
@@ -33,12 +33,28 @@ __all__ = [
     "TradeStatus",
     "TradeType",
     "get_backtesting_engine",
+    "minimum_bars_required",
 ]
 
 logger = get_logger(__name__)
 
 # Suppress Backtrader warnings for cleaner output
 warnings.filterwarnings("ignore", category=UserWarning, module="backtrader")
+
+# Extra bars beyond the strategy's longest lookback, so its indicators have
+# reached minperiod and the backtest actually trades rather than warming up.
+_WARMUP_BARS = 10
+
+
+def minimum_bars_required(strategy_params: dict[str, Any] | None) -> int:
+    """Bars a strategy needs before it can be backtested: lookback + warm-up.
+
+    Shared with the callers of ``run_strategy_backtest`` so a refusal can name
+    the threshold it refused against without re-deriving (and drifting from)
+    this formula.
+    """
+    params = strategy_params or {}
+    return int(params.get("long_period", params.get("period", 50))) + _WARMUP_BARS
 
 
 class BacktestingEngine:
@@ -125,7 +141,7 @@ class BacktestingEngine:
             # try/except and discard technical and performance analysis that
             # had already succeeded independently (see
             # tools/quantitative_comprehensive_analyzer.py, Task 15).
-            min_data_points = strategy_params.get("long_period", strategy_params.get("period", 50)) + 10
+            min_data_points = minimum_bars_required(strategy_params)
             if len(data) < min_data_points:
                 self.logger.info(
                     f"Skipping backtest for {symbol}: {len(data)} bars, need at least {min_data_points} (strategy lookback + warm-up buffer). Short series, not an error.",

--- a/src/finwiz/quantitative/data_processors.py
+++ b/src/finwiz/quantitative/data_processors.py
@@ -130,12 +130,32 @@ class DataProcessor:
             return {}
 
     def save_cache_metadata(self, cache_metadata: dict[str, Any], cache_metadata_file: Path) -> None:
-        """Save cache metadata to disk."""
+        """Save cache metadata to disk.
+
+        The caller owns ``cache_metadata`` and may mutate it from another
+        thread, so snapshot before serializing -- iterating the live dict
+        raised "dictionary changed size during iteration" and silently
+        dropped the write. ``default=str`` covers values (e.g. ``datetime``)
+        that are not natively JSON-serializable.
+
+        A cache write is a best-effort side effect, never worth aborting a
+        production run over, so every failure here is swallowed. But the two
+        kinds of failure are handled differently: an ``OSError`` (disk full,
+        permission denied, missing directory) is a routine I/O hiccup and is
+        logged at its usual one-line severity. Anything else means the
+        snapshot still couldn't be serialized despite ``default=str`` -- a
+        programming error, not a transient hiccup -- so it is logged with a
+        full traceback (``logger.exception``) instead of disappearing into
+        the same one-line message the original bug hid behind.
+        """
         try:
+            snapshot = dict(cache_metadata)
             with open(cache_metadata_file, "w") as f:
-                json.dump(cache_metadata, f, indent=2)
-        except Exception as e:
+                json.dump(snapshot, f, indent=2, default=str)
+        except OSError as e:
             self.logger.error(f"Error saving cache metadata: {e}")
+        except Exception:
+            self.logger.exception("Error saving cache metadata")
 
     def create_cache_metadata_entry(
         self,

--- a/src/finwiz/schemas/hybrid_analysis/fact_pack.py
+++ b/src/finwiz/schemas/hybrid_analysis/fact_pack.py
@@ -15,6 +15,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 _FRESHNESS_VALUES = ("fresh", "recent", "stale")
 Freshness = Literal["fresh", "recent", "stale"]
 
+# Beyond this, a cached fact pack is not merely stale — it predates any
+# reporting cycle we would defend, so the cache evicts rather than serve it.
+_STALE_HORIZON_DAYS = 90
+
 
 class FactPack(BaseModel):
     """Verified corporate facts for one holding.
@@ -38,7 +42,7 @@ class FactPack(BaseModel):
     def derive_freshness(cls, fetched_at: datetime) -> Freshness:
         """Python owns freshness derivation; AI may not lie about it.
 
-        <3d -> fresh, 3-7d -> recent, 7-14d -> stale, >14d -> raises (cache must have evicted).
+        <3d -> fresh, 3-7d -> recent, 7-90d -> stale, >90d -> raises (cache must have evicted).
         """
         if fetched_at.tzinfo is None:
             fetched_at = fetched_at.replace(tzinfo=UTC)
@@ -48,9 +52,13 @@ class FactPack(BaseModel):
             return "fresh"
         if age < timedelta(days=7):
             return "recent"
-        if age < timedelta(days=15):
+        # Corporate structure and leadership do not turn over in a fortnight.
+        # A 15-day cliff meant a rate-limited run had no cache to fall back on
+        # and killed the holding outright — worse than a labelled stale answer.
+        # Staleness is a payload field, not a stage outcome (see stages/fact_pack.py).
+        if age < timedelta(days=_STALE_HORIZON_DAYS):
             return "stale"
-        raise ValueError(f"FactPack older than 14 days (age={age}); cache should have evicted")
+        raise ValueError(f"FactPack older than {_STALE_HORIZON_DAYS} days (age={age}); cache should have evicted")
 
     @model_validator(mode="after")
     def _check_freshness_matches_fetched_at(self) -> FactPack:

--- a/src/finwiz/scoring/CLAUDE.md
+++ b/src/finwiz/scoring/CLAUDE.md
@@ -27,11 +27,11 @@ scoring/
 │   ├── crypto_analyzer.py         # CryptoAnalyzer
 │   └── factory.py                 # AnalyzerFactory.get_analyzer(asset_class)
 │
-├── discovery/                     # Newcomer discovery pipeline (feature-flag gated)
+├── discovery/                     # Newcomer discovery pipeline (recall strategy gated by portfolio_aware_discovery)
 │   ├── __init__.py                # Exports: NewcomerDiscoveryPipeline
 │   └── pipeline.py               # NewcomerDiscoveryPipeline orchestrator
 │
-├── # Legacy discovery analyzers (route through pipeline when FF_NEWCOMER_DISCOVERY=true)
+├── # Discovery analyzers — always route through NewcomerDiscoveryPipeline; no mocked/legacy fallback
 ├── stock_analyzer.py              # analyze_stock_opportunities()
 ├── etf_analyzer.py                # analyze_etf_opportunities()
 └── crypto_analyzer.py             # analyze_crypto_opportunities()

--- a/src/finwiz/scoring/crypto_analyzer.py
+++ b/src/finwiz/scoring/crypto_analyzer.py
@@ -9,7 +9,6 @@ for 10-20x speed improvement and 100% cost reduction.
 import time
 from typing import Any
 
-from finwiz.config.features.flags import is_feature_enabled
 from finwiz.tools.logger import get_logger
 
 logger = get_logger(__name__)
@@ -18,77 +17,30 @@ logger = get_logger(__name__)
 def analyze_crypto_opportunities(session_id: str) -> dict[str, Any]:
     """Analyze cryptocurrency opportunities using pure Python.
 
-    When the ``newcomer_discovery`` feature flag is enabled, routes
-    through ``NewcomerDiscoveryPipeline``.  Falls back to legacy
-    mocked data when the flag is disabled or the pipeline fails.
+    Routes through ``NewcomerDiscoveryPipeline``. A pipeline failure yields an
+    empty, honestly-labelled result — never fabricated candidates. Inventing
+    A-grade tickers to fill a gap is worse than reporting the gap.
     """
     start_time = time.time()
 
-    if is_feature_enabled("newcomer_discovery"):
-        try:
-            logger.info("Using NewcomerDiscoveryPipeline for crypto discovery")
-            from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
-
-            pipeline = NewcomerDiscoveryPipeline("crypto")
-            result = pipeline.discover(session_id)
-            return pipeline._to_legacy_format(result, start_time)
-        except Exception as e:
-            logger.error("Newcomer discovery pipeline failed for crypto, falling back to legacy: %s", e)
-
-    return _legacy_crypto_analysis(session_id, start_time)
-
-
-def _legacy_crypto_analysis(session_id: str, start_time: float) -> dict[str, Any]:
-    """Legacy mocked crypto analysis (hardcoded data)."""
-    logger.info("Starting Python-based crypto analysis (legacy)")
-
     try:
-        opportunities = [
-            {
-                "ticker": "BTC",
-                "name": "Bitcoin",
-                "grade": "A",
-                "composite_score": 0.85,
-                "recommendation": "BUY",
-                "rationale": "Strong institutional adoption and limited supply",
-            },
-            {
-                "ticker": "ETH",
-                "name": "Ethereum",
-                "grade": "A+",
-                "composite_score": 0.92,
-                "recommendation": "BUY",
-                "rationale": "Leading smart contract platform with strong ecosystem",
-            },
-        ]
+        logger.info("Using NewcomerDiscoveryPipeline for crypto discovery")
+        from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
 
-        execution_time = time.time() - start_time
-        results = {
-            "opportunities": opportunities,
-            "analysis_summary": f"Identified {len(opportunities)} crypto opportunities",
-            "performance_metrics": {
-                "execution_time_seconds": execution_time,
-                "opportunities_found": len(opportunities),
-                "cost_usd": 0.0,
-                "llm_calls_made": 0,
-                "method": "python_analysis",
-            },
-        }
-        logger.info("Crypto analysis completed in %.2fs", execution_time)
-        return results
-
+        pipeline = NewcomerDiscoveryPipeline("crypto")
+        result = pipeline.discover(session_id)
+        return pipeline._to_legacy_format(result, start_time)
     except Exception as e:
-        logger.error("Crypto Python analysis failed: %s", e)
-        execution_time = time.time() - start_time
+        logger.error("Newcomer discovery pipeline failed for crypto: %s", e)
         return {
             "opportunities": [],
-            "analysis_summary": f"Crypto analysis failed: {e}",
+            "analysis_summary": f"Crypto discovery unavailable this run: {e}",
             "performance_metrics": {
-                "execution_time_seconds": execution_time,
+                "execution_time_seconds": time.time() - start_time,
                 "opportunities_found": 0,
                 "cost_usd": 0.0,
                 "llm_calls_made": 0,
-                "method": "python_analysis_failed",
+                "method": "newcomer_discovery_failed",
                 "error": str(e),
             },
         }

--- a/src/finwiz/scoring/deep_analysis_scorer.py
+++ b/src/finwiz/scoring/deep_analysis_scorer.py
@@ -93,6 +93,11 @@ class DeepAnalysisScorer:
             # Step 1: Initialize tracking systems
             self._initialize_tracking(ticker, asset_class, data)
 
+            # Step 1b: Recover derivable fields BEFORE the gate.
+            # The gate is fail-fast by design, but failing fast on a field we can
+            # compute from data already in hand is a false negative, not honesty.
+            self._recover_derivable_fields(data)
+
             # Step 2: Validate critical fields
             self._validate_critical_fields(ticker, asset_class, data)
 
@@ -214,6 +219,15 @@ class DeepAnalysisScorer:
                 f"   Recommendation: Check API connectivity and data sources."
             )
             raise
+
+    def _recover_derivable_fields(self, data: dict[str, Any]) -> None:
+        """
+        Fill fields derivable from collected data before the critical-field gate runs.
+
+        Only touches fields that are absent; never overwrites collected values.
+        """
+        price_history = get_price_history_from_data(data)
+        calculate_missing_technical_indicators(data, price_history)
 
     def _calculate_component_scores(self, asset_class: str, data: dict[str, Any]) -> dict[str, Any]:
         """Calculate fundamental, technical, and risk component scores."""

--- a/src/finwiz/scoring/deep_analysis_scorer.py
+++ b/src/finwiz/scoring/deep_analysis_scorer.py
@@ -27,6 +27,7 @@ from finwiz.scoring.score_result_builder import ScoreResultBuilder
 from finwiz.scoring.sentiment_scorer import SentimentScorer
 from finwiz.scoring.technical_fallback import (
     calculate_missing_technical_indicators,
+    fill_volatility,
     get_price_history_from_data,
 )
 from finwiz.scoring.technical_scorer import TechnicalScorer
@@ -222,12 +223,22 @@ class DeepAnalysisScorer:
 
     def _recover_derivable_fields(self, data: dict[str, Any]) -> None:
         """
-        Fill fields derivable from collected data before the critical-field gate runs.
+        Fill fields derivable from data already in hand, before the critical-field gate runs.
 
-        Only touches fields that are absent; never overwrites collected values.
+        Deliberately narrow: only touches fields that are absent, and only when the
+        replacement value is genuinely derived from data the caller already provided
+        (e.g. volatility from price_history). It must NOT run the full technical
+        fallback here — that also assigns hardcoded assumptions (e.g. beta=1.0) with
+        no data behind them, which would let the gate wave through a holding it should
+        reject. Those fallbacks still run later, in _calculate_component_scores, where
+        they only affect scoring for holdings that already passed the gate on real data.
+
+        Uses a plain dict lookup rather than get_price_history_from_data() on purpose:
+        that helper can trigger a live network fetch as a last resort, and doing that
+        before the gate would fetch data for holdings about to be rejected anyway.
         """
-        price_history = get_price_history_from_data(data)
-        calculate_missing_technical_indicators(data, price_history)
+        price_history = data.get("price_history")
+        fill_volatility(data, price_history)
 
     def _calculate_component_scores(self, asset_class: str, data: dict[str, Any]) -> dict[str, Any]:
         """Calculate fundamental, technical, and risk component scores."""

--- a/src/finwiz/scoring/discovery/CLAUDE.md
+++ b/src/finwiz/scoring/discovery/CLAUDE.md
@@ -48,12 +48,16 @@ The pipeline composes 5 live components from `finwiz.discovery.*`:
 
 ## Feature Flag
 
-Gated by `newcomer_discovery` feature flag in `config/features/definitions.py`.
-When disabled, analyzers fall back to legacy mocked discovery data.
+The `newcomer_discovery` flag has been retired and is no longer read anywhere
+in the codebase — `analyze_{stock,etf,crypto}_opportunities()` always route
+through `NewcomerDiscoveryPipeline` unconditionally. A pipeline failure returns
+an empty, honestly-labelled result (`performance_metrics.method ==
+"newcomer_discovery_failed"`) — never mocked/invented data. The pipeline's own
+recall strategy is still governed by `portfolio_aware_discovery` (see above).
 
 ## Related Modules
 
 - `finwiz.discovery` — Individual discovery components (universe, screeners, scorer)
 - `finwiz.schemas.newcomer_discovery` — Pydantic schemas for pipeline I/O
-- `finwiz.config.features.flags` — `is_feature_enabled("newcomer_discovery")`
-- `finwiz.scoring.{stock,etf,crypto}_analyzer` — Callers that route through pipeline when flag enabled
+- `finwiz.config.features.flags` — `is_feature_enabled("portfolio_aware_discovery")`
+- `finwiz.scoring.{stock,etf,crypto}_analyzer` — Callers that always route through the pipeline (no flag gate)

--- a/src/finwiz/scoring/discovery/pipeline.py
+++ b/src/finwiz/scoring/discovery/pipeline.py
@@ -456,6 +456,8 @@ class NewcomerDiscoveryPipeline:
             logger.info("Persisted %d scored %s candidates (%d actionable) to %s", len(scored), self.asset_class, actionable_count, out)
         except OSError as e:
             logger.warning("Failed to write scored candidates: %s", e)
+        except Exception as e:
+            logger.warning("Unexpected error persisting scored candidates: %s", e)
 
     def _persist_result(self, result: NewcomerDiscoveryResult, asset_class: str) -> None:
         """Save results to ``output/discovery/newcomer_{asset_class}.json``."""

--- a/src/finwiz/scoring/discovery/pipeline.py
+++ b/src/finwiz/scoring/discovery/pipeline.py
@@ -102,7 +102,9 @@ class NewcomerDiscoveryPipeline:
         # but must still EXCLUDE noise from the surfaced opportunity list rather
         # than emit it low-graded — otherwise the a_plus_*/consolidated outputs
         # fill with F/D candidates. See feedback rule: filter, don't low-grade.
+        scored_before_filter = list(candidates)
         candidates = self._filter_actionable(candidates)
+        self._persist_scored(scored_before_filter, actionable_count=len(candidates))
 
         candidates.sort(key=lambda c: c.composite_score, reverse=True)
         candidates = candidates[: self.MAX_SURFACED_CANDIDATES]
@@ -432,6 +434,28 @@ class NewcomerDiscoveryPipeline:
     # ------------------------------------------------------------------
     # Persistence & format conversion
     # ------------------------------------------------------------------
+
+    def _persist_scored(self, scored: list[NewcomerCandidate], actionable_count: int) -> None:
+        """Write the full scored candidate list before actionability filtering.
+
+        Without this, every dropped candidate is unrecoverable and "0
+        opportunities" is indistinguishable from "we scored 10 and rejected all
+        10". Diagnostics need the distinction.
+        """
+        try:
+            discovery_dir = Path("output") / "discovery"
+            discovery_dir.mkdir(parents=True, exist_ok=True)
+            out = discovery_dir / f"scored_{self.asset_class}.json"
+            payload = {
+                "asset_class": self.asset_class,
+                "scored": [c.model_dump() for c in scored],
+                "actionable_count": actionable_count,
+            }
+            with open(out, "w") as f:
+                json.dump(payload, f, indent=2, default=str)
+            logger.info("Persisted %d scored %s candidates (%d actionable) to %s", len(scored), self.asset_class, actionable_count, out)
+        except OSError as e:
+            logger.warning("Failed to write scored candidates: %s", e)
 
     def _persist_result(self, result: NewcomerDiscoveryResult, asset_class: str) -> None:
         """Save results to ``output/discovery/newcomer_{asset_class}.json``."""

--- a/src/finwiz/scoring/etf_analyzer.py
+++ b/src/finwiz/scoring/etf_analyzer.py
@@ -9,7 +9,6 @@ for 10-20x speed improvement and 100% cost reduction.
 import time
 from typing import Any
 
-from finwiz.config.features.flags import is_feature_enabled
 from finwiz.tools.logger import get_logger
 
 logger = get_logger(__name__)
@@ -18,85 +17,30 @@ logger = get_logger(__name__)
 def analyze_etf_opportunities(session_id: str) -> dict[str, Any]:
     """Analyze ETF opportunities using pure Python.
 
-    When the ``newcomer_discovery`` feature flag is enabled, routes
-    through ``NewcomerDiscoveryPipeline``.  Falls back to legacy
-    mocked data when the flag is disabled or the pipeline fails.
+    Routes through ``NewcomerDiscoveryPipeline``. A pipeline failure yields an
+    empty, honestly-labelled result — never fabricated candidates. Inventing
+    A-grade tickers to fill a gap is worse than reporting the gap.
     """
     start_time = time.time()
 
-    if is_feature_enabled("newcomer_discovery"):
-        try:
-            logger.info("Using NewcomerDiscoveryPipeline for etf discovery")
-            from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
-
-            pipeline = NewcomerDiscoveryPipeline("etf")
-            result = pipeline.discover(session_id)
-            return pipeline._to_legacy_format(result, start_time)
-        except Exception as e:
-            logger.error("Newcomer discovery pipeline failed for etf, falling back to legacy: %s", e)
-
-    return _legacy_etf_analysis(session_id, start_time)
-
-
-def _legacy_etf_analysis(session_id: str, start_time: float) -> dict[str, Any]:
-    """Legacy mocked ETF analysis (hardcoded data)."""
-    logger.info("Starting Python-based ETF analysis (legacy)")
-
     try:
-        opportunities = [
-            {
-                "ticker": "VTI",
-                "name": "Vanguard Total Stock Market ETF",
-                "grade": "A+",
-                "composite_score": 0.93,
-                "recommendation": "BUY",
-                "rationale": "Low cost, broad diversification, strong performance",
-            },
-            {
-                "ticker": "VXUS",
-                "name": "Vanguard Total International Stock ETF",
-                "grade": "A",
-                "composite_score": 0.86,
-                "recommendation": "BUY",
-                "rationale": "International diversification with low fees",
-            },
-            {
-                "ticker": "BND",
-                "name": "Vanguard Total Bond Market ETF",
-                "grade": "A",
-                "composite_score": 0.82,
-                "recommendation": "HOLD",
-                "rationale": "Stable bond exposure for portfolio balance",
-            },
-        ]
+        logger.info("Using NewcomerDiscoveryPipeline for etf discovery")
+        from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
 
-        execution_time = time.time() - start_time
-        results = {
-            "opportunities": opportunities,
-            "analysis_summary": f"Identified {len(opportunities)} ETF opportunities",
-            "performance_metrics": {
-                "execution_time_seconds": execution_time,
-                "opportunities_found": len(opportunities),
-                "cost_usd": 0.0,
-                "llm_calls_made": 0,
-                "method": "python_analysis",
-            },
-        }
-        logger.info("ETF analysis completed in %.2fs", execution_time)
-        return results
-
+        pipeline = NewcomerDiscoveryPipeline("etf")
+        result = pipeline.discover(session_id)
+        return pipeline._to_legacy_format(result, start_time)
     except Exception as e:
-        logger.error("ETF Python analysis failed: %s", e)
-        execution_time = time.time() - start_time
+        logger.error("Newcomer discovery pipeline failed for etf: %s", e)
         return {
             "opportunities": [],
-            "analysis_summary": f"ETF analysis failed: {e}",
+            "analysis_summary": f"ETF discovery unavailable this run: {e}",
             "performance_metrics": {
-                "execution_time_seconds": execution_time,
+                "execution_time_seconds": time.time() - start_time,
                 "opportunities_found": 0,
                 "cost_usd": 0.0,
                 "llm_calls_made": 0,
-                "method": "python_analysis_failed",
+                "method": "newcomer_discovery_failed",
                 "error": str(e),
             },
         }

--- a/src/finwiz/scoring/stock_analyzer.py
+++ b/src/finwiz/scoring/stock_analyzer.py
@@ -9,7 +9,6 @@ for 10-20x speed improvement and 100% cost reduction.
 import time
 from typing import Any
 
-from finwiz.config.features.flags import is_feature_enabled
 from finwiz.tools.logger import get_logger
 
 logger = get_logger(__name__)
@@ -18,85 +17,30 @@ logger = get_logger(__name__)
 def analyze_stock_opportunities(session_id: str) -> dict[str, Any]:
     """Analyze stock opportunities using pure Python.
 
-    When the ``newcomer_discovery`` feature flag is enabled, routes
-    through ``NewcomerDiscoveryPipeline``.  Falls back to legacy
-    mocked data when the flag is disabled or the pipeline fails.
+    Routes through ``NewcomerDiscoveryPipeline``. A pipeline failure yields an
+    empty, honestly-labelled result — never fabricated candidates. Inventing
+    A-grade tickers to fill a gap is worse than reporting the gap.
     """
     start_time = time.time()
 
-    if is_feature_enabled("newcomer_discovery"):
-        try:
-            logger.info("Using NewcomerDiscoveryPipeline for stock discovery")
-            from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
-
-            pipeline = NewcomerDiscoveryPipeline("stock")
-            result = pipeline.discover(session_id)
-            return pipeline._to_legacy_format(result, start_time)
-        except Exception as e:
-            logger.error("Newcomer discovery pipeline failed for stock, falling back to legacy: %s", e)
-
-    return _legacy_stock_analysis(session_id, start_time)
-
-
-def _legacy_stock_analysis(session_id: str, start_time: float) -> dict[str, Any]:
-    """Legacy mocked stock analysis (hardcoded data)."""
-    logger.info("Starting Python-based stock analysis (legacy)")
-
     try:
-        opportunities = [
-            {
-                "ticker": "MSFT",
-                "name": "Microsoft Corporation",
-                "grade": "A+",
-                "composite_score": 0.94,
-                "recommendation": "BUY",
-                "rationale": "Strong cloud growth and AI leadership",
-            },
-            {
-                "ticker": "NVDA",
-                "name": "NVIDIA Corporation",
-                "grade": "A+",
-                "composite_score": 0.91,
-                "recommendation": "BUY",
-                "rationale": "AI chip market dominance and data center growth",
-            },
-            {
-                "ticker": "GOOGL",
-                "name": "Alphabet Inc.",
-                "grade": "A",
-                "composite_score": 0.87,
-                "recommendation": "BUY",
-                "rationale": "Search dominance and AI integration",
-            },
-        ]
+        logger.info("Using NewcomerDiscoveryPipeline for stock discovery")
+        from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
 
-        execution_time = time.time() - start_time
-        results = {
-            "opportunities": opportunities,
-            "analysis_summary": f"Identified {len(opportunities)} stock opportunities",
-            "performance_metrics": {
-                "execution_time_seconds": execution_time,
-                "opportunities_found": len(opportunities),
-                "cost_usd": 0.0,
-                "llm_calls_made": 0,
-                "method": "python_analysis",
-            },
-        }
-        logger.info("Stock analysis completed in %.2fs", execution_time)
-        return results
-
+        pipeline = NewcomerDiscoveryPipeline("stock")
+        result = pipeline.discover(session_id)
+        return pipeline._to_legacy_format(result, start_time)
     except Exception as e:
-        logger.error("Stock Python analysis failed: %s", e)
-        execution_time = time.time() - start_time
+        logger.error("Newcomer discovery pipeline failed for stock: %s", e)
         return {
             "opportunities": [],
-            "analysis_summary": f"Stock analysis failed: {e}",
+            "analysis_summary": f"Stock discovery unavailable this run: {e}",
             "performance_metrics": {
-                "execution_time_seconds": execution_time,
+                "execution_time_seconds": time.time() - start_time,
                 "opportunities_found": 0,
                 "cost_usd": 0.0,
                 "llm_calls_made": 0,
-                "method": "python_analysis_failed",
+                "method": "newcomer_discovery_failed",
                 "error": str(e),
             },
         }

--- a/src/finwiz/scoring/technical_fallback.py
+++ b/src/finwiz/scoring/technical_fallback.py
@@ -32,7 +32,7 @@ def calculate_missing_technical_indicators(data: dict[str, Any], price_history: 
         Updated data dictionary with calculated indicators
 
     """
-    _fill_volatility(data, price_history)
+    fill_volatility(data, price_history)
 
     current_price = data.get("current_price")
 
@@ -58,12 +58,16 @@ def calculate_missing_technical_indicators(data: dict[str, Any], price_history: 
     return data
 
 
-def _fill_volatility(data: dict[str, Any], price_history: pd.Series | None) -> None:
+def fill_volatility(data: dict[str, Any], price_history: pd.Series | None) -> None:
     """
     Derive annualized volatility from price history when the quant tool did not supply it.
 
     Mutates ``data`` in place. Never overwrites a value the quant tool already
     produced, and stays silent when there is not enough history to be meaningful.
+
+    Public (not prefixed with ``_``) because this is called directly by
+    DeepAnalysisScorer._recover_derivable_fields, ahead of the critical-field gate — unlike
+    the beta fallback below, which is a hardcoded assumption and must only run after the gate.
     """
     if data.get("volatility") is not None:
         return

--- a/src/finwiz/scoring/technical_fallback.py
+++ b/src/finwiz/scoring/technical_fallback.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import pandas as pd
 
+from finwiz.quantitative.risk.risk_metrics import calculate_volatility
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,6 +32,8 @@ def calculate_missing_technical_indicators(data: dict[str, Any], price_history: 
         Updated data dictionary with calculated indicators
 
     """
+    _fill_volatility(data, price_history)
+
     current_price = data.get("current_price")
 
     # Skip if no current price available
@@ -52,6 +56,26 @@ def calculate_missing_technical_indicators(data: dict[str, Any], price_history: 
         logger.debug("📊 Calculated beta fallback: 1.0 (neutral)")
 
     return data
+
+
+def _fill_volatility(data: dict[str, Any], price_history: pd.Series | None) -> None:
+    """
+    Derive annualized volatility from price history when the quant tool did not supply it.
+
+    Mutates ``data`` in place. Never overwrites a value the quant tool already
+    produced, and stays silent when there is not enough history to be meaningful.
+    """
+    if data.get("volatility") is not None:
+        return
+    if price_history is None or len(price_history) < 2:
+        return
+
+    returns = price_history.pct_change().dropna()
+    if returns.empty:
+        return
+
+    data["volatility"] = calculate_volatility(returns, annualize=True)
+    logger.debug(f"📊 Derived volatility={data['volatility']:.4f} from {len(returns)} return observations")
 
 
 def _calculate_moving_averages(data: dict[str, Any], prices: pd.Series, current_price: float) -> None:

--- a/src/finwiz/tools/alternative_finder_tool.py
+++ b/src/finwiz/tools/alternative_finder_tool.py
@@ -23,6 +23,14 @@ SwapTiming = Literal["immediate", "gradual", "tax_optimized"]
 
 logger = get_logger(__name__)
 
+# Grades eligible for "A-band" alternative sourcing from consolidated_discovery.json's
+# flat `opportunities` list. Matches the top two tiers of the Grade vocabulary that
+# finwiz.scoring.grading_system.score_to_grade actually emits (A+, A, B+, B, C+, C, D, F
+# — the sole grader behind discovery opportunities; see finwiz.discovery.candidate_scorer).
+# Broader than "A+ only" so this isn't perpetually empty: A+ alone requires a >=95%
+# composite score, which is rare in practice.
+_A_BAND_GRADES: frozenset[str] = frozenset({"A+", "A"})
+
 
 class HoldingProfile(BaseModel):
     """Profile of a holding for matching alternatives."""
@@ -172,58 +180,60 @@ class AlternativeFinder:
         return unique_alternatives
 
     def _find_aplus_alternatives(self, holding: HoldingProfile) -> list[Alternative]:
-        """Find A+ alternatives from discovery crew outputs."""
+        """Find A-band alternatives from the consolidated discovery output.
+
+        ``consolidated_discovery.json`` is the only file the discovery pipeline
+        actually writes (see ``discovery_orchestrator.py``). It holds a flat
+        ``opportunities`` list spanning every asset class and every grade —
+        unlike the array this reader used to look for, nothing pre-filters it
+        to A-band candidates, so filtering by asset class and grade happens here.
+        """
         alternatives = []
 
-        # Check for latest discovery output
-        latest_file = self.discovery_output_dir / "discovery_latest.json"
-        if not latest_file.exists():
-            self.logger.warning(f"No discovery crew output found at {latest_file}; A+ alternatives unavailable for this run.")
+        discovery_file = self.discovery_output_dir / "consolidated_discovery.json"
+        if not discovery_file.exists():
+            self.logger.warning(f"No discovery output found at {discovery_file}; A-band alternatives unavailable for this run.")
             return alternatives
 
         try:
-            with open(latest_file) as f:
+            with open(discovery_file) as f:
                 discovery_data = json.load(f)
 
-            # Extract A+ opportunities
-            pydantic_output = discovery_data.get("pydantic", {})
-            if not pydantic_output:
-                self.logger.warning(f"Discovery output exists but has no pydantic data. File: {latest_file}")
+            opportunities = discovery_data.get("opportunities", [])
+            if not opportunities:
+                self.logger.warning(f"Discovery output exists but has no opportunities. File: {discovery_file}")
                 return alternatives
 
-            # Look for A+ stocks/ETFs/crypto based on asset class
-            aplus_field = f"aplus_{holding.asset_class}s"  # aplus_stocks, aplus_etfs, aplus_cryptos
-            aplus_items = pydantic_output.get(aplus_field, [])
+            aplus_items = [item for item in opportunities if isinstance(item, dict) and item.get("asset_class") == holding.asset_class and item.get("grade") in _A_BAND_GRADES]
 
             if not aplus_items:
-                self.logger.info(f"No A+ {holding.asset_class}s found in discovery output. Field '{aplus_field}' is empty or missing.")
+                self.logger.info(f"No A-band {holding.asset_class}s found in discovery output for {holding.ticker}.")
                 return alternatives
 
-            self.logger.info(f"Found {len(aplus_items)} A+ {holding.asset_class}s in discovery output, filtering for alternatives to {holding.ticker}")
+            self.logger.info(f"Found {len(aplus_items)} A-band {holding.asset_class}s in discovery output, filtering for alternatives to {holding.ticker}")
 
             for item in aplus_items:
-                if isinstance(item, dict):
-                    ticker = item.get("ticker", "")
-                    if ticker and ticker != holding.ticker:
-                        alternative = self._create_alternative_from_aplus(
-                            item=item,
-                            holding=holding,
-                        )
-                        if alternative:
-                            alternatives.append(alternative)
-                            self.logger.info(f"Created alternative: {ticker} (grade: {item.get('grade', 'N/A')}) for {holding.ticker}")
-                    elif ticker == holding.ticker:
-                        self.logger.debug(f"Skipping {ticker} as it's the same as current holding")
+                ticker = item.get("ticker", "")
+                if ticker and ticker != holding.ticker:
+                    alternative = self._create_alternative_from_aplus(
+                        item=item,
+                        holding=holding,
+                    )
+                    if alternative:
+                        alternatives.append(alternative)
+                        self.logger.info(f"Created alternative: {ticker} (grade: {item.get('grade', 'N/A')}) for {holding.ticker}")
+                elif ticker == holding.ticker:
+                    self.logger.debug(f"Skipping {ticker} as it's the same as current holding")
 
             if not alternatives:
                 self.logger.warning(
-                    f"Found {len(aplus_items)} A+ {holding.asset_class}s but none are suitable alternatives for {holding.ticker} (all may be the same ticker or failed validation)"
+                    f"Found {len(aplus_items)} A-band {holding.asset_class}s but none are suitable alternatives for {holding.ticker} (all may be the same ticker or failed validation)"
                 )
 
         except Exception as e:
             self.logger.error(
-                f"Error reading discovery output from {latest_file}: {e}",
-                extra={"error": str(e), "file": str(latest_file)},
+                f"Error reading discovery output from {discovery_file}: {e}",
+                extra={"error": str(e), "file": str(discovery_file)},
                 exc_info=True,
             )
 

--- a/src/finwiz/tools/backtesting_tool.py
+++ b/src/finwiz/tools/backtesting_tool.py
@@ -13,6 +13,7 @@ from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
 # Lazy imports to avoid circular dependencies
+from finwiz.quantitative.backtesting import minimum_bars_required
 from finwiz.quantitative.data import get_historical_data_manager
 from finwiz.quantitative.performance import get_performance_analyzer
 from finwiz.schemas.tools import BacktestingInput
@@ -181,6 +182,20 @@ class BacktestingTool(BaseTool):
                 benchmark_symbol=input_data.benchmark_symbol,
             )
 
+            # A short series is a refusal, not a failure: the engine returns None
+            # because backtrader would never reach the strategy's minperiod. Say
+            # so by name -- reading attributes off the None instead produced
+            # "Error performing backtesting: 'NoneType' object has no attribute
+            # 'strategy_name'", which tells the reading agent nothing.
+            if backtest_result is None:
+                minimum_bars = minimum_bars_required(strategy_params)
+                refusal = (
+                    f"Insufficient data for {input_data.symbol}: {input_data.backtest_period_years}y of price history is shorter than the "
+                    f"{minimum_bars} bars {strategy_class.__name__} needs (lookback + warm-up buffer). No backtest performed."
+                )
+                logger.info(refusal)
+                return refusal
+
             # Calculate additional risk-adjusted metrics
             additional_metrics = self._calculate_additional_metrics(backtest_result)
 
@@ -344,6 +359,21 @@ class BacktestingTool(BaseTool):
                         strategy_params=strategy_params,
                         benchmark_symbol=benchmark_symbol,
                     )
+
+                    # Regimes are sub-periods of the backtest window, so they are
+                    # routinely shorter than the strategy's minimum -- this is the
+                    # most-hit refusal of the three. Drop the regime and say why:
+                    # the surrounding except used to catch the AttributeError from
+                    # reading the None and log it as an error, and inventing a 0.0
+                    # return instead would report a missing measurement as a real one.
+                    if regime_result is None:
+                        minimum_bars = minimum_bars_required(strategy_params)
+                        logger.info(
+                            f"Insufficient data for the {regime['type']} regime of {symbol} "
+                            f"({regime['start_date']} to {regime['end_date']}): shorter than the {minimum_bars} bars "
+                            f"{strategy_class.__name__} needs. Regime omitted from regime analysis and consistency scoring."
+                        )
+                        continue
 
                     # Calculate regime-specific metrics
                     regime_analysis = MarketRegime(

--- a/src/finwiz/tools/quantitative_backtesting_analyzer.py
+++ b/src/finwiz/tools/quantitative_backtesting_analyzer.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from finwiz.quantitative.backtesting import SimpleMovingAverageStrategy
+from finwiz.quantitative.backtesting import SimpleMovingAverageStrategy, minimum_bars_required
 from finwiz.schemas.quantitative_crew import QuantitativeBacktestResult
 from finwiz.tools.logger import get_logger
 
@@ -38,10 +38,12 @@ def perform_backtesting(
         backtesting_engine: Backtesting engine instance
 
     Returns:
-        JSON string with backtesting results
+        JSON string with backtesting results, or a plain-text refusal when the
+        price history is too short for the strategy to be backtested at all.
 
     """
     logger = get_logger(__name__)
+    strategy_params = {"short_period": 20, "long_period": 50}
 
     try:
         # Run backtest with simple moving average strategy
@@ -50,8 +52,22 @@ def perform_backtesting(
             input_data.symbol,
             start_date,
             end_date,
-            strategy_params={"short_period": 20, "long_period": 50},
+            strategy_params=strategy_params,
         )
+
+        # A short series is a refusal, not a failure: the engine returns None
+        # because backtrader would never reach the strategy's minperiod. Say so
+        # by name -- reading attributes off the None instead produced
+        # "Backtesting error: 'NoneType' object has no attribute
+        # 'strategy_name'", which tells the reading agent nothing.
+        if backtest_result is None:
+            minimum_bars = minimum_bars_required(strategy_params)
+            refusal = (
+                f"Insufficient data for {input_data.symbol}: price history is shorter than the {minimum_bars} bars "
+                f"{SimpleMovingAverageStrategy.__name__} needs (lookback + warm-up buffer). No backtest performed."
+            )
+            logger.info(refusal)
+            return refusal
 
         # Convert to simplified schema
         quant_backtest = QuantitativeBacktestResult(

--- a/src/finwiz/tools/quantitative_comprehensive_analyzer.py
+++ b/src/finwiz/tools/quantitative_comprehensive_analyzer.py
@@ -332,6 +332,13 @@ def generate_recommendation(symbol: str, tech_result: Any | None, backtest_resul
 
     """
     tech_signal = tech_result.overall_signal.value if tech_result is not None else "N/A"
+    # 0.0 here is a real value, not a fabrication: `confidence` measures how
+    # much basis this function had for its recommendation, and with no
+    # technical signal to weigh, the honest amount of confidence is none.
+    # Contrast with the risk_metrics fields above/below, where a substituted
+    # 0.0 would misrepresent an unmeasured quantity (volatility, drawdown)
+    # as a measured one of value zero -- that distinction is why those are
+    # omitted but this is not. See Task 15 review round 2.
     tech_confidence = tech_result.overall_confidence if tech_result is not None else 0.0
 
     backtest_return = backtest_result.annualized_return if backtest_result is not None else None

--- a/src/finwiz/tools/quantitative_comprehensive_analyzer.py
+++ b/src/finwiz/tools/quantitative_comprehensive_analyzer.py
@@ -58,15 +58,31 @@ def perform_comprehensive_analysis(
     Returns:
         JSON string with comprehensive analysis results
 
+    Technical analysis, backtesting, and performance analysis are three
+    independent computations over the same price history -- each is
+    attempted separately and a failure or refusal in one does not discard
+    the other two. That matters concretely: volatility is read downstream
+    from ``performance_metrics``, not from ``backtest_result``
+    (``deep_analysis_data_collector.flatten_collected_data``), so a
+    backtest-side failure must not take volatility down with it. Before this
+    fix, all three lived in one shared try/except, which is the actual
+    mechanism behind "a crash drops the holding's entire quantitative
+    payload" (Task 15).
+
     """
     logger = get_logger(__name__)
 
+    tech_result = None
+    quant_tech = None
     try:
-        # Technical analysis
         tech_result = technical_engine.analyze_symbol(data, input_data.symbol, timeframe="1d")
         quant_tech = _create_technical_result(input_data.symbol, tech_result)
+    except Exception as e:
+        logger.error(f"Technical analysis failed for {input_data.symbol}: {e}")
 
-        # Backtesting
+    backtest_result = None
+    quant_backtest = None
+    try:
         backtest_result = backtesting_engine.run_strategy_backtest(
             SimpleMovingAverageStrategy,
             input_data.symbol,
@@ -74,15 +90,27 @@ def perform_comprehensive_analysis(
             end_date,
             strategy_params={"short_period": 20, "long_period": 50},
         )
-        quant_backtest = _create_backtest_result(input_data.symbol, backtest_result)
+        if backtest_result is not None:
+            quant_backtest = _create_backtest_result(input_data.symbol, backtest_result)
+    except Exception as e:
+        logger.error(f"Backtest failed for {input_data.symbol}: {e}")
 
-        # Performance analysis
+    metrics = None
+    quant_perf = None
+    try:
         returns = data["Close"].pct_change().dropna()
         perf_report = performance_analyzer.analyze_performance(returns, strategy_name=f"{input_data.symbol}_analysis")
         metrics = perf_report.strategy_metrics
         quant_perf = _create_performance_result(input_data.symbol, metrics, len(returns))
+    except Exception as e:
+        logger.error(f"Performance analysis failed for {input_data.symbol}: {e}")
 
-        # Generate recommendation
+    if quant_tech is None and quant_backtest is None and quant_perf is None:
+        message = f"technical, backtest, and performance analysis all failed for {input_data.symbol}"
+        logger.error(f"Comprehensive analysis error: {message}")
+        return f"Comprehensive analysis error: {message}"
+
+    try:
         recommendation = generate_recommendation(input_data.symbol, tech_result, backtest_result, metrics)
 
         # Add ETF-specific metrics if applicable
@@ -101,7 +129,7 @@ def perform_comprehensive_analysis(
         return json.dumps(result_dict, indent=2, default=str)
 
     except Exception as e:
-        logger.error(f"Error in comprehensive analysis: {e}")
+        logger.error(f"Error assembling comprehensive analysis for {input_data.symbol}: {e}")
         return f"Comprehensive analysis error: {e!s}"
 
 
@@ -205,9 +233,9 @@ def _fetch_etf_specific_data(symbol: str, logger) -> dict:
 
 def _create_asset_specific_result(
     input_data: QuantitativeAnalysisInput,
-    quant_tech: QuantitativeTechnicalAnalysis,
-    quant_backtest: QuantitativeBacktestResult,
-    quant_perf: QuantitativePerformanceMetrics,
+    quant_tech: QuantitativeTechnicalAnalysis | None,
+    quant_backtest: QuantitativeBacktestResult | None,
+    quant_perf: QuantitativePerformanceMetrics | None,
     recommendation: QuantitativeRecommendation,
 ):
     """Create asset-class specific analysis result."""
@@ -237,63 +265,77 @@ def _create_asset_specific_result(
         )
 
 
-def generate_recommendation(symbol: str, tech_result: Any, backtest_result: Any, perf_metrics: Any) -> QuantitativeRecommendation:
+def generate_recommendation(symbol: str, tech_result: Any | None, backtest_result: Any | None, perf_metrics: Any | None) -> QuantitativeRecommendation:
     """
     Generate investment recommendation based on quantitative analysis.
 
     Args:
         symbol: Asset symbol
-        tech_result: Technical analysis result
-        backtest_result: Backtesting result
-        perf_metrics: Performance metrics
+        tech_result: Technical analysis result, or None if that sub-analysis failed
+        backtest_result: Backtesting result, or None if refused (short series) or failed
+        perf_metrics: Performance metrics, or None if that sub-analysis failed
 
     Returns:
         QuantitativeRecommendation with buy/hold/sell signal
 
-    """
-    # Determine recommendation based on signals
-    tech_signal = tech_result.overall_signal.value
-    backtest_return = backtest_result.annualized_return
-    sharpe_ratio = backtest_result.sharpe_ratio
+    Any of the three inputs may be None -- each of the three sub-analyses in
+    perform_comprehensive_analysis is now independent, so the recommendation
+    degrades gracefully to whichever subset succeeded rather than crashing.
+    Risk metrics (drawdown/volatility/sharpe/VaR) prefer the backtest when
+    available and fall back to performance analysis, since both compute the
+    same quantities from the same price history by different means.
 
-    # Simple recommendation logic
-    if tech_signal in ["BUY", "STRONG_BUY"] and backtest_return > 10 and sharpe_ratio > 1.0:
+    """
+    tech_signal = tech_result.overall_signal.value if tech_result is not None else "HOLD"
+    tech_confidence = tech_result.overall_confidence if tech_result is not None else 0.0
+
+    backtest_return = backtest_result.annualized_return if backtest_result is not None else None
+    sharpe_ratio = backtest_result.sharpe_ratio if backtest_result is not None else (perf_metrics.sharpe_ratio if perf_metrics is not None else None)
+    max_drawdown = backtest_result.max_drawdown if backtest_result is not None else (perf_metrics.max_drawdown if perf_metrics is not None else None)
+    volatility = backtest_result.volatility if backtest_result is not None else (perf_metrics.volatility if perf_metrics is not None else None)
+    var_95 = backtest_result.var_95 if backtest_result is not None else (perf_metrics.var_95 if perf_metrics is not None else None)
+
+    # Simple recommendation logic -- unknown backtest/sharpe inputs simply
+    # don't trigger their branch rather than being treated as failing it.
+    if tech_signal in ["BUY", "STRONG_BUY"] and backtest_return is not None and backtest_return > 10 and sharpe_ratio is not None and sharpe_ratio > 1.0:
         recommendation = "BUY"
-        confidence = min(0.9, tech_result.overall_confidence + 0.2)
-    elif tech_signal in ["SELL", "STRONG_SELL"] or backtest_return < -5 or sharpe_ratio < 0:
+        confidence = min(0.9, tech_confidence + 0.2)
+    elif tech_signal in ["SELL", "STRONG_SELL"] or (backtest_return is not None and backtest_return < -5) or (sharpe_ratio is not None and sharpe_ratio < 0):
         recommendation = "SELL"
-        confidence = min(0.9, tech_result.overall_confidence + 0.1)
+        confidence = min(0.9, tech_confidence + 0.1)
     else:
         recommendation = "HOLD"
-        confidence = tech_result.overall_confidence
+        confidence = tech_confidence
 
     # Risk assessment
-    if backtest_result.max_drawdown < -20:
+    if max_drawdown is not None and max_drawdown < -20:
         risk_assessment = "High risk due to significant drawdown potential"
-    elif backtest_result.volatility > 30:
+    elif volatility is not None and volatility > 30:
         risk_assessment = "Moderate to high risk due to volatility"
     else:
         risk_assessment = "Moderate risk profile"
+
+    backtest_performance = f"Annualized return: {backtest_return:.1f}%, Sharpe: {sharpe_ratio:.2f}" if backtest_return is not None and sharpe_ratio is not None else None
 
     return QuantitativeRecommendation(
         symbol=symbol,
         recommendation=recommendation,
         confidence=confidence,
         technical_signal=tech_signal,
-        backtest_performance=f"Annualized return: {backtest_return:.1f}%, Sharpe: {sharpe_ratio:.2f}",
+        backtest_performance=backtest_performance,
         risk_assessment=risk_assessment,
-        target_return=backtest_return if backtest_return > 0 else None,
+        target_return=backtest_return if backtest_return is not None and backtest_return > 0 else None,
         target_timeframe="1 year",
         key_indicators={
             "technical_signal": tech_signal,
-            "technical_confidence": tech_result.overall_confidence,
-            "bullish_signals": tech_result.bullish_signals,
-            "bearish_signals": tech_result.bearish_signals,
+            "technical_confidence": tech_confidence,
+            "bullish_signals": tech_result.bullish_signals if tech_result is not None else 0,
+            "bearish_signals": tech_result.bearish_signals if tech_result is not None else 0,
         },
         risk_metrics={
-            "max_drawdown": backtest_result.max_drawdown,
-            "volatility": backtest_result.volatility,
-            "sharpe_ratio": sharpe_ratio,
-            "var_95": backtest_result.var_95 or 0,
+            "max_drawdown": max_drawdown if max_drawdown is not None else 0.0,
+            "volatility": volatility if volatility is not None else 0.0,
+            "sharpe_ratio": sharpe_ratio if sharpe_ratio is not None else 0.0,
+            "var_95": var_95 or 0,
         },
     )

--- a/src/finwiz/tools/quantitative_comprehensive_analyzer.py
+++ b/src/finwiz/tools/quantitative_comprehensive_analyzer.py
@@ -265,6 +265,36 @@ def _create_asset_specific_result(
         )
 
 
+def _build_key_indicators(tech_result: Any | None, tech_signal: str, tech_confidence: float) -> dict[str, Any]:
+    """Signal counts are omitted (not fabricated as 0) when technical analysis failed."""
+    key_indicators: dict[str, Any] = {"technical_signal": tech_signal, "technical_confidence": tech_confidence}
+    if tech_result is not None:
+        key_indicators["bullish_signals"] = tech_result.bullish_signals
+        key_indicators["bearish_signals"] = tech_result.bearish_signals
+    return key_indicators
+
+
+def _build_risk_metrics(max_drawdown: float | None, volatility: float | None, sharpe_ratio: float | None, var_95: float | None) -> dict[str, float]:
+    """Omit a risk figure rather than fabricate 0.0 when it could not be computed.
+
+    A fabricated 0.0 here used to leak into the scorer's flat dict (via
+    DeepAnalysisDataCollector._flatten_recursive, which walks the whole
+    quantitative_analysis payload) and defeat both the Task 4/5 price-history
+    volatility fallback and the critical-field gate -- both only act when the
+    field is genuinely absent. See Task 15 review round 1.
+    """
+    risk_metrics: dict[str, float] = {}
+    if max_drawdown is not None:
+        risk_metrics["max_drawdown"] = max_drawdown
+    if volatility is not None:
+        risk_metrics["volatility"] = volatility
+    if sharpe_ratio is not None:
+        risk_metrics["sharpe_ratio"] = sharpe_ratio
+    if var_95 is not None:
+        risk_metrics["var_95"] = var_95
+    return risk_metrics
+
+
 def generate_recommendation(symbol: str, tech_result: Any | None, backtest_result: Any | None, perf_metrics: Any | None) -> QuantitativeRecommendation:
     """
     Generate investment recommendation based on quantitative analysis.
@@ -273,7 +303,8 @@ def generate_recommendation(symbol: str, tech_result: Any | None, backtest_resul
         symbol: Asset symbol
         tech_result: Technical analysis result, or None if that sub-analysis failed
         backtest_result: Backtesting result, or None if refused (short series) or failed
-        perf_metrics: Performance metrics, or None if that sub-analysis failed
+        perf_metrics: Performance metrics, or None if that sub-analysis failed (currently
+            unused here -- see note below; kept in the signature for API stability)
 
     Returns:
         QuantitativeRecommendation with buy/hold/sell signal
@@ -281,19 +312,33 @@ def generate_recommendation(symbol: str, tech_result: Any | None, backtest_resul
     Any of the three inputs may be None -- each of the three sub-analyses in
     perform_comprehensive_analysis is now independent, so the recommendation
     degrades gracefully to whichever subset succeeded rather than crashing.
-    Risk metrics (drawdown/volatility/sharpe/VaR) prefer the backtest when
-    available and fall back to performance analysis, since both compute the
-    same quantities from the same price history by different means.
+
+    Risk figures (drawdown/volatility/sharpe/VaR) are read from backtest_result
+    ONLY, never from perf_metrics: BacktestResult.volatility/max_drawdown are
+    percent-scaled (backtesting_performance.py:246) while
+    PerformanceMetrics.volatility/max_drawdown are fractional
+    (performance_metrics.py:90). volatility has a sanctioned normalizer
+    (config/critical_fields_config.py:normalize_volatility); max_drawdown does
+    not, so mixing the two sources here would silently produce a wrong,
+    mis-scaled number (e.g. -3.0 read as -300%) rather than an honestly-absent
+    one. When backtest_result is None these fields are simply None/omitted --
+    never fabricated as 0.0. A fabricated 0.0 is worse than a missing value:
+    downstream, `technical_fallback.fill_volatility` only fills volatility
+    when it is genuinely absent (`data.get("volatility") is None`), and the
+    critical-field gate (`critical_fields_config.validate_critical_fields`)
+    only refuses a holding by name when the field is missing -- a `0.0`
+    defeats both, making an unanalyzable holding look like the safest one in
+    the portfolio. See Task 15 review round 1.
 
     """
-    tech_signal = tech_result.overall_signal.value if tech_result is not None else "HOLD"
+    tech_signal = tech_result.overall_signal.value if tech_result is not None else "N/A"
     tech_confidence = tech_result.overall_confidence if tech_result is not None else 0.0
 
     backtest_return = backtest_result.annualized_return if backtest_result is not None else None
-    sharpe_ratio = backtest_result.sharpe_ratio if backtest_result is not None else (perf_metrics.sharpe_ratio if perf_metrics is not None else None)
-    max_drawdown = backtest_result.max_drawdown if backtest_result is not None else (perf_metrics.max_drawdown if perf_metrics is not None else None)
-    volatility = backtest_result.volatility if backtest_result is not None else (perf_metrics.volatility if perf_metrics is not None else None)
-    var_95 = backtest_result.var_95 if backtest_result is not None else (perf_metrics.var_95 if perf_metrics is not None else None)
+    sharpe_ratio = backtest_result.sharpe_ratio if backtest_result is not None else None
+    max_drawdown = backtest_result.max_drawdown if backtest_result is not None else None
+    volatility = backtest_result.volatility if backtest_result is not None else None
+    var_95 = backtest_result.var_95 if backtest_result is not None else None
 
     # Simple recommendation logic -- unknown backtest/sharpe inputs simply
     # don't trigger their branch rather than being treated as failing it.
@@ -307,15 +352,19 @@ def generate_recommendation(symbol: str, tech_result: Any | None, backtest_resul
         recommendation = "HOLD"
         confidence = tech_confidence
 
-    # Risk assessment
+    # Risk assessment -- an honest "unavailable" beats a fabricated "Moderate".
     if max_drawdown is not None and max_drawdown < -20:
         risk_assessment = "High risk due to significant drawdown potential"
     elif volatility is not None and volatility > 30:
         risk_assessment = "Moderate to high risk due to volatility"
-    else:
+    elif max_drawdown is not None or volatility is not None:
         risk_assessment = "Moderate risk profile"
+    else:
+        risk_assessment = "Risk assessment unavailable: backtest could not run for this series"
 
     backtest_performance = f"Annualized return: {backtest_return:.1f}%, Sharpe: {sharpe_ratio:.2f}" if backtest_return is not None and sharpe_ratio is not None else None
+    key_indicators = _build_key_indicators(tech_result, tech_signal, tech_confidence)
+    risk_metrics = _build_risk_metrics(max_drawdown, volatility, sharpe_ratio, var_95)
 
     return QuantitativeRecommendation(
         symbol=symbol,
@@ -326,16 +375,6 @@ def generate_recommendation(symbol: str, tech_result: Any | None, backtest_resul
         risk_assessment=risk_assessment,
         target_return=backtest_return if backtest_return is not None and backtest_return > 0 else None,
         target_timeframe="1 year",
-        key_indicators={
-            "technical_signal": tech_signal,
-            "technical_confidence": tech_confidence,
-            "bullish_signals": tech_result.bullish_signals if tech_result is not None else 0,
-            "bearish_signals": tech_result.bearish_signals if tech_result is not None else 0,
-        },
-        risk_metrics={
-            "max_drawdown": max_drawdown if max_drawdown is not None else 0.0,
-            "volatility": volatility if volatility is not None else 0.0,
-            "sharpe_ratio": sharpe_ratio if sharpe_ratio is not None else 0.0,
-            "var_95": var_95 or 0,
-        },
+        key_indicators=key_indicators,
+        risk_metrics=risk_metrics,
     )

--- a/tests/unit/analysis/stages/test_fact_pack.py
+++ b/tests/unit/analysis/stages/test_fact_pack.py
@@ -9,8 +9,8 @@ from typing import Any
 import pytest
 
 from finwiz.analysis.stages._ledger import RunLedger
-from finwiz.analysis.stages._resilience import StageContext
-from finwiz.analysis.stages.fact_pack import fact_pack
+from finwiz.analysis.stages._resilience import StageContext, TransientStageError
+from finwiz.analysis.stages.fact_pack import _fact_pack_inner, fact_pack
 from finwiz.cache.fact_pack_cache import FactPackCache
 from finwiz.schemas.hybrid_analysis.fact_pack import FactPack
 from finwiz.schemas.stage_contract import StageOutcome
@@ -125,6 +125,34 @@ class TestFactPackStage:
         assert result.provenance.outcome == StageOutcome.FAILED
         assert result.payload is None
         assert "DELL" in (result.provenance.reason or "")
+
+    def test_no_cache_perplexity_fails_retries_once_then_fails(self, tmp_path: Path, mocker: Any, patched_cache: FactPackCache) -> None:
+        """Regression guard: the declared retries=1 on @stage(name="fact_pack") must
+        actually fire. Before TransientStageError, _fact_pack_inner raised a plain
+        RuntimeError, which _is_transient() classified non-transient, so all 22
+        fact_pack failures on the 2026-08-15 run recorded retries_used=0.
+        """
+        spy = mocker.patch(
+            "finwiz.analysis.stages.fact_pack.fetch_fact_pack_sync",
+            return_value=None,
+        )
+        ctx = _build_ctx(tmp_path, mocker)
+        result = fact_pack(ctx, {})
+        assert result.provenance.outcome == StageOutcome.FAILED
+        assert result.provenance.retries_used == 1
+        assert spy.call_count == 2
+
+    def test_fact_pack_inner_raises_transient_error_when_no_cache_and_no_fetch(self, tmp_path: Path, mocker: Any, patched_cache: FactPackCache) -> None:
+        """No cache and Perplexity fetch fails: _fact_pack_inner raises TransientStageError,
+        not a plain RuntimeError, so the @stage decorator's _is_transient check can route it
+        through the declared retry instead of failing on the first attempt.
+        """
+        mocker.patch(
+            "finwiz.analysis.stages.fact_pack.fetch_fact_pack_sync",
+            return_value=None,
+        )
+        with pytest.raises(TransientStageError, match="fact_pack unavailable for NVDA"):
+            _fact_pack_inner("NVDA", "NVIDIA Corp", "Technology", "Semiconductors")
 
     def test_cache_stale_live_fetch_succeeds_returns_fresh(self, tmp_path: Path, mocker: Any, patched_cache: FactPackCache) -> None:
         # Stale cached + Perplexity returns new

--- a/tests/unit/analysis/stages/test_resilience.py
+++ b/tests/unit/analysis/stages/test_resilience.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import BaseModel
 
 from finwiz.analysis.stages._ledger import RunLedger
-from finwiz.analysis.stages._resilience import StageContext, stage
+from finwiz.analysis.stages._resilience import StageContext, TransientStageError, _is_transient, stage
 from finwiz.schemas.stage_contract import (
     StageOutcome,
     StageResult,
@@ -132,3 +132,34 @@ async def test_stage_async_retries_transient(tmp_path: Path) -> None:
     assert calls["n"] == 3
     assert result.provenance.outcome == StageOutcome.OK
     assert result.provenance.retries_used == 2
+
+
+def test_transient_stage_error_is_classified_transient() -> None:
+    assert _is_transient(TransientStageError("rate limited")) is True
+
+
+def test_plain_runtime_error_is_not_transient() -> None:
+    assert _is_transient(RuntimeError("bad state")) is False
+
+
+def test_stage_retries_transient_stage_error(tmp_path: Path) -> None:
+    """A sync stage body raising TransientStageError reaches its declared retry.
+
+    Regression guard for the fact_pack bug: before TransientStageError existed,
+    a plain RuntimeError from the stage body was classified non-transient, so
+    declared retries never fired (retries_used stayed 0 in the ledger).
+    """
+    calls = {"n": 0}
+
+    @stage(name="fact_pack", timeout_s=5, retries=1)
+    def _flaky(ctx: StageContext) -> _Payload:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise TransientStageError("upstream unavailable")
+        return _Payload(value=3)
+
+    ctx = _ctx(tmp_path)
+    result = _flaky(ctx)
+    assert calls["n"] == 2
+    assert result.provenance.outcome == StageOutcome.OK
+    assert result.provenance.retries_used == 1

--- a/tests/unit/analysis/test_fact_pack_research.py
+++ b/tests/unit/analysis/test_fact_pack_research.py
@@ -40,10 +40,28 @@ class TestPromptBuilder:
 
 class TestFetchFactPack:
     @pytest.mark.asyncio
+    async def test_fetch_routes_through_retry_wrapper(self, mocker: Any) -> None:
+        """fetch_fact_pack must call perplexity_with_retry (Task 1's wrapper), not
+        perplexity_structured directly, so the single fact_pack call gets retry +
+        backoff instead of failing outright on the first timeout/429.
+        """
+        called = mocker.patch(
+            "finwiz.analysis.fact_pack_research.perplexity_with_retry",
+            new=mocker.AsyncMock(return_value=None),
+        )
+
+        result = await fetch_fact_pack("NVDA", "NVIDIA Corp", "Technology", "Semiconductors")
+
+        assert result is None
+        assert called.await_count == 1
+        assert called.await_args.kwargs["schema"] is _FactPackRaw
+        assert called.await_args.kwargs["search_recency_filter"] == "month"
+
+    @pytest.mark.asyncio
     async def test_fetch_returns_factpack_with_python_freshness(self, mocker: Any) -> None:
         mocker.patch(
-            "finwiz.analysis.fact_pack_research.perplexity_structured",
-            return_value=_build_raw(),
+            "finwiz.analysis.fact_pack_research.perplexity_with_retry",
+            new=mocker.AsyncMock(return_value=_build_raw()),
         )
         fp = await fetch_fact_pack("DELL", "Dell Technologies", "Tech", "Hardware")
         assert fp is not None
@@ -54,19 +72,25 @@ class TestFetchFactPack:
         assert fp.fetched_at.tzinfo is not None
 
     @pytest.mark.asyncio
-    async def test_fetch_returns_none_on_perplexity_failure(self, mocker: Any) -> None:
+    async def test_fetch_returns_none_when_wrapper_raises(self, mocker: Any) -> None:
+        """perplexity_with_retry already catches every exception internally and
+        returns None on failure, so it shouldn't raise in normal operation. The
+        try/except in fetch_fact_pack is defensive depth at the stage boundary
+        (guards against the wrapper's contract changing later) rather than
+        something this call site currently relies on for a *known* failure mode.
+        """
         mocker.patch(
-            "finwiz.analysis.fact_pack_research.perplexity_structured",
-            side_effect=RuntimeError("Perplexity down"),
+            "finwiz.analysis.fact_pack_research.perplexity_with_retry",
+            new=mocker.AsyncMock(side_effect=RuntimeError("unexpected")),
         )
         fp = await fetch_fact_pack("DELL", "Dell Technologies")
         assert fp is None
 
     @pytest.mark.asyncio
-    async def test_fetch_returns_none_on_perplexity_returning_none(self, mocker: Any) -> None:
+    async def test_fetch_returns_none_on_wrapper_returning_none(self, mocker: Any) -> None:
         mocker.patch(
-            "finwiz.analysis.fact_pack_research.perplexity_structured",
-            return_value=None,
+            "finwiz.analysis.fact_pack_research.perplexity_with_retry",
+            new=mocker.AsyncMock(return_value=None),
         )
         fp = await fetch_fact_pack("DELL", "Dell Technologies")
         assert fp is None

--- a/tests/unit/cache/test_fact_pack_cache.py
+++ b/tests/unit/cache/test_fact_pack_cache.py
@@ -52,13 +52,30 @@ class TestFactPackCache:
         assert loaded is not None
         assert loaded.freshness == "stale"
 
+    def test_get_returns_stale_entry_within_new_horizon_not_evicted(self, tmp_path: Path) -> None:
+        """A 20d-old entry used to be evicted under the old 15-day cliff. It now
+        falls within the widened stale band (7-90d) so a rate-limited run can
+        still be rescued by it — see fact_pack.py's _STALE_HORIZON_DAYS.
+        """
+        cache = FactPackCache(cache_dir=tmp_path)
+        fp = _build_fp(days_old=0)
+        cache.put("DELL", fp)
+        path = tmp_path / "DELL.json"
+        data = json.loads(path.read_text())
+        twenty_days = (datetime.now(UTC) - timedelta(days=20)).isoformat()
+        data["payload"]["fetched_at"] = twenty_days
+        path.write_text(json.dumps(data, default=str))
+        loaded = cache.get("DELL")
+        assert loaded is not None
+        assert loaded.freshness == "stale"
+
     def test_get_returns_none_for_too_old(self, tmp_path: Path) -> None:
         cache = FactPackCache(cache_dir=tmp_path)
         fp = _build_fp(days_old=0)
         cache.put("DELL", fp)
         path = tmp_path / "DELL.json"
         data = json.loads(path.read_text())
-        too_old = (datetime.now(UTC) - timedelta(days=20)).isoformat()
+        too_old = (datetime.now(UTC) - timedelta(days=95)).isoformat()
         data["payload"]["fetched_at"] = too_old
         path.write_text(json.dumps(data, default=str))
         assert cache.get("DELL") is None

--- a/tests/unit/config/test_critical_fields_config.py
+++ b/tests/unit/config/test_critical_fields_config.py
@@ -1,5 +1,7 @@
 """Tests for critical fields configuration and sanity checks."""
 
+import math
+
 import pytest
 
 from finwiz.config.critical_fields_config import CriticalFieldError, normalize_volatility, validate_critical_fields
@@ -89,6 +91,19 @@ class TestNormalizeVolatility:
         """Exactly 5.0 sits at the rescale threshold (not > 5.0) and is left unchanged, not divided by 100."""
         assert normalize_volatility(5.0) == 5.0
 
+    def test_nan_volatility_is_rejected(self):
+        """NaN defeats every ordinary comparison (all False), so it must be explicitly rejected (Ruling 16)."""
+        # Never assert `== float("nan")` — NaN is never equal to itself. Assert the None result directly.
+        assert normalize_volatility(float("nan")) is None
+
+    def test_positive_infinity_volatility_is_rejected(self):
+        """+inf is not a real volatility reading — reject as None (Ruling 16)."""
+        assert normalize_volatility(float("inf")) is None
+
+    def test_negative_infinity_volatility_is_rejected(self):
+        """-inf is not a real volatility reading — reject as None (Ruling 16)."""
+        assert normalize_volatility(float("-inf")) is None
+
 
 class TestVolatilityGateNormalization:
     """Tests that validate_critical_fields normalizes volatility before the sanity check runs."""
@@ -149,3 +164,13 @@ class TestVolatilityGateNormalization:
         data = _make_stock_data(volatility=5.0)
         validate_critical_fields("TEST", "stock", data)  # Should not raise
         assert data["volatility"] == 5.0
+
+    def test_gate_rejects_nan_volatility_as_invalid(self):
+        """A NaN volatility must be refused by the gate as an invalid value, not silently accepted (Ruling 16)."""
+        data = _make_stock_data(volatility=float("nan"))
+        with pytest.raises(CriticalFieldError) as exc_info:
+            validate_critical_fields("TEST", "stock", data)
+        assert "volatility (invalid value: nan)" in exc_info.value.missing_fields
+        # normalize_volatility rejected it, so the gate must not have overwritten data in place.
+        # Never assert `== float("nan")` here — NaN is never equal to itself.
+        assert math.isnan(data["volatility"])

--- a/tests/unit/config/test_critical_fields_config.py
+++ b/tests/unit/config/test_critical_fields_config.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from finwiz.config.critical_fields_config import CriticalFieldError, validate_critical_fields
+from finwiz.config.critical_fields_config import CriticalFieldError, normalize_volatility, validate_critical_fields
 
 
 def _make_stock_data(**overrides):
@@ -46,5 +46,54 @@ class TestRoeSanityCheck:
     def test_should_flag_extreme_negative_roe(self):
         """ROE=-6.0 (-600%) is extreme and likely a data error."""
         data = _make_stock_data(roe=-6.0)
+        with pytest.raises(CriticalFieldError):
+            validate_critical_fields("TEST", "stock", data)
+
+
+class TestNormalizeVolatility:
+    """Tests for normalize_volatility() — coercing raw volatility to the fractional scale."""
+
+    def test_fractional_volatility_passes_through(self):
+        """Values already on the fractional scale (0.25 = 25%) are returned unchanged."""
+        assert normalize_volatility(0.25) == 0.25
+
+    def test_percent_scaled_volatility_is_rescaled(self):
+        """Values on the percent scale (25.3 = 25.3%) are rescaled to fractional."""
+        assert normalize_volatility(25.3) == pytest.approx(0.253)
+
+    def test_absurd_volatility_is_rejected(self):
+        """Values above the absurd ceiling are neither real fractional nor percent readings — reject as None."""
+        assert normalize_volatility(900.0) is None
+
+    def test_negative_volatility_is_rejected(self):
+        """Negative volatility is not physically meaningful — reject as None."""
+        assert normalize_volatility(-0.25) is None
+
+    def test_none_stays_none(self):
+        """A missing reading stays missing."""
+        assert normalize_volatility(None) is None
+
+    def test_zero_is_preserved_not_treated_as_missing(self):
+        """A genuine 0.0 volatility reading must not be coerced to None."""
+        assert normalize_volatility(0.0) == 0.0
+
+
+class TestVolatilityGateNormalization:
+    """Tests that validate_critical_fields normalizes volatility before the sanity check runs."""
+
+    def test_percent_scaled_volatility_no_longer_rejected_by_gate(self):
+        """A percent-scaled volatility (25.3) must not be reported as an invalid value by the gate."""
+        data = _make_stock_data(volatility=25.3)
+        validate_critical_fields("TEST", "stock", data)  # Should not raise
+
+    def test_gate_normalizes_volatility_in_place(self):
+        """After validation, the normalized fractional value replaces the raw percent-scaled one."""
+        data = _make_stock_data(volatility=25.3)
+        validate_critical_fields("TEST", "stock", data)
+        assert data["volatility"] == pytest.approx(0.253)
+
+    def test_absurd_volatility_still_fails_the_gate(self):
+        """An absurd volatility reading (900.0) is still rejected, just as a units error rather than merely missing."""
+        data = _make_stock_data(volatility=900.0)
         with pytest.raises(CriticalFieldError):
             validate_critical_fields("TEST", "stock", data)

--- a/tests/unit/config/test_critical_fields_config.py
+++ b/tests/unit/config/test_critical_fields_config.py
@@ -77,6 +77,18 @@ class TestNormalizeVolatility:
         """A genuine 0.0 volatility reading must not be coerced to None."""
         assert normalize_volatility(0.0) == 0.0
 
+    def test_ceiling_boundary_is_rejected(self):
+        """Exactly the absurd ceiling (500.0) is rejected, not silently accepted as a valid 500% reading (Ruling 13)."""
+        assert normalize_volatility(500.0) is None
+
+    def test_just_below_ceiling_is_still_rescaled(self):
+        """Just under the ceiling is still treated as percent-scaled and rescaled, not rejected."""
+        assert normalize_volatility(499.9) == pytest.approx(4.999)
+
+    def test_rescale_threshold_boundary_passes_through_unchanged(self):
+        """Exactly 5.0 sits at the rescale threshold (not > 5.0) and is left unchanged, not divided by 100."""
+        assert normalize_volatility(5.0) == 5.0
+
 
 class TestVolatilityGateNormalization:
     """Tests that validate_critical_fields normalizes volatility before the sanity check runs."""
@@ -97,3 +109,43 @@ class TestVolatilityGateNormalization:
         data = _make_stock_data(volatility=900.0)
         with pytest.raises(CriticalFieldError):
             validate_critical_fields("TEST", "stock", data)
+
+    def test_absurd_volatility_reported_as_invalid_not_missing(self):
+        """Risk A fix: a present-but-absurd volatility must be named honestly as invalid, not masked as missing."""
+        data = _make_stock_data(volatility=900.0)
+        with pytest.raises(CriticalFieldError) as exc_info:
+            validate_critical_fields("TEST", "stock", data)
+        assert "volatility (invalid value: 900.0)" in exc_info.value.missing_fields
+
+    def test_negative_volatility_reported_as_invalid_not_missing(self):
+        """A present-but-negative volatility must also be named as invalid, not masked as missing."""
+        data = _make_stock_data(volatility=-5.0)
+        with pytest.raises(CriticalFieldError) as exc_info:
+            validate_critical_fields("TEST", "stock", data)
+        assert "volatility (invalid value: -5.0)" in exc_info.value.missing_fields
+
+    def test_none_volatility_still_reported_as_missing(self):
+        """A raw None must still fall through to the ordinary "(missing)" message, not "(invalid value)"."""
+        data = _make_stock_data(volatility=None)
+        with pytest.raises(CriticalFieldError) as exc_info:
+            validate_critical_fields("TEST", "stock", data)
+        assert "volatility (missing)" in exc_info.value.missing_fields
+
+    def test_gate_accepts_zero_volatility(self):
+        """A genuine 0.0 volatility must pass the gate through validate_critical_fields itself, not just the bare function."""
+        data = _make_stock_data(volatility=0.0)
+        validate_critical_fields("TEST", "stock", data)  # Should not raise
+        assert data["volatility"] == 0.0
+
+    def test_gate_rejects_ceiling_boundary_volatility(self):
+        """A volatility of exactly 500.0 must still fail the gate (Ruling 13 boundary)."""
+        data = _make_stock_data(volatility=500.0)
+        with pytest.raises(CriticalFieldError) as exc_info:
+            validate_critical_fields("TEST", "stock", data)
+        assert "volatility (invalid value: 500.0)" in exc_info.value.missing_fields
+
+    def test_gate_accepts_rescale_threshold_boundary_volatility(self):
+        """A volatility of exactly 5.0 sits at the rescale threshold and must pass the gate unchanged."""
+        data = _make_stock_data(volatility=5.0)
+        validate_critical_fields("TEST", "stock", data)  # Should not raise
+        assert data["volatility"] == 5.0

--- a/tests/unit/discovery/test_discovery_paths.py
+++ b/tests/unit/discovery/test_discovery_paths.py
@@ -1,0 +1,13 @@
+"""The discovery artifact name must be consistent between writer and readers."""
+
+from pathlib import Path
+
+SRC = Path("src/finwiz")
+
+
+def test_no_source_file_references_the_retired_name():
+    offenders = []
+    for path in SRC.rglob("*.py"):
+        if "discovery_latest.json" in path.read_text(encoding="utf-8"):
+            offenders.append(str(path))
+    assert offenders == []

--- a/tests/unit/discovery/test_market_data.py
+++ b/tests/unit/discovery/test_market_data.py
@@ -1,0 +1,116 @@
+"""Unit tests for ``discovery.market_data.factor_score_from_returns`` calibration.
+
+The factor score gates discovery candidates against the C grade floor (0.65,
+``grading_system.py``). These tests pin both ends of the ladder: a genuinely
+strong return series must be able to reach the floor, and a flat/weak/negative
+one must not. Beyond the degenerate constant-return series (zero volatility by
+construction), several cases use a two-point alternating series that has an
+*exact*, controllable mean and population std (matching ``numpy.std()``'s
+default ``ddof=0``) so the volatility term is genuinely exercised rather than
+pinned at its maximum.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from finwiz.discovery.market_data import factor_score_from_returns
+from finwiz.scoring.grading_system import score_to_grade
+
+ACTIONABLE_FLOOR = 0.65
+ACTIONABLE_GRADES = {"C", "C+", "B", "B+", "A", "A+"}
+
+
+def _constant_returns(daily: float, days: int = 126) -> list[float]:
+    """A zero-volatility series: every day returns exactly ``daily``."""
+    return [daily] * days
+
+
+def _two_point_returns(cumulative: float, daily_vol: float, days: int = 126) -> list[float]:
+    """An alternating series with an exact target cumulative return and daily std.
+
+    Solves the constant per-day rate ``d`` that compounds to ``cumulative`` over
+    ``days``, then alternates ``d + daily_vol`` / ``d - daily_vol`` so the
+    population standard deviation (``numpy.std()`` default ``ddof=0``) is
+    exactly ``daily_vol`` -- unlike a constant series, this exercises the
+    volatility term instead of always pinning it at 1.0.
+    """
+    d = (1.0 + cumulative) ** (1.0 / days) - 1.0
+    return [d + daily_vol if i % 2 == 0 else d - daily_vol for i in range(days)]
+
+
+class TestShortSeries:
+    def test_none_input_returns_none(self) -> None:
+        assert factor_score_from_returns(None) is None
+
+    def test_too_short_returns_none(self) -> None:
+        assert factor_score_from_returns([0.01, 0.01]) is None
+
+
+class TestCalibrationAgainstGradeLadder:
+    """Pin both ends: strong performers must clear C, weak ones must not."""
+
+    def test_strong_low_volatility_performer_clears_the_actionable_floor(self) -> None:
+        # ~+30% over six months with a smooth daily gain -- an unambiguously good candidate.
+        score = factor_score_from_returns(_constant_returns(0.0021))
+
+        assert score is not None
+        assert score >= ACTIONABLE_FLOOR
+        assert score_to_grade(score).grade in ACTIONABLE_GRADES
+
+    def test_flat_performer_stays_below_the_floor(self) -> None:
+        score = factor_score_from_returns(_constant_returns(0.0))
+
+        assert score is not None
+        assert score < ACTIONABLE_FLOOR
+
+    def test_declining_performer_scores_low(self) -> None:
+        score = factor_score_from_returns(_constant_returns(-0.002))
+
+        assert score is not None
+        assert score < 0.5
+
+    def test_realistic_strong_candidate_with_ordinary_volatility_clears_the_floor(self) -> None:
+        # +12% cumulative over 126 trading days (~+25%/yr) with 1.5% daily volatility
+        # -- realistic for a solid mid-cap, not the idealized zero-vol series above.
+        returns = _two_point_returns(cumulative=0.12, daily_vol=0.015)
+        score = factor_score_from_returns(returns)
+
+        assert score is not None
+        assert score >= ACTIONABLE_FLOOR
+        assert score_to_grade(score).grade in ACTIONABLE_GRADES
+
+    def test_realistic_mediocre_candidate_with_ordinary_volatility_stays_below_the_floor(self) -> None:
+        # +8% cumulative over 126 trading days (~+16%/yr) with the same 1.5% daily
+        # volatility -- a middling candidate must not clear the bar just because
+        # the scale widened. This guards against "calibrating so hard everything clears."
+        returns = _two_point_returns(cumulative=0.08, daily_vol=0.015)
+        score = factor_score_from_returns(returns)
+
+        assert score is not None
+        assert score < ACTIONABLE_FLOOR
+
+    def test_higher_cumulative_return_scores_higher_at_fixed_volatility(self) -> None:
+        weaker = factor_score_from_returns(_two_point_returns(cumulative=0.05, daily_vol=0.015))
+        stronger = factor_score_from_returns(_two_point_returns(cumulative=0.20, daily_vol=0.015))
+
+        assert weaker is not None
+        assert stronger is not None
+        assert stronger > weaker
+
+    def test_higher_volatility_scores_lower_at_fixed_cumulative_return(self) -> None:
+        calmer = factor_score_from_returns(_two_point_returns(cumulative=0.10, daily_vol=0.010))
+        choppier = factor_score_from_returns(_two_point_returns(cumulative=0.10, daily_vol=0.035))
+
+        assert calmer is not None
+        assert choppier is not None
+        assert calmer > choppier
+
+
+class TestScoreRange:
+    @pytest.mark.parametrize("daily", [-0.05, -0.001, 0.0, 0.001, 0.05])
+    def test_score_stays_in_unit_range(self, daily: float) -> None:
+        score = factor_score_from_returns(_constant_returns(daily))
+
+        assert score is not None
+        assert 0.0 <= score <= 1.0

--- a/tests/unit/discovery/test_universe_provider.py
+++ b/tests/unit/discovery/test_universe_provider.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from finwiz.discovery.universe_provider import DynamicUniverseProvider
+from finwiz.discovery.universe_provider import MIN_UNIVERSE_SIZE, DynamicUniverseProvider
 
 
 def test_untradable_placeholders_are_filtered_out(mocker):
@@ -35,3 +35,26 @@ def test_seed_override_is_honored_for_stocks(mocker):
     provider.get_universe("stock")
 
     assert mine.call_args.args[0] == ["QQQ"]
+
+
+def test_static_universe_is_unioned_in_when_mining_falls_short(mocker):
+    provider = DynamicUniverseProvider()
+    mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL", "MSFT"])
+    mocker.patch.object(provider, "_fallback_static_universe", return_value=[f"T{i}" for i in range(MIN_UNIVERSE_SIZE)])
+
+    result = provider.get_universe("etf")
+
+    assert len(result) >= MIN_UNIVERSE_SIZE
+    assert "AAPL" in result
+
+
+def test_shortfall_is_logged_when_floor_cannot_be_met(mocker):
+    provider = DynamicUniverseProvider()
+    mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL"])
+    mocker.patch.object(provider, "_fallback_static_universe", return_value=["MSFT"])
+    warn = mocker.patch.object(provider._logger, "warning")
+
+    result = provider.get_universe("etf")
+
+    assert len(result) == 2
+    assert any("below the floor" in str(c.args[0]) for c in warn.call_args_list)

--- a/tests/unit/discovery/test_universe_provider.py
+++ b/tests/unit/discovery/test_universe_provider.py
@@ -58,3 +58,28 @@ def test_shortfall_is_logged_when_floor_cannot_be_met(mocker):
 
     assert len(result) == 2
     assert any("below the floor" in str(c.args[0]) for c in warn.call_args_list)
+
+
+def test_excluded_ticker_cannot_leak_back_in_via_the_static_union(mocker):
+    provider = DynamicUniverseProvider()
+    mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL"])
+    static_universe = ["GOOG", *[f"T{i}" for i in range(MIN_UNIVERSE_SIZE - 1)]]
+    mocker.patch.object(provider, "_fallback_static_universe", return_value=static_universe)
+
+    result = provider.get_universe("etf", exclude_tickers=["GOOG"])
+
+    assert "GOOG" not in result
+    assert "AAPL" in result
+    assert len(result) >= MIN_UNIVERSE_SIZE
+
+
+def test_crypto_shortfall_does_not_trigger_static_union_but_still_warns(mocker):
+    provider = DynamicUniverseProvider()
+    static = mocker.patch.object(provider, "_fallback_static_universe", return_value=[f"C{i}" for i in range(10)])
+    warn = mocker.patch.object(provider._logger, "warning")
+
+    result = provider.get_universe("crypto")
+
+    assert static.call_count == 1
+    assert len(result) == 10
+    assert any("below the floor" in str(c.args[0]) for c in warn.call_args_list)

--- a/tests/unit/discovery/test_universe_provider.py
+++ b/tests/unit/discovery/test_universe_provider.py
@@ -15,3 +15,23 @@ def test_untradable_placeholders_are_filtered_out(mocker):
     assert "XTSLA" not in result
     assert "AAPL" in result
     assert "MSFT" in result
+
+
+def test_seed_override_is_honored_for_etfs(mocker):
+    provider = DynamicUniverseProvider(seed_etfs=["SPY"])
+    mocker.patch.object(provider, "_fallback_static_universe", return_value=[])
+    mine = mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL"])
+
+    provider.get_universe("etf")
+
+    assert mine.call_args.args[0] == ["SPY"]
+
+
+def test_seed_override_is_honored_for_stocks(mocker):
+    provider = DynamicUniverseProvider(seed_etfs=["QQQ"])
+    mocker.patch.object(provider, "_fallback_static_universe", return_value=[])
+    mine = mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL"])
+
+    provider.get_universe("stock")
+
+    assert mine.call_args.args[0] == ["QQQ"]

--- a/tests/unit/discovery/test_universe_provider.py
+++ b/tests/unit/discovery/test_universe_provider.py
@@ -1,0 +1,17 @@
+"""Tests for universe selection, hygiene and the candidate floor."""
+
+from __future__ import annotations
+
+from finwiz.discovery.universe_provider import DynamicUniverseProvider
+
+
+def test_untradable_placeholders_are_filtered_out(mocker):
+    provider = DynamicUniverseProvider()
+    mocker.patch.object(provider, "_fallback_static_universe", return_value=[])
+    mocker.patch.object(provider, "_mine_etf_holdings", return_value=["AAPL", "XTSLA", "MSFT"])
+
+    result = provider.get_universe("etf")
+
+    assert "XTSLA" not in result
+    assert "AAPL" in result
+    assert "MSFT" in result

--- a/tests/unit/infrastructure/resilience/test_perplexity_retry.py
+++ b/tests/unit/infrastructure/resilience/test_perplexity_retry.py
@@ -65,6 +65,26 @@ async def test_gives_up_after_max_attempts(mocker):
 
 
 @pytest.mark.asyncio
+async def test_retries_and_returns_none_when_call_raises(mocker):
+    # The vendored client's own try/except covers most failures, but a missing-key
+    # ValueError from require_api_key() escapes it (raised before that try starts),
+    # and any other unexpected raise outside its internal handling would too. The
+    # wrapper must treat a raise exactly like a None result: retry, then give up
+    # cleanly, never propagate.
+    inner = mocker.patch(
+        "finwiz.infrastructure.resilience.perplexity_retry.perplexity_structured",
+        new=mocker.AsyncMock(side_effect=ValueError("boom")),
+    )
+    sleep = mocker.patch("finwiz.infrastructure.resilience.perplexity_retry.asyncio.sleep", new=mocker.AsyncMock())
+
+    result = await perplexity_with_retry(prompt="p", schema=_Payload, system="s", max_attempts=3)
+
+    assert result is None
+    assert inner.await_count == 3
+    assert sleep.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_missing_api_key_fails_fast_without_retrying(mocker, monkeypatch):
     monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
     monkeypatch.delenv("PPLX_API_KEY", raising=False)

--- a/tests/unit/infrastructure/resilience/test_perplexity_retry.py
+++ b/tests/unit/infrastructure/resilience/test_perplexity_retry.py
@@ -17,6 +17,25 @@ class _Payload(BaseModel):
     value: str
 
 
+@pytest.fixture(autouse=True)
+def _placeholder_api_key(monkeypatch):
+    """Give every test in this module a placeholder Perplexity key.
+
+    ``perplexity_with_retry`` short-circuits before its first attempt when
+    neither PERPLEXITY_API_KEY nor PPLX_API_KEY is set, so the retry, backoff and
+    throttle tests all need one present. They used to inherit it from the
+    developer's ambient environment, which made this file red on any machine
+    without it -- CI, a fresh clone. Pinning both names here makes the module
+    independent of the environment in either direction: no real key is ever
+    needed, and an ambient one can never change what these tests exercise.
+
+    A test that wants the no-key path deletes these itself; ``monkeypatch`` is
+    the same function-scoped instance, so the test's own call wins.
+    """
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-perplexity-key")
+    monkeypatch.delenv("PPLX_API_KEY", raising=False)
+
+
 @pytest.mark.asyncio
 async def test_returns_payload_on_first_success(mocker):
     inner = mocker.patch(
@@ -127,7 +146,6 @@ def test_throttle_caps_concurrent_calls_across_independent_event_loops(mocker, m
     cap = 4  # PERPLEXITY_CONCURRENCY's production default.
     monkeypatch.setattr(perplexity_retry, "PERPLEXITY_CONCURRENCY", cap)
     monkeypatch.setattr(perplexity_retry, "_throttle", None)
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-perplexity-key")
 
     thread_count = cap + 2
     lock = threading.Lock()

--- a/tests/unit/infrastructure/resilience/test_perplexity_retry.py
+++ b/tests/unit/infrastructure/resilience/test_perplexity_retry.py
@@ -1,6 +1,7 @@
 """Tests for the Perplexity retry wrapper."""
 
 import asyncio
+import importlib
 import threading
 
 import pytest
@@ -11,6 +12,20 @@ from finwiz.infrastructure.resilience.perplexity_retry import (
     get_perplexity_semaphore,
     perplexity_with_retry,
 )
+
+
+def _reload_with_env(monkeypatch, value: str | None) -> None:
+    """Reload perplexity_retry with PERPLEXITY_CONCURRENCY set to `value` (or unset).
+
+    PERPLEXITY_CONCURRENCY is computed once at import time, so observing how a
+    given env value resolves requires re-executing the module -- following the
+    same pattern as test_timeout_headroom.py's CREW_TIMEOUT reload.
+    """
+    if value is None:
+        monkeypatch.delenv("PERPLEXITY_CONCURRENCY", raising=False)
+    else:
+        monkeypatch.setenv("PERPLEXITY_CONCURRENCY", value)
+    importlib.reload(perplexity_retry)
 
 
 class _Payload(BaseModel):
@@ -118,6 +133,40 @@ async def test_missing_api_key_fails_fast_without_retrying(mocker, monkeypatch):
 
     assert result is None
     assert inner.await_count == 0
+
+
+class TestConcurrencyFloor:
+    """PERPLEXITY_CONCURRENCY must never resolve to a value that breaks the throttle.
+
+    0 makes BoundedSemaphore(0).acquire(blocking=False) always return False, so
+    _throttle_slot()'s poll loop spins forever with no timeout. A negative value
+    raises ValueError out of BoundedSemaphore's own constructor, which the retry
+    wrapper's broad `except Exception` launders into a generic per-holding
+    failure instead of surfacing the real (config) cause. Both must be floored
+    to 1 instead.
+    """
+
+    def test_zero_is_floored_to_one(self, monkeypatch):
+        try:
+            _reload_with_env(monkeypatch, "0")
+            assert perplexity_retry.PERPLEXITY_CONCURRENCY == 1
+        finally:
+            _reload_with_env(monkeypatch, None)
+
+    def test_negative_is_floored_to_one(self, monkeypatch):
+        try:
+            _reload_with_env(monkeypatch, "-3")
+            assert perplexity_retry.PERPLEXITY_CONCURRENCY == 1
+        finally:
+            _reload_with_env(monkeypatch, None)
+
+    def test_default_is_unaffected(self, monkeypatch):
+        """A sane value (including the unset default) is not clamped away."""
+        try:
+            _reload_with_env(monkeypatch, None)
+            assert perplexity_retry.PERPLEXITY_CONCURRENCY == 4
+        finally:
+            _reload_with_env(monkeypatch, None)
 
 
 def test_throttle_is_a_loop_agnostic_process_singleton():

--- a/tests/unit/infrastructure/resilience/test_perplexity_retry.py
+++ b/tests/unit/infrastructure/resilience/test_perplexity_retry.py
@@ -1,10 +1,12 @@
 """Tests for the Perplexity retry wrapper."""
 
 import asyncio
+import threading
 
 import pytest
 from pydantic import BaseModel
 
+from finwiz.infrastructure.resilience import perplexity_retry
 from finwiz.infrastructure.resilience.perplexity_retry import (
     get_perplexity_semaphore,
     perplexity_with_retry,
@@ -99,6 +101,72 @@ async def test_missing_api_key_fails_fast_without_retrying(mocker, monkeypatch):
     assert inner.await_count == 0
 
 
-def test_semaphore_is_a_process_singleton():
+def test_throttle_is_a_loop_agnostic_process_singleton():
+    # Replaces the former `test_semaphore_is_a_process_singleton`, which asserted the
+    # throttle was an `asyncio.Semaphore`. That is the very property that broke it:
+    # an asyncio primitive binds to the first event loop that contends on it and
+    # raises RuntimeError for every other one. Production runs one holding per
+    # worker thread, each on its own fresh loop (deep_analysis_orchestrator ->
+    # run_in_executor -> fetch_fact_pack_sync -> asyncio.run), so the throttle must
+    # be a plain threading primitive that belongs to no loop at all.
     assert get_perplexity_semaphore() is get_perplexity_semaphore()
-    assert isinstance(get_perplexity_semaphore(), asyncio.Semaphore)
+    assert isinstance(get_perplexity_semaphore(), threading.BoundedSemaphore)
+
+
+def test_throttle_caps_concurrent_calls_across_independent_event_loops(mocker, monkeypatch):
+    """More threads than the cap, each on its own loop: no RuntimeError, real ceiling.
+
+    This is the production topology at production numbers: the deep-analysis
+    orchestrator hands each holding to a ThreadPoolExecutor worker, the worker has
+    no running loop, so ``fetch_fact_pack_sync`` takes its bare ``asyncio.run``
+    branch -- a fresh event loop per holding, per thread. A loop-bound throttle
+    fails every thread but the first with a swallowed ``RuntimeError`` (which the
+    wrapper logs as an attempt failure and turns into a ``None`` result) and can
+    park a thread forever on a future belonging to a dead loop.
+    """
+    cap = 4  # PERPLEXITY_CONCURRENCY's production default.
+    monkeypatch.setattr(perplexity_retry, "PERPLEXITY_CONCURRENCY", cap)
+    monkeypatch.setattr(perplexity_retry, "_throttle", None)
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-perplexity-key")
+
+    thread_count = cap + 2
+    lock = threading.Lock()
+    state = {"in_flight": 0, "max_in_flight": 0}
+    reached_cap = threading.Event()
+    warnings: list[str] = []
+
+    async def fake_call(**_kwargs):
+        with lock:
+            state["in_flight"] += 1
+            state["max_in_flight"] = max(state["max_in_flight"], state["in_flight"])
+            if state["in_flight"] >= cap:
+                reached_cap.set()
+        try:
+            # Hold the slot until `cap` calls are genuinely concurrent, so the observed
+            # ceiling is deterministic instead of a timing race. Off-loop so a waiting
+            # task on this thread's loop is never blocked by a holder on it.
+            await asyncio.to_thread(reached_cap.wait, 5.0)
+            return _Payload(value="ok")
+        finally:
+            with lock:
+                state["in_flight"] -= 1
+
+    mocker.patch.object(perplexity_retry, "perplexity_structured", new=fake_call)
+    mocker.patch.object(perplexity_retry.logger, "warning", new=lambda msg, *a, **k: warnings.append(str(msg)))
+
+    results: list[object] = []
+
+    def worker() -> None:
+        results.append(asyncio.run(perplexity_with_retry(prompt="p", schema=_Payload, system="s", max_attempts=1)))
+
+    # daemon=True so a thread parked on a dead loop's future cannot wedge the suite.
+    threads = [threading.Thread(target=worker, daemon=True) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15.0)
+
+    assert [t.name for t in threads if t.is_alive()] == [], "thread(s) deadlocked inside asyncio.run"
+    assert warnings == [], "the throttle made calls fail (the wrapper swallows the raise into a warning)"
+    assert results == [_Payload(value="ok")] * thread_count
+    assert state["max_in_flight"] == cap, f"expected the throttle to admit exactly {cap} concurrent calls, saw {state['max_in_flight']}"

--- a/tests/unit/infrastructure/resilience/test_perplexity_retry.py
+++ b/tests/unit/infrastructure/resilience/test_perplexity_retry.py
@@ -1,0 +1,84 @@
+"""Tests for the Perplexity retry wrapper."""
+
+import asyncio
+
+import pytest
+from pydantic import BaseModel
+
+from finwiz.infrastructure.resilience.perplexity_retry import (
+    get_perplexity_semaphore,
+    perplexity_with_retry,
+)
+
+
+class _Payload(BaseModel):
+    value: str
+
+
+@pytest.mark.asyncio
+async def test_returns_payload_on_first_success(mocker):
+    inner = mocker.patch(
+        "finwiz.infrastructure.resilience.perplexity_retry.perplexity_structured",
+        new=mocker.AsyncMock(return_value=_Payload(value="ok")),
+    )
+    sleep = mocker.patch("finwiz.infrastructure.resilience.perplexity_retry.asyncio.sleep", new=mocker.AsyncMock())
+
+    result = await perplexity_with_retry(prompt="p", schema=_Payload, system="s")
+
+    assert result == _Payload(value="ok")
+    assert inner.await_count == 1
+    assert sleep.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_retries_until_success_and_backs_off(mocker):
+    # The wrapper delegates backoff math to PerplexityFallbackManager.calculate_backoff_delay
+    # (src/finwiz/tools/perplexity_errors.py), which jitters via `random.random()` inside its
+    # own local `import random` -- not `random.uniform`. Patching the real `random.random` to
+    # 0.5 zeros the +/-25% jitter term (2 * 0.5 - 1 == 0), leaving pure base_delay * 2**attempt.
+    inner = mocker.patch(
+        "finwiz.infrastructure.resilience.perplexity_retry.perplexity_structured",
+        new=mocker.AsyncMock(side_effect=[None, None, _Payload(value="late")]),
+    )
+    sleep = mocker.patch("finwiz.infrastructure.resilience.perplexity_retry.asyncio.sleep", new=mocker.AsyncMock())
+    mocker.patch("random.random", return_value=0.5)
+
+    result = await perplexity_with_retry(prompt="p", schema=_Payload, system="s", base_delay=2.0)
+
+    assert result == _Payload(value="late")
+    assert inner.await_count == 3
+    assert [c.args[0] for c in sleep.await_args_list] == [2.0, 4.0]
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_max_attempts(mocker):
+    inner = mocker.patch(
+        "finwiz.infrastructure.resilience.perplexity_retry.perplexity_structured",
+        new=mocker.AsyncMock(return_value=None),
+    )
+    mocker.patch("finwiz.infrastructure.resilience.perplexity_retry.asyncio.sleep", new=mocker.AsyncMock())
+
+    result = await perplexity_with_retry(prompt="p", schema=_Payload, system="s", max_attempts=3)
+
+    assert result is None
+    assert inner.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_fails_fast_without_retrying(mocker, monkeypatch):
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    monkeypatch.delenv("PPLX_API_KEY", raising=False)
+    inner = mocker.patch(
+        "finwiz.infrastructure.resilience.perplexity_retry.perplexity_structured",
+        new=mocker.AsyncMock(return_value=None),
+    )
+
+    result = await perplexity_with_retry(prompt="p", schema=_Payload, system="s")
+
+    assert result is None
+    assert inner.await_count == 0
+
+
+def test_semaphore_is_a_process_singleton():
+    assert get_perplexity_semaphore() is get_perplexity_semaphore()
+    assert isinstance(get_perplexity_semaphore(), asyncio.Semaphore)

--- a/tests/unit/integration/opportunity_extractors/test_crypto_extractor.py
+++ b/tests/unit/integration/opportunity_extractors/test_crypto_extractor.py
@@ -220,14 +220,41 @@ class TestCryptoOpportunityExtractor:
         assert opportunities[0]["symbol"] == "BTC"
         assert opportunities[1]["symbol"] == "ETH"
 
-    def test_should_handle_missing_market_metrics_gracefully(self, extractor, valid_crypto_candidate):
-        """Test handling of missing market metrics.
+    def test_should_mark_missing_market_metric_unavailable_when_partial_data_present(self, extractor, valid_crypto_candidate):
+        """An entirely absent market metric must not be defaulted to 0 -- a 0
+        reads as a real (and gate-failing) measurement, not as "unknown".
 
-        An entirely absent market_cap_usd/volume_24h_usd must not be defaulted to
-        0 -- a 0 reads as a real (and gate-failing) measurement, not as "unknown".
-        This used to assert key_metrics["market_cap_usd"] == 0, which was itself
-        the fabricated-zero bug: it pinned exactly the behavior that made a
-        genuinely unmeasured metric indistinguishable from a measured-and-zero one.
+        Only volume_24h_usd is deleted here (market_cap_usd stays) so
+        composite_score can still be derived from real data and the opportunity
+        is still built -- isolating the key_metrics marker behavior from the
+        "refuse entirely" case covered separately below.
+        """
+        # Arrange
+        del valid_crypto_candidate["volume_24h_usd"]
+
+        # Act
+        opportunity = extractor._build_opportunity(valid_crypto_candidate, 0)
+
+        # Assert
+        assert opportunity is not None
+        assert opportunity["key_metrics"]["market_cap_usd"] == valid_crypto_candidate["market_cap_usd"]
+        assert opportunity["key_metrics"]["volume_24h_usd"] == {
+            "unavailable": True,
+            "field": "volume_24h_usd",
+            "reason": extractor._NO_DATA_REASON,
+        }
+
+    def test_should_refuse_when_no_composite_score_and_no_market_data_at_all(self, extractor, valid_crypto_candidate):
+        """No composite_score and no market data at all: refuse rather than
+        fabricate a composite_score from nothing.
+
+        valid_crypto_candidate never carries composite_score directly, so
+        deleting both market_cap_usd and volume_24h_usd removes every input the
+        fallback derivation needs. This used to return an opportunity with
+        composite_score computed from zeros -- a plausible-looking, fully
+        fabricated 0.0 -- with every affected key_metrics value marked
+        unavailable around it. Now the extractor refuses to build the
+        opportunity at all: there is nothing here to score, so it says so.
         """
         # Arrange
         del valid_crypto_candidate["market_cap_usd"]
@@ -237,18 +264,7 @@ class TestCryptoOpportunityExtractor:
         opportunity = extractor._build_opportunity(valid_crypto_candidate, 0)
 
         # Assert
-        assert opportunity is not None
-        assert opportunity["composite_score"] >= 0
-        assert opportunity["key_metrics"]["market_cap_usd"] == {
-            "unavailable": True,
-            "field": "market_cap_usd",
-            "reason": extractor._NO_DATA_REASON,
-        }
-        assert opportunity["key_metrics"]["volume_24h_usd"] == {
-            "unavailable": True,
-            "field": "volume_24h_usd",
-            "reason": extractor._NO_DATA_REASON,
-        }
+        assert opportunity is None
 
     def test_should_handle_missing_risk_assessment_gracefully(self, extractor, valid_crypto_candidate):
         """Test handling of missing risk assessment."""
@@ -292,16 +308,39 @@ class TestCryptoOpportunityExtractor:
         # Assert
         assert len(opportunities) == 0
 
-    def test_should_handle_extraction_errors_gracefully(self, extractor):
-        """Test handling of extraction errors."""
+    def test_should_refuse_when_composite_score_cannot_be_derived(self, extractor):
+        """A candidate with no composite_score and no market data must be
+        refused, not built with a fabricated composite_score computed from
+        zeros.
+
+        This used to return an opportunity with default values throughout,
+        including a composite_score silently computed from absent market data
+        (0.0 -- indistinguishable from a genuine "this asset scored zero").
+        Refusing is the honest outcome: there's nothing here to score.
+        """
         # Arrange
-        invalid_candidate = {"symbol": "TEST"}  # Missing required fields
+        invalid_candidate = {"symbol": "TEST"}  # No composite_score, no market data
 
         # Act
         opportunity = extractor._build_opportunity(invalid_candidate, 0)
 
         # Assert
-        # Should return opportunity with default values (Python doesn't raise on missing dict keys with .get())
+        assert opportunity is None
+
+    def test_should_handle_missing_optional_fields_gracefully(self, extractor):
+        """Test handling of extraction errors for fields other than composite_score's inputs.
+
+        As long as composite_score itself is derivable (supplied directly here),
+        every other missing field still defaults gracefully -- Python doesn't
+        raise on missing dict keys accessed via .get().
+        """
+        # Arrange
+        minimal_candidate = {"symbol": "TEST", "composite_score": 0.5}  # Missing everything else
+
+        # Act
+        opportunity = extractor._build_opportunity(minimal_candidate, 0)
+
+        # Assert
         assert opportunity is not None
         assert opportunity["symbol"] == "TEST"
-        assert opportunity["composite_score"] >= 0
+        assert opportunity["composite_score"] == approx(0.5)

--- a/tests/unit/integration/opportunity_extractors/test_crypto_extractor.py
+++ b/tests/unit/integration/opportunity_extractors/test_crypto_extractor.py
@@ -221,7 +221,14 @@ class TestCryptoOpportunityExtractor:
         assert opportunities[1]["symbol"] == "ETH"
 
     def test_should_handle_missing_market_metrics_gracefully(self, extractor, valid_crypto_candidate):
-        """Test handling of missing market metrics."""
+        """Test handling of missing market metrics.
+
+        An entirely absent market_cap_usd/volume_24h_usd must not be defaulted to
+        0 -- a 0 reads as a real (and gate-failing) measurement, not as "unknown".
+        This used to assert key_metrics["market_cap_usd"] == 0, which was itself
+        the fabricated-zero bug: it pinned exactly the behavior that made a
+        genuinely unmeasured metric indistinguishable from a measured-and-zero one.
+        """
         # Arrange
         del valid_crypto_candidate["market_cap_usd"]
         del valid_crypto_candidate["volume_24h_usd"]
@@ -232,7 +239,16 @@ class TestCryptoOpportunityExtractor:
         # Assert
         assert opportunity is not None
         assert opportunity["composite_score"] >= 0
-        assert opportunity["key_metrics"]["market_cap_usd"] == 0
+        assert opportunity["key_metrics"]["market_cap_usd"] == {
+            "unavailable": True,
+            "field": "market_cap_usd",
+            "reason": extractor._NO_DATA_REASON,
+        }
+        assert opportunity["key_metrics"]["volume_24h_usd"] == {
+            "unavailable": True,
+            "field": "volume_24h_usd",
+            "reason": extractor._NO_DATA_REASON,
+        }
 
     def test_should_handle_missing_risk_assessment_gracefully(self, extractor, valid_crypto_candidate):
         """Test handling of missing risk assessment."""

--- a/tests/unit/integration/opportunity_extractors/test_crypto_extractor.py
+++ b/tests/unit/integration/opportunity_extractors/test_crypto_extractor.py
@@ -98,6 +98,34 @@ class TestCryptoOpportunityExtractor:
         # Assert
         assert result is False
 
+    def test_should_include_crypto_keyed_by_ticker_instead_of_symbol(self, extractor, valid_crypto_candidate):
+        """NewcomerDiscoveryPipeline's writer emits "ticker", not "symbol" -- must still be included."""
+        # Arrange
+        del valid_crypto_candidate["symbol"]
+        valid_crypto_candidate["ticker"] = "BTC-USD"
+
+        # Act
+        result = extractor._should_include(valid_crypto_candidate)
+
+        # Assert
+        assert result is True
+
+    def test_should_include_crypto_with_no_market_cap_data_at_all(self, extractor, valid_crypto_candidate):
+        """NewcomerDiscoveryPipeline's candidates never carry market_cap_usd/market_cap.
+
+        Missing market-cap data must not be treated as a de-facto zero market
+        cap -- there is no signal to gate on, so the candidate should pass
+        through, not be silently dropped.
+        """
+        # Arrange
+        del valid_crypto_candidate["market_cap_usd"]
+
+        # Act
+        result = extractor._should_include(valid_crypto_candidate)
+
+        # Assert
+        assert result is True
+
     def test_should_exclude_crypto_without_name(self, extractor, valid_crypto_candidate):
         """Test that cryptos without name are excluded."""
         # Arrange

--- a/tests/unit/integration/opportunity_extractors/test_etf_extractor.py
+++ b/tests/unit/integration/opportunity_extractors/test_etf_extractor.py
@@ -280,3 +280,24 @@ class TestETFOpportunityExtractor:
         assert opportunity is not None
         assert opportunity["symbol"] == "TEST"
         assert opportunity["composite_score"] >= 0
+
+    def test_malformed_candidate_does_not_zero_its_siblings(self, extractor, valid_etf_candidate):
+        """A single candidate that raises inside extract() must not wipe the whole batch.
+
+        cost_metrics: None is a candidate whose field is present but the wrong
+        type: `"ter" in None` raises TypeError from inside _should_include, which
+        the extraction loop does not catch per-candidate -- before the fix, that
+        exception escaped a single try wrapped around the *entire* loop in
+        OpportunityExtractor.extract() (orchestrators/discovery/extractors/base.py),
+        discarding every opportunity already built for every well-formed sibling
+        candidate in the same batch, not just the malformed one.
+        """
+        # Arrange
+        malformed_candidate = {"symbol": "BAD", "name": "Malformed ETF", "grade": "A+", "cost_metrics": None}
+
+        # Act
+        opportunities = extractor.extract([valid_etf_candidate, malformed_candidate])
+
+        # Assert
+        assert len(opportunities) == 1, "the malformed candidate must be skipped, not fatal to its well-formed sibling"
+        assert opportunities[0]["symbol"] == "VWCE"

--- a/tests/unit/integration/opportunity_extractors/test_etf_extractor.py
+++ b/tests/unit/integration/opportunity_extractors/test_etf_extractor.py
@@ -267,19 +267,42 @@ class TestETFOpportunityExtractor:
         # Assert
         assert len(opportunities) == 0
 
-    def test_should_handle_extraction_errors_gracefully(self, extractor):
-        """Test handling of extraction errors."""
+    def test_should_refuse_rather_than_score_a_fabricated_perfect_ter(self, extractor):
+        """A candidate with no composite_score and no cost_metrics must be
+        refused, not built with a fabricated composite_score of 1.0.
+
+        This used to return an opportunity with composite_score computed from
+        an all-zero cost_metrics fallback: min((1-0)*0.4 + (1-0)*0.4 + 0.2, 1.0)
+        == 1.0 -- a perfect score, on the exact axis (TER) the ETF inclusion
+        gate exists to screen, synthesised entirely from data that was never
+        measured. Refusing is the honest outcome: there's nothing here to score.
+        """
         # Arrange
-        invalid_candidate = {"symbol": "TEST"}  # Missing required fields
+        invalid_candidate = {"symbol": "TEST"}  # No composite_score, no cost_metrics
 
         # Act
         opportunity = extractor._build_opportunity(invalid_candidate, 0)
 
         # Assert
-        # Should return opportunity with default values (Python doesn't raise on missing dict keys with .get())
+        assert opportunity is None
+
+    def test_should_handle_missing_optional_fields_gracefully(self, extractor):
+        """Test handling of extraction errors for fields other than composite_score's inputs.
+
+        As long as composite_score itself is derivable (supplied directly here),
+        every other missing field still defaults gracefully -- Python doesn't
+        raise on missing dict keys accessed via .get().
+        """
+        # Arrange
+        minimal_candidate = {"symbol": "TEST", "composite_score": 0.5}  # Missing everything else
+
+        # Act
+        opportunity = extractor._build_opportunity(minimal_candidate, 0)
+
+        # Assert
         assert opportunity is not None
         assert opportunity["symbol"] == "TEST"
-        assert opportunity["composite_score"] >= 0
+        assert opportunity["composite_score"] == approx(0.5)
 
     def test_malformed_candidate_does_not_zero_its_siblings(self, extractor, valid_etf_candidate):
         """A single candidate that raises inside extract() must not wipe the whole batch.

--- a/tests/unit/integration/opportunity_extractors/test_etf_extractor.py
+++ b/tests/unit/integration/opportunity_extractors/test_etf_extractor.py
@@ -96,6 +96,34 @@ class TestETFOpportunityExtractor:
         # Assert
         assert result is False
 
+    def test_should_include_etf_keyed_by_ticker_instead_of_symbol(self, extractor, valid_etf_candidate):
+        """NewcomerDiscoveryPipeline's writer emits "ticker", not "symbol" -- must still be included."""
+        # Arrange
+        del valid_etf_candidate["symbol"]
+        valid_etf_candidate["ticker"] = "VWCE"
+
+        # Act
+        result = extractor._should_include(valid_etf_candidate)
+
+        # Assert
+        assert result is True
+
+    def test_should_include_etf_with_no_cost_data_at_all(self, extractor, valid_etf_candidate):
+        """NewcomerDiscoveryPipeline's candidates never carry cost_metrics/key_metrics.
+
+        Missing TER data must not be treated as a de-facto high TER -- there is
+        no signal to gate on, so the candidate should pass through, not be
+        silently dropped.
+        """
+        # Arrange
+        del valid_etf_candidate["cost_metrics"]
+
+        # Act
+        result = extractor._should_include(valid_etf_candidate)
+
+        # Assert
+        assert result is True
+
     def test_should_exclude_etf_without_name(self, extractor, valid_etf_candidate):
         """Test that ETFs without name are excluded."""
         # Arrange

--- a/tests/unit/integration/opportunity_extractors/test_stock_extractor.py
+++ b/tests/unit/integration/opportunity_extractors/test_stock_extractor.py
@@ -4,6 +4,8 @@ Unit tests for StockOpportunityExtractor.
 Tests stock-specific extraction logic using the Template Method pattern.
 """
 
+import logging
+
 import pytest
 from pytest import approx
 
@@ -227,16 +229,73 @@ class TestStockOpportunityExtractor:
         # Assert
         assert len(opportunities) == 0
 
-    def test_should_handle_extraction_errors_gracefully(self, extractor):
-        """Test handling of extraction errors."""
+    def test_should_refuse_when_composite_score_cannot_be_derived(self, extractor):
+        """A candidate with no composite_score and no fundamentals must be
+        refused, not built with a fabricated composite_score computed from
+        zeros.
+
+        This used to return an opportunity with default values throughout,
+        including a composite_score silently computed from absent fundamentals
+        (0.2 -- a number that looks real but means nothing). Refusing is the
+        honest outcome: there's nothing here to score.
+        """
         # Arrange
-        invalid_candidate = {"symbol": "TEST"}  # Missing required fields
+        invalid_candidate = {"symbol": "TEST"}  # No composite_score, no fundamentals
 
         # Act
         opportunity = extractor._build_opportunity(invalid_candidate, 0)
 
         # Assert
-        # Should return opportunity with default values (Python doesn't raise on missing dict keys with .get())
+        assert opportunity is None
+
+    def test_should_handle_missing_optional_fields_gracefully(self, extractor):
+        """Test handling of extraction errors for fields other than composite_score's inputs.
+
+        As long as composite_score itself is derivable (supplied directly here),
+        every other missing field still defaults gracefully -- Python doesn't
+        raise on missing dict keys accessed via .get().
+        """
+        # Arrange
+        minimal_candidate = {"symbol": "TEST", "composite_score": 0.5}  # Missing everything else
+
+        # Act
+        opportunity = extractor._build_opportunity(minimal_candidate, 0)
+
+        # Assert
         assert opportunity is not None
         assert opportunity["symbol"] == "TEST"
-        assert opportunity["composite_score"] >= 0
+        assert opportunity["composite_score"] == approx(0.5)
+
+    def test_build_opportunity_failure_names_the_candidate_and_does_not_zero_siblings(self, extractor, valid_stock_candidate, caplog):
+        """A candidate that raises inside _build_opportunity (not _should_include)
+        must still be named in the log and skipped, not silently dropped -- and
+        a well-formed sibling in the same batch must still come through.
+
+        _build_opportunity used to have its own try/except that logged without
+        the candidate's symbol and returned None; base.py's `if opportunity:`
+        then skipped that None with no log at all -- the dominant failure path
+        (this method touches far more fields than _should_include) vanished
+        silently. Deleting that inner try/except lets extract()'s per-candidate
+        handler, which does log the identifier, catch this instead -- one
+        handler instead of four.
+        """
+        # Arrange: implementation is present but the wrong type, so
+        # candidate.get("implementation", {}).get("entry_strategy", "") raises
+        # AttributeError from inside _build_opportunity's return statement --
+        # not from _should_include, which never looks at "implementation".
+        malformed_candidate = {
+            "symbol": "BADIMPL",
+            "name": "Bad Impl",
+            "grade": "A+",
+            "composite_score": 0.5,
+            "implementation": "not-a-dict",
+        }
+
+        # Act
+        with caplog.at_level(logging.ERROR):
+            opportunities = extractor.extract([valid_stock_candidate, malformed_candidate])
+
+        # Assert
+        assert len(opportunities) == 1, "the malformed candidate must be skipped, not fatal to its well-formed sibling"
+        assert opportunities[0]["symbol"] == "NVDA"
+        assert any("BADIMPL" in record.message for record in caplog.records), "the malformed candidate must be named in the log"

--- a/tests/unit/integration/opportunity_extractors/test_stock_extractor.py
+++ b/tests/unit/integration/opportunity_extractors/test_stock_extractor.py
@@ -87,6 +87,31 @@ class TestStockOpportunityExtractor:
         # Assert
         assert result is False
 
+    def test_should_include_stock_keyed_by_ticker_instead_of_symbol(self, extractor, valid_stock_candidate):
+        """NewcomerDiscoveryPipeline's writer emits "ticker", not "symbol" -- must still be included."""
+        # Arrange
+        del valid_stock_candidate["symbol"]
+        valid_stock_candidate["ticker"] = "NVDA"
+
+        # Act
+        result = extractor._should_include(valid_stock_candidate)
+
+        # Assert
+        assert result is True
+
+    def test_should_build_opportunity_from_ticker_keyed_candidate(self, extractor, valid_stock_candidate):
+        """_build_opportunity must also fall back to "ticker" for the symbol field."""
+        # Arrange
+        del valid_stock_candidate["symbol"]
+        valid_stock_candidate["ticker"] = "NVDA"
+
+        # Act
+        opportunity = extractor._build_opportunity(valid_stock_candidate, 0)
+
+        # Assert
+        assert opportunity is not None
+        assert opportunity["symbol"] == "NVDA"
+
     def test_should_exclude_stock_without_name(self, extractor, valid_stock_candidate):
         """Test that stocks without name are excluded."""
         # Arrange

--- a/tests/unit/integration/test_data_parser.py
+++ b/tests/unit/integration/test_data_parser.py
@@ -1,0 +1,61 @@
+"""Unit tests for DataParser.load_and_parse_json's dict-shape handling."""
+
+import json
+
+from finwiz.orchestrators.extraction.parsers import DataParser
+
+
+class TestLoadAndParseJsonOpportunitiesKey:
+    """NewcomerDiscoveryPipeline's writer emits {"opportunities": [...]}, not
+    {"candidates": [...]} or {"a_plus_candidates": [...]}. The parser must
+    accept all three shapes.
+    """
+
+    def test_reads_candidates_from_opportunities_key(self, tmp_path):
+        # Arrange
+        payload = {"opportunities": [{"ticker": "NVDA", "grade": "A+"}], "analysis_summary": "found one"}
+        json_file = tmp_path / "a_plus_stocks.json"
+        json_file.write_text(json.dumps(payload))
+
+        # Act
+        candidates = DataParser().load_and_parse_json(json_file, "stock")
+
+        # Assert
+        assert candidates == [{"ticker": "NVDA", "grade": "A+"}]
+
+    def test_still_reads_candidates_from_candidates_key(self, tmp_path):
+        # Arrange
+        payload = {"candidates": [{"symbol": "NVDA", "grade": "A+"}]}
+        json_file = tmp_path / "a_plus_stocks.json"
+        json_file.write_text(json.dumps(payload))
+
+        # Act
+        candidates = DataParser().load_and_parse_json(json_file, "stock")
+
+        # Assert
+        assert candidates == [{"symbol": "NVDA", "grade": "A+"}]
+
+    def test_still_reads_candidates_from_a_plus_candidates_key(self, tmp_path):
+        # Arrange
+        payload = {"a_plus_candidates": [{"candidate": {"symbol": "NVDA"}, "composite_score": 0.9}]}
+        json_file = tmp_path / "a_plus_stocks.json"
+        json_file.write_text(json.dumps(payload))
+
+        # Act
+        candidates = DataParser().load_and_parse_json(json_file, "stock")
+
+        # Assert
+        # Nested "candidate" wrapper is unwrapped and merged with sibling fields.
+        assert candidates == [{"symbol": "NVDA", "composite_score": 0.9}]
+
+    def test_returns_empty_list_when_none_of_the_known_keys_are_present(self, tmp_path):
+        # Arrange
+        payload = {"unrelated_key": [{"symbol": "NVDA"}]}
+        json_file = tmp_path / "a_plus_stocks.json"
+        json_file.write_text(json.dumps(payload))
+
+        # Act
+        candidates = DataParser().load_and_parse_json(json_file, "stock")
+
+        # Assert
+        assert candidates == []

--- a/tests/unit/integration/test_discovery_writer_reader_contract.py
+++ b/tests/unit/integration/test_discovery_writer_reader_contract.py
@@ -156,3 +156,24 @@ class TestDiscoveryWriterReaderContract:
         crypto_metrics = collection.crypto_opportunities[0].key_metrics
         assert crypto_metrics["market_cap_usd"]["unavailable"] is True
         assert crypto_metrics["volume_24h_usd"]["unavailable"] is True
+
+    def test_confidence_and_risk_provenance_is_visible_for_real_writer_payload(self, discovery_output_dir):
+        """A grade-derived confidence/risk_score must not be indistinguishable
+        from a measured one, especially sitting beside a key_metrics block where
+        every entry is marked unavailable.
+
+        _to_legacy_format never emits confidence_level or risk_assessment for any
+        candidate, so every opportunity built from this payload shape falls back
+        to the grade-derived defaults in every extractor. Both fields keep their
+        float type (required -- they feed ranking and validation), so provenance
+        is surfaced as an appended rationale note instead of a schema change.
+        """
+        extractor = APlusDataExtractor(output_dir=discovery_output_dir)
+
+        collection = extractor.extract_aplus_opportunities()
+
+        assert collection is not None
+        for opportunities in (collection.stock_opportunities, collection.etf_opportunities, collection.crypto_opportunities):
+            rationale = " | ".join(opportunities[0].rationale)
+            assert "derived from grade" in rationale, f"confidence provenance missing from {rationale}"
+            assert "is a default, not measured" in rationale, f"risk_score provenance missing from {rationale}"

--- a/tests/unit/integration/test_discovery_writer_reader_contract.py
+++ b/tests/unit/integration/test_discovery_writer_reader_contract.py
@@ -1,0 +1,103 @@
+"""Regression test for the discovery writer/reader contract.
+
+``NewcomerDiscoveryPipeline._to_legacy_format`` (the writer -- the sole
+producer of ``output/discovery/a_plus_{stocks,etfs,crypto}.json``, see
+``scoring/stock_analyzer.py`` / ``etf_analyzer.py`` / ``crypto_analyzer.py``)
+and ``APlusDataExtractor.extract_aplus_opportunities`` (the reader) must agree
+on the shape of that JSON. If they drift, a successful discovery run that
+found real opportunities renders as a confident, silent zero -- exactly the
+class of bug this branch exists to eliminate elsewhere (market_context,
+backtesting_metrics).
+
+This test builds the writer's *exact* payload by calling the real
+``_to_legacy_format`` for all three asset classes (never a hand-written dict,
+which could itself drift from the writer), writes it to the files the reader
+actually consumes, and asserts a non-empty, correctly-populated collection
+comes back. That's the contract; without this test the two sides can drift
+apart again silently.
+"""
+
+import json
+import time
+
+import pytest
+
+from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
+from finwiz.schemas.newcomer_discovery import NewcomerCandidate, NewcomerDiscoveryResult
+from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
+
+_FILENAMES = {"stock": "a_plus_stocks.json", "etf": "a_plus_etfs.json", "crypto": "a_plus_crypto.json"}
+
+
+def _make_candidate(ticker: str, name: str, asset_class: str) -> NewcomerCandidate:
+    """Build an A+-grade candidate as the newcomer discovery pipeline would."""
+    return NewcomerCandidate(
+        ticker=ticker,
+        name=name,
+        asset_class=asset_class,
+        source="test",
+        composite_score=0.9,
+        grade="A+",
+        recommendation="BUY",
+        rationale="Strong fundamentals",
+    )
+
+
+@pytest.fixture
+def discovery_output_dir(tmp_path, mocker):
+    """Write the writer's real payload for each asset class to a temp output dir.
+
+    Mirrors exactly what DiscoveryOrchestrator._save_discovery_results does:
+    dump the dict _to_legacy_format returns straight to
+    output/discovery/a_plus_{asset_class}.json.
+    """
+    mocker.patch.object(NewcomerDiscoveryPipeline, "_load_portfolio_tickers")
+
+    output_dir = tmp_path / "output"
+    discovery_dir = output_dir / "discovery"
+    discovery_dir.mkdir(parents=True)
+
+    candidates_by_class = {
+        "stock": [_make_candidate("NVDA", "NVIDIA Corporation", "stock")],
+        "etf": [_make_candidate("VWCE", "Vanguard FTSE All-World UCITS ETF", "etf")],
+        "crypto": [_make_candidate("BTC-USD", "Bitcoin", "crypto")],
+    }
+
+    for asset_class, candidates in candidates_by_class.items():
+        pipeline = NewcomerDiscoveryPipeline(asset_class)
+        result = NewcomerDiscoveryResult(
+            asset_class=asset_class,
+            session_id="s1",
+            timestamp="2026-01-01T00:00:00",
+            candidates=candidates,
+            total_candidates=len(candidates),
+            summary="test discovery run",
+        )
+        payload = pipeline._to_legacy_format(result, time.time())
+        (discovery_dir / _FILENAMES[asset_class]).write_text(json.dumps(payload, default=str))
+
+    return output_dir
+
+
+class TestDiscoveryWriterReaderContract:
+    """A successful discovery run must not render as a confident zero."""
+
+    def test_real_writer_payload_survives_extraction_for_all_asset_classes(self, discovery_output_dir):
+        extractor = APlusDataExtractor(output_dir=discovery_output_dir)
+
+        collection = extractor.extract_aplus_opportunities()
+
+        assert collection is not None, "extraction returned None for a real, populated writer payload"
+
+        assert len(collection.stock_opportunities) == 1, "stock opportunity from the writer's payload was dropped"
+        assert collection.stock_opportunities[0].symbol == "NVDA"
+        assert collection.stock_opportunities[0].name == "NVIDIA Corporation"
+        assert collection.stock_opportunities[0].grade == "A+"
+
+        assert len(collection.etf_opportunities) == 1, "ETF opportunity from the writer's payload was dropped"
+        assert collection.etf_opportunities[0].symbol == "VWCE"
+
+        assert len(collection.crypto_opportunities) == 1, "crypto opportunity from the writer's payload was dropped"
+        assert collection.crypto_opportunities[0].symbol == "BTC"  # -USD suffix stripped by the extractor
+
+        assert collection.discovery_summary != "No A+ opportunities identified in current market conditions."

--- a/tests/unit/integration/test_discovery_writer_reader_contract.py
+++ b/tests/unit/integration/test_discovery_writer_reader_contract.py
@@ -101,3 +101,58 @@ class TestDiscoveryWriterReaderContract:
         assert collection.crypto_opportunities[0].symbol == "BTC"  # -USD suffix stripped by the extractor
 
         assert collection.discovery_summary != "No A+ opportunities identified in current market conditions."
+
+    def test_writer_rationale_and_recommendation_survive_into_the_collection(self, discovery_output_dir):
+        """The writer's flat rationale/recommendation must not be silently discarded.
+
+        _to_legacy_format emits candidate["rationale"] = "Strong fundamentals" and
+        candidate["recommendation"] = "BUY" (see _make_candidate above). Neither is
+        read by the moat/diversification/technology-derived structured rationale,
+        so before the fix both were dropped for every candidate this pipeline
+        produces -- confirmed by direct inspection before the fix: the extracted
+        opportunity's rationale was `[]` for stock and crypto candidates built from
+        this exact payload shape.
+        """
+        extractor = APlusDataExtractor(output_dir=discovery_output_dir)
+
+        collection = extractor.extract_aplus_opportunities()
+
+        assert collection is not None
+        for opportunities in (collection.stock_opportunities, collection.etf_opportunities, collection.crypto_opportunities):
+            assert len(opportunities) == 1
+            rationale = opportunities[0].rationale
+            assert "Strong fundamentals" in rationale, f"writer's rationale text missing from {rationale}"
+            assert "Recommendation: BUY" in rationale, f"writer's recommendation missing from {rationale}"
+
+    def test_unmeasured_key_metrics_are_marked_unavailable_not_zero(self, discovery_output_dir):
+        """A metric this pipeline never measures must not be reported as a real zero.
+
+        _to_legacy_format never emits fundamentals/cost_metrics/market_cap_usd/
+        technology for any candidate, so before the fix every one of these came
+        back as a fabricated 0 / 0.0 / "" / "$0" -- indistinguishable from a real
+        measurement (and, for ETF's ter/aum, reading as an excellent one on the
+        exact axis the TER gate exists to screen).
+        """
+        extractor = APlusDataExtractor(output_dir=discovery_output_dir)
+
+        collection = extractor.extract_aplus_opportunities()
+
+        assert collection is not None
+
+        stock_metrics = collection.stock_opportunities[0].key_metrics
+        assert stock_metrics["roe_3y_avg"] == {"unavailable": True, "field": "roe_3y_avg", "reason": stock_metrics["roe_3y_avg"]["reason"]}, (
+            "roe_3y_avg must be a named-unavailable marker, not a bare 0"
+        )
+        assert stock_metrics["roe_3y_avg"]["unavailable"] is True
+        assert stock_metrics["revenue_cagr_5y"]["unavailable"] is True
+        assert stock_metrics["debt_to_equity"]["unavailable"] is True
+        assert stock_metrics["market_cap_usd"]["unavailable"] is True, "0 for market_cap_usd reads as a real, tiny company, not 'unknown'"
+
+        etf_metrics = collection.etf_opportunities[0].key_metrics
+        assert etf_metrics["ter"]["unavailable"] is True, "an unmeasured TER must not read as a real 0.0 (which passes the gate)"
+        assert etf_metrics["aum_usd"]["unavailable"] is True
+        assert etf_metrics["aum_formatted"]["unavailable"] is True, 'an unmeasured AUM must not render as "$0"'
+
+        crypto_metrics = collection.crypto_opportunities[0].key_metrics
+        assert crypto_metrics["market_cap_usd"]["unavailable"] is True
+        assert crypto_metrics["volume_24h_usd"]["unavailable"] is True

--- a/tests/unit/orchestrators/test_deep_analysis_data_collector.py
+++ b/tests/unit/orchestrators/test_deep_analysis_data_collector.py
@@ -178,3 +178,68 @@ class TestBenchmarkBetaFallback:
         combined = pd.concat({"AAPL": ticker_df, "^GSPC": bench_df}, axis=1)
         mocker.patch("yfinance.download", return_value=combined)
         assert collector._compute_benchmark_beta("AAPL", "stock") is None
+
+
+class TestFlattenExcludesPercentScaledDuplicates:
+    """Task 15 review round 2 (Ruling 30).
+
+    When performance analysis fails and the backtest succeeds,
+    backtest_result.max_drawdown (percent-scaled, e.g. -3.0 for a -3%
+    drawdown -- backtesting_performance.py:246) and
+    quantitative_recommendation.risk_metrics (which mirrors backtest_result,
+    see Task 15 round 1) used to leak into the flat dict through
+    _flatten_recursive's generic "first key wins" walk, since nothing set
+    "max_drawdown" from the sanctioned, fractional-scale
+    performance_metrics extraction first. risk_scorer.py compares
+    max_drawdown against fractional thresholds (0.10/0.20/0.35/0.50), so
+    the percent-scaled leak silently scored a -3% drawdown as if it were
+    -300% -- the worst possible bucket for what is actually a very safe
+    holding.
+    """
+
+    @pytest.fixture
+    def collector(self, mocker):
+        return DeepAnalysisDataCollector(state=mocker.MagicMock())
+
+    @pytest.fixture
+    def thin_history_payload(self):
+        """performance_metrics is None (that sub-analysis failed);
+        backtest_result and quantitative_recommendation.risk_metrics both
+        carry the same percent-scaled max_drawdown, mirroring what
+        perform_comprehensive_analysis actually produces after Task 15
+        round 1 (risk_metrics is sourced from backtest_result only)."""
+        return {
+            "ticker": "TEST",
+            "asset_class": "stock",
+            "ticker_info": {"beta": 1.0},  # short-circuits the network-hitting beta fallback
+            "quantitative_analysis": {
+                "backtest_result": {
+                    "symbol": "TEST",
+                    "strategy_name": "SimpleMovingAverageStrategy",
+                    "max_drawdown": -3.0,
+                    "volatility": 10.0,
+                    "sharpe_ratio": 0.5,
+                },
+                "performance_metrics": None,
+                "quantitative_recommendation": {
+                    "risk_metrics": {"max_drawdown": -3.0, "volatility": 10.0, "sharpe_ratio": 0.5},
+                },
+            },
+        }
+
+    def test_percent_scaled_max_drawdown_does_not_reach_the_flat_dict(self, collector, thin_history_payload):
+        flattened = collector.flatten_collected_data(thin_history_payload)
+        assert "max_drawdown" not in flattened, f"percent-scaled max_drawdown leaked into the flat dict: {flattened.get('max_drawdown')}"
+
+    def test_risk_scorer_does_not_score_a_safe_drawdown_as_catastrophic(self, collector, thin_history_payload):
+        """Drives the real RiskScorer on the real flattened output -- pins
+        the actual downstream consequence, not just the intermediate dict."""
+        from finwiz.scoring.risk_scorer import RiskScorer
+
+        flattened = collector.flatten_collected_data(thin_history_payload)
+        _score, details = RiskScorer().calculate_risk_score(flattened)
+
+        # Absent max_drawdown falls back to RiskScorer's own -0.20 default
+        # (fractional, lands in the drawdown_low bucket) -- not the worst
+        # bucket (0.2) a misread "-300%" would produce.
+        assert details["drawdown_score"] == 0.8, f"drawdown scored as catastrophic -- the percent-scaled leak reproduced: {details}"

--- a/tests/unit/orchestrators/test_discovery_orchestrator.py
+++ b/tests/unit/orchestrators/test_discovery_orchestrator.py
@@ -101,6 +101,53 @@ class TestDiscoveryOrchestrator:
         assert orchestrator.state.crypto_analysis_error == "Crypto analysis failed"
         orchestrator.availability_tracker.track_data_source.assert_called_once()
 
+    def test_should_report_crypto_pipeline_failure_honestly(self, orchestrator, mocker):
+        """A pipeline failure disguised as an empty result must not read as success.
+
+        analyze_crypto_opportunities() no longer raises on pipeline failure - it
+        returns an honestly-labelled empty dict (method == "newcomer_discovery_failed").
+        The orchestrator must not render this as a success tick / available source /
+        analysis_success=True.
+        """
+        mock_analyze = mocker.patch("finwiz.scoring.crypto_analyzer.analyze_crypto_opportunities")
+        mock_analyze.return_value = {
+            "analysis_summary": "Crypto discovery unavailable this run: universe fetch exploded",
+            "opportunities": [],
+            "performance_metrics": {
+                "opportunities_found": 0,
+                "method": "newcomer_discovery_failed",
+                "error": "universe fetch exploded",
+            },
+        }
+
+        result = orchestrator.check_crypto()
+
+        assert result["crypto_analysis_complete"] is True
+        assert orchestrator.state.crypto_analysis_success is False
+        assert orchestrator.state.crypto_analysis_error == "universe fetch exploded"
+        kwargs = orchestrator.availability_tracker.track_data_source.call_args.kwargs
+        assert kwargs["status"] == "unavailable"
+
+    def test_should_report_crypto_pipeline_zero_result_as_success(self, orchestrator, mocker):
+        """A genuine zero-candidate run must still be reported as a successful run."""
+        mock_analyze = mocker.patch("finwiz.scoring.crypto_analyzer.analyze_crypto_opportunities")
+        mock_analyze.return_value = {
+            "analysis_summary": "Discovered 0 crypto newcomer candidates",
+            "opportunities": [],
+            "performance_metrics": {
+                "opportunities_found": 0,
+                "method": "newcomer_discovery_pipeline",
+            },
+        }
+
+        result = orchestrator.check_crypto()
+
+        assert result["crypto_analysis_complete"] is True
+        assert orchestrator.state.crypto_analysis_success is True
+        assert orchestrator.state.crypto_analysis_error is None
+        kwargs = orchestrator.availability_tracker.track_data_source.call_args.kwargs
+        assert kwargs["status"] == "available"
+
     def test_should_execute_stock_discovery_successfully(self, orchestrator, mocker):
         """Test successful stock discovery execution."""
         # Arrange
@@ -139,6 +186,47 @@ class TestDiscoveryOrchestrator:
         assert orchestrator.state.stock_analysis_error == "Stock analysis failed"
         orchestrator.availability_tracker.track_data_source.assert_called_once()
 
+    def test_should_report_stock_pipeline_failure_honestly(self, orchestrator, mocker):
+        """A pipeline failure disguised as an empty result must not read as success."""
+        mock_analyze = mocker.patch("finwiz.scoring.stock_analyzer.analyze_stock_opportunities")
+        mock_analyze.return_value = {
+            "analysis_summary": "Stock discovery unavailable this run: universe fetch exploded",
+            "opportunities": [],
+            "performance_metrics": {
+                "opportunities_found": 0,
+                "method": "newcomer_discovery_failed",
+                "error": "universe fetch exploded",
+            },
+        }
+
+        result = orchestrator.check_stock()
+
+        assert result["stock_analysis_complete"] is True
+        assert orchestrator.state.stock_analysis_success is False
+        assert orchestrator.state.stock_analysis_error == "universe fetch exploded"
+        kwargs = orchestrator.availability_tracker.track_data_source.call_args.kwargs
+        assert kwargs["status"] == "unavailable"
+
+    def test_should_report_stock_pipeline_zero_result_as_success(self, orchestrator, mocker):
+        """A genuine zero-candidate run must still be reported as a successful run."""
+        mock_analyze = mocker.patch("finwiz.scoring.stock_analyzer.analyze_stock_opportunities")
+        mock_analyze.return_value = {
+            "analysis_summary": "Discovered 0 stock newcomer candidates",
+            "opportunities": [],
+            "performance_metrics": {
+                "opportunities_found": 0,
+                "method": "newcomer_discovery_pipeline",
+            },
+        }
+
+        result = orchestrator.check_stock()
+
+        assert result["stock_analysis_complete"] is True
+        assert orchestrator.state.stock_analysis_success is True
+        assert orchestrator.state.stock_analysis_error is None
+        kwargs = orchestrator.availability_tracker.track_data_source.call_args.kwargs
+        assert kwargs["status"] == "available"
+
     def test_should_execute_etf_discovery_successfully(self, orchestrator, mocker):
         """Test successful ETF discovery execution."""
         # Arrange
@@ -176,6 +264,47 @@ class TestDiscoveryOrchestrator:
         assert orchestrator.state.etf_analysis_success is False
         assert orchestrator.state.etf_analysis_error == "ETF analysis failed"
         orchestrator.availability_tracker.track_data_source.assert_called_once()
+
+    def test_should_report_etf_pipeline_failure_honestly(self, orchestrator, mocker):
+        """A pipeline failure disguised as an empty result must not read as success."""
+        mock_analyze = mocker.patch("finwiz.scoring.etf_analyzer.analyze_etf_opportunities")
+        mock_analyze.return_value = {
+            "analysis_summary": "ETF discovery unavailable this run: universe fetch exploded",
+            "opportunities": [],
+            "performance_metrics": {
+                "opportunities_found": 0,
+                "method": "newcomer_discovery_failed",
+                "error": "universe fetch exploded",
+            },
+        }
+
+        result = orchestrator.check_etf()
+
+        assert result["etf_analysis_complete"] is True
+        assert orchestrator.state.etf_analysis_success is False
+        assert orchestrator.state.etf_analysis_error == "universe fetch exploded"
+        kwargs = orchestrator.availability_tracker.track_data_source.call_args.kwargs
+        assert kwargs["status"] == "unavailable"
+
+    def test_should_report_etf_pipeline_zero_result_as_success(self, orchestrator, mocker):
+        """A genuine zero-candidate run must still be reported as a successful run."""
+        mock_analyze = mocker.patch("finwiz.scoring.etf_analyzer.analyze_etf_opportunities")
+        mock_analyze.return_value = {
+            "analysis_summary": "Discovered 0 etf newcomer candidates",
+            "opportunities": [],
+            "performance_metrics": {
+                "opportunities_found": 0,
+                "method": "newcomer_discovery_pipeline",
+            },
+        }
+
+        result = orchestrator.check_etf()
+
+        assert result["etf_analysis_complete"] is True
+        assert orchestrator.state.etf_analysis_success is True
+        assert orchestrator.state.etf_analysis_error is None
+        kwargs = orchestrator.availability_tracker.track_data_source.call_args.kwargs
+        assert kwargs["status"] == "available"
 
     def test_should_consolidate_discovery_results_successfully(self, orchestrator):
         """Test successful discovery result consolidation."""

--- a/tests/unit/orchestrators/test_extraction_engine.py
+++ b/tests/unit/orchestrators/test_extraction_engine.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for ExtractionEngine's market_context / backtesting_metrics markers.
+
+market_context and validation_results were written against the raw CrewAI
+discovery-crew kickoff shape; the pipeline actually wired into
+DiscoveryOrchestrator today (NewcomerDiscoveryPipeline) never emits either
+field into consolidated_discovery.json. Task-11 Ruling 23 (11c) requires these
+two extractors to report an explicit, named "unavailable" marker rather than a
+silent empty result that reads the same as "we looked and there was nothing".
+"""
+
+import json
+
+from finwiz.orchestrators.extraction.engine import ExtractionEngine
+
+
+class TestMarketContextUnavailable:
+    """market_context has no producer in the current discovery pipeline."""
+
+    def test_returns_named_unavailable_marker(self, tmp_path):
+        """The marker must be distinguishable from a genuine empty result ({} or None)."""
+        engine = ExtractionEngine(output_dir=tmp_path)
+
+        result = engine._extract_market_context()
+
+        assert result is not None
+        assert result != {}
+        assert result["unavailable"] is True
+        assert result["field"] == "market_context"
+        assert result.get("reason")
+
+    def test_marker_returned_even_when_discovery_output_exists(self, tmp_path):
+        """No producer exists for this field regardless of whether discovery ran."""
+        discovery_dir = tmp_path / "discovery"
+        discovery_dir.mkdir()
+        with open(discovery_dir / "consolidated_discovery.json", "w") as f:
+            json.dump({"opportunities": [{"ticker": "AAPL", "grade": "A+", "asset_class": "stock"}]}, f)
+
+        engine = ExtractionEngine(output_dir=tmp_path)
+
+        result = engine._extract_market_context()
+
+        assert result == {
+            "unavailable": True,
+            "field": "market_context",
+            "reason": ExtractionEngine._NO_PRODUCER_REASON,
+        }
+
+
+class TestBacktestingMetricsUnavailable:
+    """backtesting_metrics (validation_results) has no producer in the current discovery pipeline."""
+
+    def test_returns_named_unavailable_marker(self, tmp_path):
+        """The marker must be distinguishable from a genuine empty result ({} or None)."""
+        engine = ExtractionEngine(output_dir=tmp_path)
+
+        result = engine._extract_backtesting_metrics()
+
+        assert result is not None
+        assert result != {}
+        assert result["unavailable"] is True
+        assert result["field"] == "backtesting_metrics"
+        assert result.get("reason")
+
+    def test_backtesting_marker_distinguishable_from_market_context_marker(self, tmp_path):
+        """Both extractors share a reason string but must carry different 'field' values."""
+        engine = ExtractionEngine(output_dir=tmp_path)
+
+        market_context = engine._extract_market_context()
+        backtesting_metrics = engine._extract_backtesting_metrics()
+
+        assert market_context["field"] != backtesting_metrics["field"]

--- a/tests/unit/quantitative/test_backtesting.py
+++ b/tests/unit/quantitative/test_backtesting.py
@@ -550,6 +550,73 @@ class TestBacktestingEngine:
         with pytest.raises(Exception, match="Network error"):
             engine.run_strategy_backtest(SimpleMovingAverageStrategy, symbol, start_date, end_date)
 
+    def test_should_return_none_for_series_shorter_than_strategy_lookback(self, mocker):
+        """A series shorter than the strategy's lookback window (+ warm-up
+        buffer) is a legitimate refusal, not an error: backtrader would
+        never reach minperiod for the strategy's indicators, so trying to
+        run it produces no usable result. The old behavior (raising
+        ValueError here) propagated up through the comprehensive analyzer's
+        shared try/except and discarded technical and performance analysis
+        that had already succeeded independently -- this is the actual
+        mechanism behind "drops the holding's entire quantitative payload"."""
+        # Arrange
+        config = BacktestConfig(initial_capital=100000.0)
+        mock_data_manager = mocker.patch("finwiz.quantitative.backtesting.HistoricalDataManager")
+        engine = BacktestingEngine(config)
+
+        dates = pd.date_range(start="2023-01-01", periods=30, freq="D")
+        short_data = pd.DataFrame(
+            {
+                "Open": [100.0] * 30,
+                "High": [101.0] * 30,
+                "Low": [99.0] * 30,
+                "Close": [100.0] * 30,
+                "Volume": [1000] * 30,
+            },
+            index=dates,
+        )
+        mock_data_manager_instance = mocker.MagicMock()
+        mock_data_manager_instance.fetch_historical_data.return_value = short_data
+        mock_data_manager.return_value = mock_data_manager_instance
+        engine.data_manager = mock_data_manager_instance
+
+        symbol = fake.pystr(min_chars=3, max_chars=5).upper()
+        start_date = datetime(2023, 1, 1)
+        end_date = datetime(2023, 1, 30)
+
+        # Act
+        result = engine.run_strategy_backtest(
+            SimpleMovingAverageStrategy,
+            symbol,
+            start_date,
+            end_date,
+            strategy_params={"short_period": 20, "long_period": 50},
+        )
+
+        # Assert -- refusal, not a crash and not a fabricated result
+        assert result is None
+
+    def test_should_still_raise_for_empty_or_unfetchable_data(self, mocker):
+        """Only the "fetched-but-too-short" case degrades to None. Data that
+        could not be fetched at all (empty frame, provider error) is a
+        different failure class and still raises -- that distinction is
+        preserved from the pre-existing tests above."""
+        config = BacktestConfig(initial_capital=100000.0)
+        mock_data_manager = mocker.patch("finwiz.quantitative.backtesting.HistoricalDataManager")
+        engine = BacktestingEngine(config)
+
+        mock_data_manager_instance = mocker.MagicMock()
+        mock_data_manager_instance.fetch_historical_data.return_value = pd.DataFrame()
+        mock_data_manager.return_value = mock_data_manager_instance
+        engine.data_manager = mock_data_manager_instance
+
+        symbol = fake.pystr(min_chars=3, max_chars=5).upper()
+        start_date = datetime(2023, 1, 1)
+        end_date = datetime(2023, 3, 31)
+
+        with pytest.raises(ValueError, match="No data available"):
+            engine.run_strategy_backtest(SimpleMovingAverageStrategy, symbol, start_date, end_date)
+
     def test_should_create_backtrader_datafeed_correctly(self, backtesting_engine, sample_ohlcv_data):
         """Test creation of Backtrader data feed."""
         # Arrange
@@ -663,6 +730,40 @@ class TestBacktestingEngine:
         assert all(isinstance(result, BacktestResult) for result in results)
         assert results[0].strategy_name == "SimpleMovingAverageStrategy"
         assert results[1].strategy_name == "SimpleMovingAverageStrategy"
+
+    def test_should_skip_none_results_in_multi_strategy_backtest(self, mocker):
+        """A strategy config whose lookback window doesn't fit the fetched
+        series returns None from run_strategy_backtest and must be skipped,
+        not appended -- the same way an outright exception is already
+        skipped, so callers never see a None mixed into the results list."""
+        config = BacktestConfig(initial_capital=100000.0)
+        mock_data_manager = mocker.patch("finwiz.quantitative.backtesting.HistoricalDataManager")
+        engine = BacktestingEngine(config)
+
+        dates = pd.date_range(start="2023-01-01", periods=30, freq="D")
+        short_data = pd.DataFrame(
+            {
+                "Open": [100.0] * 30,
+                "High": [101.0] * 30,
+                "Low": [99.0] * 30,
+                "Close": [100.0] * 30,
+                "Volume": [1000] * 30,
+            },
+            index=dates,
+        )
+        mock_data_manager_instance = mocker.MagicMock()
+        mock_data_manager_instance.fetch_historical_data.return_value = short_data
+        mock_data_manager.return_value = mock_data_manager_instance
+        engine.data_manager = mock_data_manager_instance
+
+        strategies = [(SimpleMovingAverageStrategy, {"short_period": 20, "long_period": 50})]
+        symbol = fake.pystr(min_chars=3, max_chars=5).upper()
+        start_date = datetime(2023, 1, 1)
+        end_date = datetime(2023, 1, 30)
+
+        results = engine.run_multi_strategy_backtest(strategies, symbol, start_date, end_date)
+
+        assert results == []
 
     def test_should_handle_plot_results_without_backtest(self, backtesting_engine):
         """Test plotting results when no backtest has been run."""

--- a/tests/unit/quantitative/test_data_processors.py
+++ b/tests/unit/quantitative/test_data_processors.py
@@ -1,0 +1,124 @@
+"""Tests for finwiz.quantitative.data_processors.DataProcessor.save_cache_metadata.
+
+Covers the cache-metadata write path: it must survive a caller mutating the
+metadata dict from another thread, must not choke on non-JSON-native values
+(e.g. ``datetime``), and must never let a write failure escape and abort a
+production run -- while still being loud about failures that are not simple
+I/O hiccups.
+"""
+
+import json
+import logging
+import threading
+from datetime import datetime
+
+from finwiz.quantitative.config import QuantConfig
+from finwiz.quantitative.data_processors import DataProcessor
+
+LOGGER_NAME = "finwiz.quantitative.data_processors.DataProcessor"
+
+
+class _UnstringifiableValue:
+    """A value that even ``default=str`` cannot serialize."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("cannot stringify this value")
+
+
+def test_save_cache_metadata_writes_valid_json(tmp_path):
+    """Happy path: a plain metadata dict round-trips through the file."""
+    processor = DataProcessor(QuantConfig())
+    target = tmp_path / "cache_metadata.json"
+
+    processor.save_cache_metadata({"symbol": "AAPL", "row_count": 10}, target)
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"symbol": "AAPL", "row_count": 10}
+
+
+def test_save_cache_metadata_serializes_datetime_via_default_str(tmp_path):
+    """Reproduces the original bug: a datetime value used to raise TypeError,
+    which the bare `except Exception` swallowed into a log line, leaving no
+    file on disk at all.
+    """
+    processor = DataProcessor(QuantConfig())
+    target = tmp_path / "cache_metadata.json"
+
+    processor.save_cache_metadata({"fetched_at": datetime(2026, 8, 15, 12, 30)}, target)
+
+    saved = json.loads(target.read_text(encoding="utf-8"))
+    assert saved["fetched_at"] == "2026-08-15 12:30:00"
+
+
+def test_save_cache_metadata_survives_concurrent_mutation(tmp_path):
+    """The caller owns the dict and may mutate it from another thread while
+    save_cache_metadata is serializing it; the write must not fail.
+
+    The churn thread adds and evicts keys in a rolling window rather than
+    growing the dict unboundedly. An unbounded churner races json.dump's
+    per-write GIL yield points: the dict balloons between dump calls, each
+    call takes longer, which gives the churner even more time to grow it
+    further -- a runaway that made an earlier version of this test run for
+    minutes. A bounded window still exercises the exact defect (dict size
+    changing mid-iteration) without that blowup.
+    """
+    processor = DataProcessor(QuantConfig())
+    metadata = {f"seed{i}": i for i in range(500)}
+    target = tmp_path / "cache_metadata.json"
+    stop = threading.Event()
+    errors: list[BaseException] = []
+    window = 200
+
+    def churn():
+        i = 0
+        while not stop.is_set():
+            metadata[f"k{i}"] = i
+            if i >= window:
+                metadata.pop(f"k{i - window}", None)
+            i += 1
+
+    writer = threading.Thread(target=churn, daemon=True)
+    writer.start()
+    try:
+        for _ in range(50):
+            try:
+                processor.save_cache_metadata(metadata, target)
+            except BaseException as exc:  # the test is the assertion
+                errors.append(exc)
+    finally:
+        stop.set()
+        writer.join(timeout=2.0)
+
+    assert errors == []
+    assert json.loads(target.read_text(encoding="utf-8"))
+
+
+def test_save_cache_metadata_os_error_is_swallowed_and_logged(tmp_path, caplog):
+    """A filesystem failure (e.g. the parent directory does not exist) is a
+    best-effort cache miss, not a reason to crash the caller.
+    """
+    processor = DataProcessor(QuantConfig())
+    target = tmp_path / "missing_dir" / "cache_metadata.json"
+
+    caplog.set_level(logging.ERROR, logger=LOGGER_NAME)
+    processor.save_cache_metadata({"symbol": "AAPL"}, target)  # must not raise
+
+    assert not target.exists()
+    assert any("Error saving cache metadata" in r.message for r in caplog.records)
+
+
+def test_save_cache_metadata_unserializable_value_is_swallowed_but_logged_loudly(tmp_path, caplog):
+    """A value that survives ``default=str`` being present but still can't be
+    turned into a string is a programming error, not an I/O hiccup. It must
+    still never propagate out of save_cache_metadata, but it must be logged
+    with enough detail (a traceback) to actually be noticed -- unlike the
+    original one-line swallow.
+    """
+    processor = DataProcessor(QuantConfig())
+    target = tmp_path / "cache_metadata.json"
+
+    caplog.set_level(logging.ERROR, logger=LOGGER_NAME)
+    processor.save_cache_metadata({"bad": _UnstringifiableValue()}, target)  # must not raise
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.exc_info is not None

--- a/tests/unit/quantitative/test_data_processors.py
+++ b/tests/unit/quantitative/test_data_processors.py
@@ -9,7 +9,6 @@ I/O hiccups.
 
 import json
 import logging
-import threading
 from datetime import datetime
 
 from finwiz.quantitative.config import QuantConfig
@@ -49,47 +48,47 @@ def test_save_cache_metadata_serializes_datetime_via_default_str(tmp_path):
     assert saved["fetched_at"] == "2026-08-15 12:30:00"
 
 
-def test_save_cache_metadata_survives_concurrent_mutation(tmp_path):
-    """The caller owns the dict and may mutate it from another thread while
-    save_cache_metadata is serializing it; the write must not fail.
+def test_save_cache_metadata_snapshot_is_unaffected_by_concurrent_mutation(tmp_path, mocker):
+    """Deterministic proof that save_cache_metadata serializes an isolated
+    snapshot, not the caller's live dict.
 
-    The churn thread adds and evicts keys in a rolling window rather than
-    growing the dict unboundedly. An unbounded churner races json.dump's
-    per-write GIL yield points: the dict balloons between dump calls, each
-    call takes longer, which gives the churner even more time to grow it
-    further -- a runaway that made an earlier version of this test run for
-    minutes. A bounded window still exercises the exact defect (dict size
-    changing mid-iteration) without that blowup.
+    A threaded version of this test (real OS thread mutating `metadata`
+    while save_cache_metadata ran) proved the mechanism but only failed on
+    the exact scheduling that happened to trigger the race, and an earlier,
+    unbounded-growth version of that thread caused a runaway feedback loop
+    with json.dump's per-write GIL yield points (minutes of CPU before it
+    was killed). Neither is acceptable as a regression guard: a race that
+    only sometimes fires gives false confidence, and a revert of the fix
+    could sail through CI green.
+
+    Instead, force the mutation to land at a controlled point: patch
+    json.dump itself so that, at the exact moment save_cache_metadata hands
+    off to it, the *caller's* dict gets a key added and a key removed --
+    simulating a concurrent writer's mutation landing right then. Against
+    the fix, that mutation cannot reach the snapshot (a different object,
+    already copied before this point), so the write is untouched and
+    matches the pre-mutation content. Against a reverted fix (dumping
+    `cache_metadata` directly, no snapshot), the mutated object *is* the one
+    being serialized, so the write reflects the mutation and this assertion
+    fails -- verified by temporarily reverting the snapshot line (see
+    task-14-report.md for that evidence).
     """
     processor = DataProcessor(QuantConfig())
-    metadata = {f"seed{i}": i for i in range(500)}
+    cache_metadata = {f"seed{i}": i for i in range(20)}
+    expected_snapshot = dict(cache_metadata)
     target = tmp_path / "cache_metadata.json"
-    stop = threading.Event()
-    errors: list[BaseException] = []
-    window = 200
+    real_dump = json.dump
 
-    def churn():
-        i = 0
-        while not stop.is_set():
-            metadata[f"k{i}"] = i
-            if i >= window:
-                metadata.pop(f"k{i - window}", None)
-            i += 1
+    def mutate_then_dump(obj, fp, **kwargs):
+        cache_metadata["added_concurrently"] = -1
+        del cache_metadata["seed0"]
+        return real_dump(obj, fp, **kwargs)
 
-    writer = threading.Thread(target=churn, daemon=True)
-    writer.start()
-    try:
-        for _ in range(50):
-            try:
-                processor.save_cache_metadata(metadata, target)
-            except BaseException as exc:  # the test is the assertion
-                errors.append(exc)
-    finally:
-        stop.set()
-        writer.join(timeout=2.0)
+    mocker.patch("finwiz.quantitative.data_processors.json.dump", side_effect=mutate_then_dump)
 
-    assert errors == []
-    assert json.loads(target.read_text(encoding="utf-8"))
+    processor.save_cache_metadata(cache_metadata, target)  # must not raise
+
+    assert json.loads(target.read_text(encoding="utf-8")) == expected_snapshot
 
 
 def test_save_cache_metadata_os_error_is_swallowed_and_logged(tmp_path, caplog):

--- a/tests/unit/schemas/test_fact_pack.py
+++ b/tests/unit/schemas/test_fact_pack.py
@@ -35,16 +35,28 @@ class TestFreshnessDerivation:
             (7, "stale"),
             (10, "stale"),
             (14, "stale"),
+            (30, "stale"),
+            (89.9, "stale"),
         ],
     )
     def test_derive_freshness_table(self, days_old: float, expected: str) -> None:
         fetched = datetime.now(UTC) - timedelta(days=days_old)
         assert FactPack.derive_freshness(fetched) == expected
 
-    def test_derive_freshness_raises_on_too_old(self) -> None:
-        old = datetime.now(UTC) - timedelta(days=15)
-        with pytest.raises(ValueError, match="older than 14 days"):
-            FactPack.derive_freshness(old)
+    def test_month_old_pack_is_stale_not_an_error(self) -> None:
+        """Regression guard: a 16d+ cache entry used to raise ValueError, which
+        FactPackCache.get() caught and returned None — indistinguishable from no
+        cache at all. A rate-limited run then had nothing to fall back on and the
+        holding died outright, instead of degrading to a labelled stale answer.
+        Corporate structure and leadership do not turn over in a fortnight.
+        """
+        month_old = datetime.now(UTC) - timedelta(days=30)
+        assert FactPack.derive_freshness(month_old) == "stale"
+
+    def test_derive_freshness_raises_beyond_new_horizon(self) -> None:
+        ancient = datetime.now(UTC) - timedelta(days=91)
+        with pytest.raises(ValueError, match="older than 90 days"):
+            FactPack.derive_freshness(ancient)
 
 
 class TestFactPackValidation:

--- a/tests/unit/scoring/discovery/test_pipeline.py
+++ b/tests/unit/scoring/discovery/test_pipeline.py
@@ -455,13 +455,24 @@ class TestPortfolioAwareDiscovery:
         mocker.patch.object(pipeline, "_gather_portfolio_aware_candidates", return_value=graded)
         mocker.patch.object(pipeline, "_enrich_top_candidates", side_effect=lambda c: (c, 0, 0))
         mocker.patch.object(pipeline, "_persist_result")
-        mocker.patch.object(pipeline, "_persist_scored")
+        mock_persist_scored = mocker.patch.object(pipeline, "_persist_scored")
 
         result = pipeline.discover("sess-filter")
         grades = {c.grade for c in result.candidates}
         tickers = {c.ticker for c in result.candidates}
         assert "D" not in grades and "F" not in grades
         assert tickers == {"STRONG", "MIDC"}
+
+        # _persist_scored must receive the FULL pre-filter set (including the
+        # dropped D/F candidates) -- this is the actual point of the task.
+        # Asserting only on result.candidates above would pass even if
+        # _persist_scored were wired to the post-filter list or dropped
+        # entirely, which is exactly the regression this test exists to catch.
+        mock_persist_scored.assert_called_once()
+        persisted_call = mock_persist_scored.call_args
+        persisted_tickers = {c.ticker for c in persisted_call.args[0]}
+        assert persisted_tickers == {"STRONG", "MIDC", "WEAKD", "WEAKF"}
+        assert persisted_call.kwargs["actionable_count"] == 2
 
     def test_signal_score_used_when_present(self, pipeline, mocker):
         """When a ticker trips a signal, its richer signal composite is the standalone factor."""

--- a/tests/unit/scoring/discovery/test_pipeline.py
+++ b/tests/unit/scoring/discovery/test_pipeline.py
@@ -1,5 +1,6 @@
 """Unit tests for NewcomerDiscoveryPipeline."""
 
+import json
 import time
 
 import pytest
@@ -63,6 +64,7 @@ class TestNewcomerDiscoveryPipeline:
         mocker.patch.object(pipeline, "_score_candidates", side_effect=lambda c: c)
         mocker.patch.object(pipeline, "_enrich_top_candidates", side_effect=lambda c: (c, 0, 0))
         mocker.patch.object(pipeline, "_persist_result")
+        mocker.patch.object(pipeline, "_persist_scored")
 
         result = pipeline.discover("test-session")
         tickers = [c.ticker for c in result.candidates]
@@ -78,6 +80,7 @@ class TestNewcomerDiscoveryPipeline:
         mocker.patch.object(pipeline, "_score_candidates", side_effect=lambda c: c)
         mocker.patch.object(pipeline, "_enrich_top_candidates", side_effect=lambda c: (c, 0, 0))
         mocker.patch.object(pipeline, "_persist_result")
+        mocker.patch.object(pipeline, "_persist_scored")
 
         result = pipeline.discover("sess-123")
         assert isinstance(result, NewcomerDiscoveryResult)
@@ -93,6 +96,7 @@ class TestNewcomerDiscoveryPipeline:
         mocker.patch.object(pipeline, "_enrich_top_candidates", side_effect=lambda c: (c, 0, 0))
 
         mock_persist = mocker.patch.object(pipeline, "_persist_result")
+        mocker.patch.object(pipeline, "_persist_scored")
         pipeline.discover("test-session")
         mock_persist.assert_called_once()
 
@@ -135,6 +139,7 @@ class TestNewcomerDiscoveryPipeline:
         mocker.patch.object(pipeline, "_score_candidates", side_effect=lambda c: c)
         mocker.patch.object(pipeline, "_enrich_top_candidates", side_effect=lambda c: (c, 0, 0))
         mocker.patch.object(pipeline, "_persist_result")
+        mocker.patch.object(pipeline, "_persist_scored")
 
         result = pipeline.discover("test-session")
         assert result.total_candidates == 0
@@ -145,6 +150,7 @@ class TestNewcomerDiscoveryPipeline:
         mocker.patch.object(pipeline, "_score_candidates", side_effect=lambda c: c)
         mocker.patch.object(pipeline, "_enrich_top_candidates", side_effect=lambda c: (c, 0, 0))
         mocker.patch.object(pipeline, "_persist_result")
+        mocker.patch.object(pipeline, "_persist_scored")
 
         result = pipeline.discover("test-session")
         assert result.total_candidates == 0
@@ -161,6 +167,7 @@ class TestNewcomerDiscoveryPipeline:
             side_effect=lambda c: (c, 1, 0),  # attempted 1, succeeded 0
         )
         mocker.patch.object(pipeline, "_persist_result")
+        mocker.patch.object(pipeline, "_persist_scored")
 
         result = pipeline.discover("test-session")
         assert result.total_candidates == 1
@@ -177,6 +184,7 @@ class TestNewcomerDiscoveryPipeline:
         mocker.patch.object(pipeline, "_score_candidates", side_effect=lambda c: c)
         mocker.patch.object(pipeline, "_enrich_top_candidates", side_effect=lambda c: (c, 0, 0))
         mocker.patch.object(pipeline, "_persist_result")
+        mocker.patch.object(pipeline, "_persist_scored")
 
         result = pipeline.discover("test-session")
         scores = [c.composite_score for c in result.candidates]
@@ -447,6 +455,7 @@ class TestPortfolioAwareDiscovery:
         mocker.patch.object(pipeline, "_gather_portfolio_aware_candidates", return_value=graded)
         mocker.patch.object(pipeline, "_enrich_top_candidates", side_effect=lambda c: (c, 0, 0))
         mocker.patch.object(pipeline, "_persist_result")
+        mocker.patch.object(pipeline, "_persist_scored")
 
         result = pipeline.discover("sess-filter")
         grades = {c.grade for c in result.candidates}
@@ -512,3 +521,23 @@ class TestEnrichment:
         result, attempted, succeeded = pipeline._enrich_top_candidates(candidates)
         assert attempted == 0
         assert succeeded == 0
+
+
+def test_scored_candidates_are_persisted_before_filtering(tmp_path, mocker, monkeypatch):
+    # NewcomerCandidate/NewcomerDiscoveryPipeline are already imported at module
+    # level above; pipeline.py itself only imports NewcomerCandidate under
+    # TYPE_CHECKING, so it is not reachable as a `pipeline` module attribute.
+    monkeypatch.chdir(tmp_path)
+    mocker.patch.object(NewcomerDiscoveryPipeline, "_load_portfolio_tickers", return_value=None)
+    pipeline = NewcomerDiscoveryPipeline("etf")
+
+    scored = [
+        NewcomerCandidate(ticker="AAA", asset_class="etf", composite_score=0.72, grade="C+"),
+        NewcomerCandidate(ticker="BBB", asset_class="etf", composite_score=0.40, grade="F"),
+    ]
+    pipeline._persist_scored(scored, actionable_count=1)
+
+    written = json.loads((tmp_path / "output" / "discovery" / "scored_etf.json").read_text(encoding="utf-8"))
+    assert len(written["scored"]) == 2
+    assert written["actionable_count"] == 1
+    assert {c["ticker"] for c in written["scored"]} == {"AAA", "BBB"}

--- a/tests/unit/scoring/test_critical_fields_validation.py
+++ b/tests/unit/scoring/test_critical_fields_validation.py
@@ -189,6 +189,28 @@ class TestDerivableFieldRecoveryBeforeGate:
         # Assert
         assert "current_price" in str(exc_info.value)
 
+    def test_beta_hardcoded_fallback_does_not_rescue_the_gate(self, scorer):
+        """Test that recovery stays narrow: beta's neutral-default fallback must never let a stock through the gate.
+
+        Unlike volatility (derived from real price_history), beta's fallback is a hardcoded
+        assumption (1.0). Pre-gate recovery must not apply it, or the gate stops meaning anything.
+        """
+        # Arrange - stock has price_history (so volatility IS derivable) but no beta
+        data = {
+            "current_price": 150.0,
+            "roe": 0.20,
+            "debt_to_equity": 0.5,
+            "revenue_growth": 0.15,
+            "price_history": self._price_series(),
+            # beta is missing and must NOT be silently defaulted before the gate
+        }
+
+        # Act & Assert
+        with pytest.raises(CriticalFieldError) as exc_info:
+            scorer.calculate_composite_score(ticker="AAPL", asset_class="stock", data=data)
+
+        assert any("beta" in field for field in exc_info.value.missing_fields)
+
 
 class TestCriticalFieldsConfig:
     """Test critical fields configuration."""

--- a/tests/unit/scoring/test_critical_fields_validation.py
+++ b/tests/unit/scoring/test_critical_fields_validation.py
@@ -5,6 +5,7 @@ Tests that the scorer FAILS FAST when critical fields are missing,
 rather than silently using hardcoded fallback values.
 """
 
+import pandas as pd
 import pytest
 from pytest import approx
 
@@ -150,6 +151,43 @@ class TestCriticalFieldsValidation:
 
         # Lineage should track the failure
         # (Implementation detail - lineage tracker should record validation failure)
+
+
+class TestDerivableFieldRecoveryBeforeGate:
+    """Test that fields derivable from collected data (e.g. volatility) are recovered before the gate fires."""
+
+    @pytest.fixture
+    def scorer(self):
+        """Create scorer instance."""
+        return DeepAnalysisScorer()
+
+    @staticmethod
+    def _price_series() -> pd.Series:
+        return pd.Series([100.0, 101.5, 99.8, 102.3, 101.1, 103.4, 102.0, 104.2, 103.1, 105.0])
+
+    def test_volatility_is_recovered_before_the_critical_gate(self, scorer):
+        """Test that a missing volatility is derived from price_history before the critical-field gate runs."""
+        # Arrange - ETF data has price_history but no volatility
+        data = {
+            "current_price": 105.0,
+            "expense_ratio": 0.07,
+            "price_history": self._price_series(),
+        }
+
+        # Act
+        result = scorer.calculate_composite_score(ticker="VUSA.L", asset_class="etf", data=data)
+
+        # Assert - analysis proceeds instead of raising CriticalFieldError
+        assert result.composite_score >= 0.0
+
+    def test_gate_still_fires_when_nothing_can_be_recovered(self, scorer):
+        """Test that the gate still fails fast when a critical field cannot be derived from anything on hand."""
+        # Arrange - no current_price and no price_history to derive it from
+        with pytest.raises(CriticalFieldError) as exc_info:
+            scorer.calculate_composite_score(ticker="XTSLA", asset_class="etf", data={"expense_ratio": 0.07})
+
+        # Assert
+        assert "current_price" in str(exc_info.value)
 
 
 class TestCriticalFieldsConfig:

--- a/tests/unit/scoring/test_crypto_analyzer.py
+++ b/tests/unit/scoring/test_crypto_analyzer.py
@@ -1,0 +1,55 @@
+"""Crypto discovery analyzer must never fabricate opportunities.
+
+`analyze_crypto_opportunities` routes through `NewcomerDiscoveryPipeline`. On
+pipeline failure it must return an empty, honestly-labelled result — never
+the old hardcoded BTC/ETH fallback opportunities.
+"""
+
+import inspect
+
+from finwiz.scoring import crypto_analyzer
+from finwiz.scoring.crypto_analyzer import analyze_crypto_opportunities
+
+
+def test_pipeline_failure_yields_no_opportunities(mocker):
+    mocker.patch(
+        "finwiz.scoring.discovery.pipeline.NewcomerDiscoveryPipeline",
+        side_effect=RuntimeError("universe fetch exploded"),
+    )
+
+    result = analyze_crypto_opportunities("test-session")
+
+    assert result["opportunities"] == []
+    assert result["performance_metrics"]["opportunities_found"] == 0
+    assert result["performance_metrics"]["method"] == "newcomer_discovery_failed"
+    assert "error" in result["performance_metrics"]
+
+
+def test_pipeline_success_is_labelled_distinctly_from_failure(mocker):
+    """A run that legitimately finds nothing must not look like a failure."""
+    mock_pipeline_cls = mocker.patch("finwiz.scoring.discovery.pipeline.NewcomerDiscoveryPipeline")
+    mock_pipeline = mock_pipeline_cls.return_value
+    mock_pipeline.discover.return_value = mocker.Mock()
+    mock_pipeline._to_legacy_format.return_value = {
+        "opportunities": [],
+        "analysis_summary": "Discovered 0 crypto newcomer candidates",
+        "performance_metrics": {
+            "execution_time_seconds": 0.01,
+            "opportunities_found": 0,
+            "cost_usd": 0.0,
+            "llm_calls_made": 0,
+            "method": "newcomer_discovery_pipeline",
+        },
+    }
+
+    result = analyze_crypto_opportunities("test-session")
+
+    assert result["opportunities"] == []
+    assert result["performance_metrics"]["method"] == "newcomer_discovery_pipeline"
+    assert "error" not in result["performance_metrics"]
+
+
+def test_no_hardcoded_tickers_remain_in_module():
+    source = inspect.getsource(crypto_analyzer)
+    for invented in ("BTC", "ETH"):
+        assert invented not in source

--- a/tests/unit/scoring/test_etf_analyzer.py
+++ b/tests/unit/scoring/test_etf_analyzer.py
@@ -1,0 +1,55 @@
+"""ETF discovery analyzer must never fabricate opportunities.
+
+`analyze_etf_opportunities` routes through `NewcomerDiscoveryPipeline`. On
+pipeline failure it must return an empty, honestly-labelled result — never
+the old hardcoded VTI/VXUS/BND fallback opportunities.
+"""
+
+import inspect
+
+from finwiz.scoring import etf_analyzer
+from finwiz.scoring.etf_analyzer import analyze_etf_opportunities
+
+
+def test_pipeline_failure_yields_no_opportunities(mocker):
+    mocker.patch(
+        "finwiz.scoring.discovery.pipeline.NewcomerDiscoveryPipeline",
+        side_effect=RuntimeError("universe fetch exploded"),
+    )
+
+    result = analyze_etf_opportunities("test-session")
+
+    assert result["opportunities"] == []
+    assert result["performance_metrics"]["opportunities_found"] == 0
+    assert result["performance_metrics"]["method"] == "newcomer_discovery_failed"
+    assert "error" in result["performance_metrics"]
+
+
+def test_pipeline_success_is_labelled_distinctly_from_failure(mocker):
+    """A run that legitimately finds nothing must not look like a failure."""
+    mock_pipeline_cls = mocker.patch("finwiz.scoring.discovery.pipeline.NewcomerDiscoveryPipeline")
+    mock_pipeline = mock_pipeline_cls.return_value
+    mock_pipeline.discover.return_value = mocker.Mock()
+    mock_pipeline._to_legacy_format.return_value = {
+        "opportunities": [],
+        "analysis_summary": "Discovered 0 etf newcomer candidates",
+        "performance_metrics": {
+            "execution_time_seconds": 0.01,
+            "opportunities_found": 0,
+            "cost_usd": 0.0,
+            "llm_calls_made": 0,
+            "method": "newcomer_discovery_pipeline",
+        },
+    }
+
+    result = analyze_etf_opportunities("test-session")
+
+    assert result["opportunities"] == []
+    assert result["performance_metrics"]["method"] == "newcomer_discovery_pipeline"
+    assert "error" not in result["performance_metrics"]
+
+
+def test_no_hardcoded_tickers_remain_in_module():
+    source = inspect.getsource(etf_analyzer)
+    for invented in ("VTI", "VXUS", "BND"):
+        assert invented not in source

--- a/tests/unit/scoring/test_stock_analyzer.py
+++ b/tests/unit/scoring/test_stock_analyzer.py
@@ -1,0 +1,55 @@
+"""Stock discovery analyzer must never fabricate opportunities.
+
+`analyze_stock_opportunities` routes through `NewcomerDiscoveryPipeline`. On
+pipeline failure it must return an empty, honestly-labelled result — never
+the old hardcoded MSFT/NVDA/GOOGL fallback opportunities.
+"""
+
+import inspect
+
+from finwiz.scoring import stock_analyzer
+from finwiz.scoring.stock_analyzer import analyze_stock_opportunities
+
+
+def test_pipeline_failure_yields_no_opportunities(mocker):
+    mocker.patch(
+        "finwiz.scoring.discovery.pipeline.NewcomerDiscoveryPipeline",
+        side_effect=RuntimeError("universe fetch exploded"),
+    )
+
+    result = analyze_stock_opportunities("test-session")
+
+    assert result["opportunities"] == []
+    assert result["performance_metrics"]["opportunities_found"] == 0
+    assert result["performance_metrics"]["method"] == "newcomer_discovery_failed"
+    assert "error" in result["performance_metrics"]
+
+
+def test_pipeline_success_is_labelled_distinctly_from_failure(mocker):
+    """A run that legitimately finds nothing must not look like a failure."""
+    mock_pipeline_cls = mocker.patch("finwiz.scoring.discovery.pipeline.NewcomerDiscoveryPipeline")
+    mock_pipeline = mock_pipeline_cls.return_value
+    mock_pipeline.discover.return_value = mocker.Mock()
+    mock_pipeline._to_legacy_format.return_value = {
+        "opportunities": [],
+        "analysis_summary": "Discovered 0 stock newcomer candidates",
+        "performance_metrics": {
+            "execution_time_seconds": 0.01,
+            "opportunities_found": 0,
+            "cost_usd": 0.0,
+            "llm_calls_made": 0,
+            "method": "newcomer_discovery_pipeline",
+        },
+    }
+
+    result = analyze_stock_opportunities("test-session")
+
+    assert result["opportunities"] == []
+    assert result["performance_metrics"]["method"] == "newcomer_discovery_pipeline"
+    assert "error" not in result["performance_metrics"]
+
+
+def test_no_hardcoded_tickers_remain_in_module():
+    source = inspect.getsource(stock_analyzer)
+    for invented in ("MSFT", "NVDA", "GOOGL"):
+        assert invented not in source

--- a/tests/unit/scoring/test_technical_fallback.py
+++ b/tests/unit/scoring/test_technical_fallback.py
@@ -296,6 +296,29 @@ class TestVolatilityFallback:
         # Assert
         assert "volatility" not in result
 
+    def test_flat_price_series_yields_zero_volatility_and_is_preserved(self):
+        """Test that a genuine 0.0 volatility (perfectly flat prices) is computed and never treated as missing.
+
+        The ``is not None`` guard in _fill_volatility must not be replaced with a truthy check,
+        or a real 0.0 would look "missing" and get recomputed/discarded on a later call.
+        """
+        # Arrange - zero variance in prices means zero volatility, not "no data"
+        flat_prices = pd.Series([100.0] * 10)
+        data = {"current_price": 100.0}
+
+        # Act
+        result = calculate_missing_technical_indicators(data, flat_prices)
+
+        # Assert - a genuine zero was computed
+        assert "volatility" in result
+        assert result["volatility"] == approx(0.0)
+
+        # Act again - re-running must preserve the existing 0.0, not treat it as absent
+        second_result = calculate_missing_technical_indicators(dict(result), flat_prices)
+
+        # Assert
+        assert second_result["volatility"] == approx(0.0)
+
 
 class TestGetPriceHistoryFromData:
     """Test cases for get_price_history_from_data function."""

--- a/tests/unit/scoring/test_technical_fallback.py
+++ b/tests/unit/scoring/test_technical_fallback.py
@@ -244,6 +244,59 @@ class TestCalculateMissingTechnicalIndicators:
         assert result_bearish["macd"] < 0
 
 
+class TestVolatilityFallback:
+    """Test cases for volatility derivation in calculate_missing_technical_indicators."""
+
+    @staticmethod
+    def _price_series() -> pd.Series:
+        return pd.Series([100.0, 101.5, 99.8, 102.3, 101.1, 103.4, 102.0, 104.2, 103.1, 105.0])
+
+    def test_derives_volatility_from_price_history_when_missing(self):
+        """Test that volatility is derived from price history when the quant tool didn't supply it."""
+        # Arrange
+        data = {"current_price": 105.0}
+
+        # Act
+        result = calculate_missing_technical_indicators(data, self._price_series())
+
+        # Assert
+        assert "volatility" in result
+        assert 0.0 < result["volatility"] < 5.0
+
+    def test_does_not_overwrite_existing_volatility(self):
+        """Test that a volatility value already supplied by the quant tool is never overwritten."""
+        # Arrange
+        data = {"current_price": 105.0, "volatility": 0.42}
+
+        # Act
+        result = calculate_missing_technical_indicators(data, self._price_series())
+
+        # Assert
+        assert result["volatility"] == approx(0.42)
+
+    def test_leaves_volatility_absent_when_no_price_history(self):
+        """Test that volatility stays absent when there is no price history to derive it from."""
+        # Arrange
+        data = {"current_price": 105.0}
+
+        # Act
+        result = calculate_missing_technical_indicators(data, None)
+
+        # Assert
+        assert "volatility" not in result
+
+    def test_leaves_volatility_absent_when_history_too_short(self):
+        """Test that volatility stays absent when price history has fewer than 2 points."""
+        # Arrange
+        data = {"current_price": 105.0}
+
+        # Act
+        result = calculate_missing_technical_indicators(data, pd.Series([100.0]))
+
+        # Assert
+        assert "volatility" not in result
+
+
 class TestGetPriceHistoryFromData:
     """Test cases for get_price_history_from_data function."""
 

--- a/tests/unit/scoring/test_technical_fallback.py
+++ b/tests/unit/scoring/test_technical_fallback.py
@@ -299,7 +299,7 @@ class TestVolatilityFallback:
     def test_flat_price_series_yields_zero_volatility_and_is_preserved(self):
         """Test that a genuine 0.0 volatility (perfectly flat prices) is computed and never treated as missing.
 
-        The ``is not None`` guard in _fill_volatility must not be replaced with a truthy check,
+        The ``is not None`` guard in fill_volatility must not be replaced with a truthy check,
         or a real 0.0 would look "missing" and get recomputed/discarded on a later call.
         """
         # Arrange - zero variance in prices means zero volatility, not "no data"

--- a/tests/unit/tools/test_alternative_finder_tool.py
+++ b/tests/unit/tools/test_alternative_finder_tool.py
@@ -21,73 +21,74 @@ class TestAlternativeFinder:
 
     @pytest.fixture
     def sample_discovery_output(self, tmp_path):
-        """Create sample discovery crew output."""
+        """Create sample discovery output (consolidated_discovery.json, flat opportunities shape)."""
         discovery_dir = tmp_path / "discovery"
         discovery_dir.mkdir()
 
         discovery_data = {
-            "pydantic": {
-                "aplus_stocks": [
-                    {
-                        "ticker": "MSFT",
-                        "name": "Microsoft Corporation",
-                        "composite_score": 0.90,
-                        "grade": "A+",
-                        "risk_score": 2.0,
-                        "key_metrics": {"pe_ratio": 30, "growth_rate": 0.15},
-                        "thesis_bullets": ["Strong cloud growth", "AI leadership"],
-                        "citations": ["SEC 10-K", "Yahoo Finance"],
-                        "confidence_level": 0.90,
-                        "expected_annual_benefit": 0.12,
-                    },
-                    {
-                        "ticker": "GOOGL",
-                        "name": "Alphabet Inc.",
-                        "composite_score": 0.88,
-                        "grade": "A",
-                        "risk_score": 2.2,
-                        "key_metrics": {"pe_ratio": 25, "growth_rate": 0.12},
-                        "thesis_bullets": ["Search dominance", "Cloud growth"],
-                        "citations": ["SEC 10-K"],
-                        "confidence_level": 0.85,
-                    },
-                ],
-                "aplus_etfs": [
-                    {
-                        "ticker": "VTI",
-                        "name": "Vanguard Total Stock Market ETF",
-                        "composite_score": 0.92,
-                        "grade": "A+",
-                        "risk_score": 1.8,
-                        "expense_ratio": 0.03,
-                        "key_metrics": {"tracking_error": 0.02},
-                        "thesis_bullets": ["Low cost", "Broad diversification"],
-                        "citations": ["Vanguard"],
-                        "confidence_level": 0.95,
-                    },
-                ],
-                "aplus_cryptos": [
-                    {
-                        "ticker": "BTC",
-                        "name": "Bitcoin",
-                        "composite_score": 0.85,
-                        "grade": "A",
-                        "risk_score": 3.5,
-                        "market_cap": 1000000000000,
-                        "key_metrics": {"volume_24h": 50000000000},
-                        "thesis_bullets": ["Store of value", "Institutional adoption"],
-                        "citations": ["CoinMarketCap"],
-                        "confidence_level": 0.80,
-                    },
-                ],
-            }
+            "timestamp": "2026-08-15T00:00:00",
+            "total_opportunities": 4,
+            "opportunities": [
+                {
+                    "ticker": "MSFT",
+                    "name": "Microsoft Corporation",
+                    "asset_class": "stock",
+                    "composite_score": 0.90,
+                    "grade": "A+",
+                    "risk_score": 2.0,
+                    "key_metrics": {"pe_ratio": 30, "growth_rate": 0.15},
+                    "thesis_bullets": ["Strong cloud growth", "AI leadership"],
+                    "citations": ["SEC 10-K", "Yahoo Finance"],
+                    "confidence_level": 0.90,
+                    "expected_annual_benefit": 0.12,
+                },
+                {
+                    "ticker": "GOOGL",
+                    "name": "Alphabet Inc.",
+                    "asset_class": "stock",
+                    "composite_score": 0.88,
+                    "grade": "A",
+                    "risk_score": 2.2,
+                    "key_metrics": {"pe_ratio": 25, "growth_rate": 0.12},
+                    "thesis_bullets": ["Search dominance", "Cloud growth"],
+                    "citations": ["SEC 10-K"],
+                    "confidence_level": 0.85,
+                },
+                {
+                    "ticker": "VTI",
+                    "name": "Vanguard Total Stock Market ETF",
+                    "asset_class": "etf",
+                    "composite_score": 0.92,
+                    "grade": "A+",
+                    "risk_score": 1.8,
+                    "expense_ratio": 0.03,
+                    "key_metrics": {"tracking_error": 0.02},
+                    "thesis_bullets": ["Low cost", "Broad diversification"],
+                    "citations": ["Vanguard"],
+                    "confidence_level": 0.95,
+                },
+                {
+                    "ticker": "BTC",
+                    "name": "Bitcoin",
+                    "asset_class": "crypto",
+                    "composite_score": 0.85,
+                    "grade": "A",
+                    "risk_score": 3.5,
+                    "market_cap": 1000000000000,
+                    "key_metrics": {"volume_24h": 50000000000},
+                    "thesis_bullets": ["Store of value", "Institutional adoption"],
+                    "citations": ["CoinMarketCap"],
+                    "confidence_level": 0.80,
+                },
+            ],
+            "by_asset_class": {"stock": 2, "etf": 1, "crypto": 1},
         }
 
-        latest_file = discovery_dir / "discovery_latest.json"
-        with open(latest_file, "w") as f:
+        consolidated_file = discovery_dir / "consolidated_discovery.json"
+        with open(consolidated_file, "w") as f:
             json.dump(discovery_data, f)
 
-        return latest_file
+        return consolidated_file
 
     def test_should_find_no_alternatives_for_grade_b_or_above(self, finder):
         """Test that no alternatives are found for holdings graded B or above."""
@@ -234,8 +235,14 @@ class TestAlternativeFinder:
         assert "immédiatement" in msft_alt.transition_strategy.lower()
 
     def test_should_create_gradual_swap_timing_for_moderate_grade_improvement(self, finder, sample_discovery_output):
-        """Test gradual swap timing for moderate grade improvements (C to B+)."""
+        """Test gradual swap timing for moderate grade improvements (C+ to A)."""
         # Arrange
+        # GOOGL is grade A (value 9) in the base fixture; no discovery-output
+        # modification needed here. (Note: a B+ alternative can no longer be
+        # used to hit this bucket the way this test used to — B+ falls outside
+        # the A-band grade filter now applied to consolidated_discovery.json's
+        # opportunities list, so a B+ item would simply be excluded rather than
+        # surfaced with a smaller grade_improvement.)
         holding = HoldingProfile(
             ticker="OK.STOCK",
             name="OK Stock",
@@ -244,33 +251,29 @@ class TestAlternativeFinder:
             composite_score=0.60,
         )
 
-        # Modify discovery output to have B+ grade (value 8, improvement = 2)
-        discovery_dir = finder.discovery_output_dir
-        latest_file = discovery_dir / "discovery_latest.json"
-
-        with open(latest_file) as f:
-            data = json.load(f)
-
-        # Change GOOGL to B+ for gradual timing (improvement = 2)
-        data["pydantic"]["aplus_stocks"][1]["grade"] = "B+"
-
-        with open(latest_file, "w") as f:
-            json.dump(data, f)
-
         # Act
         alternatives = finder.find_alternatives(holding, max_alternatives=3)
 
         # Assert
-        # B+ (value 8) - C+ (value 6) = 2, should be gradual
+        # A (value 9) - C+ (value 6) = 3, should be gradual
         googl_alt = next((alt for alt in alternatives if alt.ticker == "GOOGL"), None)
         assert googl_alt is not None
         assert googl_alt.swap_timing == "gradual"
         assert "progressive" in googl_alt.transition_strategy.lower()
 
     def test_should_create_tax_optimized_swap_timing_for_small_grade_improvement(self, finder, sample_discovery_output):
-        """Test tax-optimized swap timing for small grade improvements."""
-        # Arrange - Create a holding with grade C+ (value 6)
-        # and modify discovery output to have a B+ alternative (value 8)
+        """Test tax-optimized swap timing for small grade improvements.
+
+        Note: with the A-band-only filter (grade in {"A+", "A"}, value >= 9)
+        applied to discovery opportunities, and alternatives only searched for
+        holdings graded below B (value <= 6), the minimum achievable
+        grade_improvement is 9 - 6 = 3 — always "gradual" or "immediate",
+        never "tax_optimized" (< 2). This was already true before this file's
+        A-band rewrite (the previous version of this test never actually
+        asserted a tax_optimized outcome either); kept as a smoke test that
+        the base fixture still yields alternatives at all.
+        """
+        # Arrange
         holding = HoldingProfile(
             ticker="DECENT.STOCK",
             name="Decent Stock",
@@ -279,30 +282,11 @@ class TestAlternativeFinder:
             composite_score=0.65,
         )
 
-        # Modify discovery output to have B+ grade
-        discovery_dir = finder.discovery_output_dir
-        latest_file = discovery_dir / "discovery_latest.json"
-
-        with open(latest_file) as f:
-            data = json.load(f)
-
-        # Change GOOGL to B+ for this test
-        data["pydantic"]["aplus_stocks"][1]["grade"] = "B+"
-        data["pydantic"]["aplus_stocks"][1]["ticker"] = "BPLUS.STOCK"
-
-        with open(latest_file, "w") as f:
-            json.dump(data, f)
-
         # Act
         alternatives = finder.find_alternatives(holding, max_alternatives=3)
 
         # Assert
-        # B+ (value 8) - C+ (value 6) = 2, should be gradual
-        # But if we want tax_optimized, need improvement < 2
-        # Let's check what we get
-        if alternatives:
-            # Just verify the logic works
-            assert len(alternatives) > 0
+        assert len(alternatives) > 0
 
     def test_should_include_french_transition_strategy(self, finder, sample_discovery_output):
         """Test that transition strategy is in French."""
@@ -440,10 +424,10 @@ class TestAlternativeFinder:
         # Arrange
         discovery_dir = tmp_path / "discovery"
         discovery_dir.mkdir()
-        latest_file = discovery_dir / "discovery_latest.json"
+        consolidated_file = discovery_dir / "consolidated_discovery.json"
 
         # Write corrupted JSON
-        with open(latest_file, "w") as f:
+        with open(consolidated_file, "w") as f:
             f.write("{invalid json")
 
         holding = HoldingProfile(
@@ -571,28 +555,28 @@ class TestAlternativeFinder:
         discovery_dir.mkdir()
 
         discovery_data = {
-            "pydantic": {
-                "aplus_stocks": [
-                    {
-                        "ticker": "MSFT",
-                        "name": "Microsoft",
-                        "composite_score": 0.90,
-                        "grade": "A+",
-                        "risk_score": 2.0,
-                    },
-                    {
-                        "ticker": "MSFT",  # Duplicate
-                        "name": "Microsoft",
-                        "composite_score": 0.90,
-                        "grade": "A+",
-                        "risk_score": 2.0,
-                    },
-                ],
-            }
+            "opportunities": [
+                {
+                    "ticker": "MSFT",
+                    "name": "Microsoft",
+                    "asset_class": "stock",
+                    "composite_score": 0.90,
+                    "grade": "A+",
+                    "risk_score": 2.0,
+                },
+                {
+                    "ticker": "MSFT",  # Duplicate
+                    "name": "Microsoft",
+                    "asset_class": "stock",
+                    "composite_score": 0.90,
+                    "grade": "A+",
+                    "risk_score": 2.0,
+                },
+            ],
         }
 
-        latest_file = discovery_dir / "discovery_latest.json"
-        with open(latest_file, "w") as f:
+        consolidated_file = discovery_dir / "consolidated_discovery.json"
+        with open(consolidated_file, "w") as f:
             json.dump(discovery_data, f)
 
         holding = HoldingProfile(
@@ -610,3 +594,78 @@ class TestAlternativeFinder:
         # Should only have one MSFT, not two
         tickers = [alt.ticker for alt in alternatives]
         assert tickers.count("MSFT") == 1
+
+    def test_should_exclude_opportunity_from_different_asset_class(self, finder, tmp_path):
+        """An A-band opportunity for a different asset class must not surface as an alternative.
+
+        Pins one of the two ways the consolidated_discovery.json filter can
+        silently pass everything: forgetting the asset_class check.
+        """
+        # Arrange
+        discovery_dir = tmp_path / "discovery"
+        discovery_dir.mkdir()
+        discovery_data = {
+            "opportunities": [
+                {
+                    "ticker": "VTI",
+                    "name": "Vanguard Total Stock Market ETF",
+                    "asset_class": "etf",  # holding below is a stock
+                    "composite_score": 0.92,
+                    "grade": "A+",
+                },
+            ],
+        }
+        with open(discovery_dir / "consolidated_discovery.json", "w") as f:
+            json.dump(discovery_data, f)
+
+        holding = HoldingProfile(
+            ticker="BAD.STOCK",
+            name="Bad Stock",
+            asset_class="stock",
+            grade="D",
+            composite_score=0.40,
+        )
+
+        # Act
+        alternatives = finder.find_alternatives(holding, max_alternatives=3)
+
+        # Assert
+        assert alternatives == []
+
+    def test_should_exclude_non_a_band_opportunity(self, finder, tmp_path):
+        """A same-asset-class opportunity below the A-band must not surface as an alternative.
+
+        Pins the other way the consolidated_discovery.json filter can silently
+        pass everything: forgetting the grade check (B+ and below are not
+        A-band, even though they're above the "actionable" C floor upstream).
+        """
+        # Arrange
+        discovery_dir = tmp_path / "discovery"
+        discovery_dir.mkdir()
+        discovery_data = {
+            "opportunities": [
+                {
+                    "ticker": "DECENT.STOCK",
+                    "name": "Decent Stock",
+                    "asset_class": "stock",
+                    "composite_score": 0.78,
+                    "grade": "B+",  # below A-band (A+/A)
+                },
+            ],
+        }
+        with open(discovery_dir / "consolidated_discovery.json", "w") as f:
+            json.dump(discovery_data, f)
+
+        holding = HoldingProfile(
+            ticker="BAD.STOCK",
+            name="Bad Stock",
+            asset_class="stock",
+            grade="D",
+            composite_score=0.40,
+        )
+
+        # Act
+        alternatives = finder.find_alternatives(holding, max_alternatives=3)
+
+        # Assert
+        assert alternatives == []

--- a/tests/unit/tools/test_backtesting_tool.py
+++ b/tests/unit/tools/test_backtesting_tool.py
@@ -6,6 +6,7 @@ risk-adjusted performance metrics, and validation criteria.
 """
 
 import json
+import logging
 from datetime import datetime
 
 import pandas as pd
@@ -162,76 +163,79 @@ class TestBacktestingResult:
         assert result.validation_passed is False  # Default value
 
 
+@pytest.fixture
+def backtesting_tool():
+    """Create BacktestingTool instance for testing."""
+    return BacktestingTool()
+
+
+@pytest.fixture
+def mock_backtest_result(mocker):
+    """Create mock backtest result."""
+    mock_result = mocker.MagicMock()
+    mock_result.strategy_name = "SimpleMovingAverageStrategy"
+    mock_result.total_return = 25.5
+    mock_result.annualized_return = 12.8
+    mock_result.benchmark_return = 18.5
+    mock_result.sharpe_ratio = 1.25
+    mock_result.max_drawdown = -8.5
+    mock_result.volatility = 16.2
+    mock_result.total_trades = 35
+    mock_result.win_rate = 0.65
+    mock_result.var_95 = -2.1
+    mock_result.cvar_95 = -3.2
+    mock_result.calmar_ratio = 1.51
+    mock_result.start_date = datetime(2019, 1, 1)
+    mock_result.end_date = datetime(2024, 1, 1)
+    mock_result.initial_capital = 100000.0
+    mock_result.final_value = 125500.0
+    mock_result.portfolio_values = {
+        "2019-01-01": 100000.0,
+        "2019-06-01": 105000.0,
+        "2020-01-01": 110000.0,
+        "2020-06-01": 115000.0,
+        "2021-01-01": 120000.0,
+        "2021-06-01": 125000.0,
+        "2022-01-01": 125500.0,
+    }
+    mock_result.trades = []
+    return mock_result
+
+
+@pytest.fixture
+def mock_benchmark_data():
+    """Create mock benchmark data for regime analysis."""
+    dates = pd.date_range(start="2019-01-01", end="2024-01-01", freq="D")
+    # Create data with different regimes
+    prices = []
+    base_price = 100.0
+
+    for i, _date in enumerate(dates):
+        # Simulate different market regimes
+        if i < len(dates) // 3:  # Bull market
+            daily_return = 0.0008  # ~20% annual
+        elif i < 2 * len(dates) // 3:  # Bear market
+            daily_return = -0.0004  # ~-10% annual
+        else:  # Sideways market
+            daily_return = 0.0001  # ~2.5% annual
+
+        base_price *= 1 + daily_return
+        prices.append(base_price)
+
+    return pd.DataFrame(
+        {
+            "Close": prices,
+            "Open": [p * 0.999 for p in prices],
+            "High": [p * 1.002 for p in prices],
+            "Low": [p * 0.998 for p in prices],
+            "Volume": [1000000] * len(prices),
+        },
+        index=dates,
+    )
+
+
 class TestBacktestingTool:
     """Test BacktestingTool functionality."""
-
-    @pytest.fixture
-    def backtesting_tool(self):
-        """Create BacktestingTool instance for testing."""
-        return BacktestingTool()
-
-    @pytest.fixture
-    def mock_backtest_result(self, mocker):
-        """Create mock backtest result."""
-        mock_result = mocker.MagicMock()
-        mock_result.strategy_name = "SimpleMovingAverageStrategy"
-        mock_result.total_return = 25.5
-        mock_result.annualized_return = 12.8
-        mock_result.benchmark_return = 18.5
-        mock_result.sharpe_ratio = 1.25
-        mock_result.max_drawdown = -8.5
-        mock_result.volatility = 16.2
-        mock_result.total_trades = 35
-        mock_result.win_rate = 0.65
-        mock_result.var_95 = -2.1
-        mock_result.cvar_95 = -3.2
-        mock_result.calmar_ratio = 1.51
-        mock_result.start_date = datetime(2019, 1, 1)
-        mock_result.end_date = datetime(2024, 1, 1)
-        mock_result.initial_capital = 100000.0
-        mock_result.final_value = 125500.0
-        mock_result.portfolio_values = {
-            "2019-01-01": 100000.0,
-            "2019-06-01": 105000.0,
-            "2020-01-01": 110000.0,
-            "2020-06-01": 115000.0,
-            "2021-01-01": 120000.0,
-            "2021-06-01": 125000.0,
-            "2022-01-01": 125500.0,
-        }
-        mock_result.trades = []
-        return mock_result
-
-    @pytest.fixture
-    def mock_benchmark_data(self):
-        """Create mock benchmark data for regime analysis."""
-        dates = pd.date_range(start="2019-01-01", end="2024-01-01", freq="D")
-        # Create data with different regimes
-        prices = []
-        base_price = 100.0
-
-        for i, date in enumerate(dates):
-            # Simulate different market regimes
-            if i < len(dates) // 3:  # Bull market
-                daily_return = 0.0008  # ~20% annual
-            elif i < 2 * len(dates) // 3:  # Bear market
-                daily_return = -0.0004  # ~-10% annual
-            else:  # Sideways market
-                daily_return = 0.0001  # ~2.5% annual
-
-            base_price *= 1 + daily_return
-            prices.append(base_price)
-
-        return pd.DataFrame(
-            {
-                "Close": prices,
-                "Open": [p * 0.999 for p in prices],
-                "High": [p * 1.002 for p in prices],
-                "Low": [p * 0.998 for p in prices],
-                "Volume": [1000000] * len(prices),
-            },
-            index=dates,
-        )
 
     def test_should_have_correct_tool_properties(self, backtesting_tool):
         """Test tool has correct name and description."""
@@ -486,6 +490,104 @@ class TestBacktestingTool:
         assert validation_score < 0.7  # Should fail validation threshold
         assert validation_passed is False
         assert len(validation_notes) > 1  # Should have multiple failure notes
+
+
+class TestBacktestingToolShortSeriesRefusal:
+    """A series too short to backtest must be refused by name, not by NoneType.
+
+    ``BacktestingEngine.run_strategy_backtest`` returns None when the fetched
+    series is shorter than the strategy's lookback plus warm-up buffer. Reading
+    attributes off that None raised AttributeError, which the tool's shared
+    except turned into "Error performing backtesting: 'NoneType' object has no
+    attribute 'strategy_name'" -- an internal detail in place of the reason.
+    """
+
+    def test_should_refuse_by_name_when_main_backtest_has_too_little_data(self, mocker, backtesting_tool):
+        # Arrange
+        mock_backtesting_engine = mocker.patch("finwiz.quantitative.backtesting.get_backtesting_engine")
+        mocker.patch("finwiz.tools.backtesting_tool.get_historical_data_manager")
+        mocker.patch("finwiz.tools.backtesting_tool.get_performance_analyzer")
+
+        mock_engine = mocker.MagicMock()
+        mock_engine.run_strategy_backtest.return_value = None
+        mock_backtesting_engine.return_value = mock_engine
+
+        # Act
+        result = backtesting_tool._run(symbol="AAPL", strategy="sma_crossover", include_regime_analysis=False)
+
+        # Assert
+        assert "NoneType" not in result
+        assert "Insufficient data" in result
+        assert "AAPL" in result
+        # long_period defaults to 50 inside the engine, plus a 10-bar warm-up buffer.
+        assert "60" in result
+
+    def test_should_omit_regimes_that_are_too_short_to_backtest(self, mocker, backtesting_tool, mock_backtest_result, mock_benchmark_data, caplog):
+        """Regimes are sub-periods of the window, so they are routinely too short.
+
+        A regime that cannot be backtested is dropped from the analysis and from
+        consistency scoring -- reporting a 0.0 return for it would present a
+        missing measurement as a real one. The per-regime except already dropped
+        it, so the payload was never corrupted here; what was wrong is the record
+        left behind, which logged a legitimate refusal as
+        "Error analyzing bull regime: 'NoneType' object has no attribute
+        'total_return'".
+        """
+        # Arrange
+        mock_data_manager_func = mocker.patch("finwiz.tools.backtesting_tool.get_historical_data_manager")
+        mock_backtesting_engine = mocker.patch("finwiz.quantitative.backtesting.get_backtesting_engine")
+        mocker.patch("finwiz.tools.backtesting_tool.get_performance_analyzer")
+
+        mock_dm = mocker.MagicMock()
+        mock_dm.fetch_historical_data.return_value = mock_benchmark_data
+        mock_data_manager_func.return_value = mock_dm
+
+        # The full-window backtest succeeds; every regime sub-period is too short.
+        mock_engine = mocker.MagicMock()
+        mock_engine.run_strategy_backtest.side_effect = [mock_backtest_result] + [None] * 50
+        mock_backtesting_engine.return_value = mock_engine
+
+        # Act
+        with caplog.at_level(logging.INFO, logger="finwiz.tools.backtesting_tool"):
+            result_json = backtesting_tool._run(symbol="AAPL", strategy="sma_crossover", include_regime_analysis=True)
+
+        # Assert — the holding still gets its full-window backtest, minus the regimes.
+        assert "NoneType" not in result_json
+        result = json.loads(result_json)
+        assert result["symbol"] == "AAPL"
+        assert result["total_return"] == approx(25.5)
+        assert result["regime_analysis"] == []
+        assert result["regime_consistency"] == approx(0.0)
+
+        # ...and the record says why, by name, instead of leaking an AttributeError.
+        assert [r.message for r in caplog.records if "NoneType" in r.message] == []
+        assert any("Insufficient data" in r.message and "regime" in r.message for r in caplog.records)
+
+    def test_should_keep_regimes_that_can_be_backtested(self, mocker, backtesting_tool, mock_backtest_result, mock_benchmark_data):
+        """A refused regime is dropped; the ones that ran are still reported."""
+        # Arrange
+        mock_data_manager_func = mocker.patch("finwiz.tools.backtesting_tool.get_historical_data_manager")
+        mock_backtesting_engine = mocker.patch("finwiz.quantitative.backtesting.get_backtesting_engine")
+        mocker.patch("finwiz.tools.backtesting_tool.get_performance_analyzer")
+
+        mock_dm = mocker.MagicMock()
+        mock_dm.fetch_historical_data.return_value = mock_benchmark_data
+        mock_data_manager_func.return_value = mock_dm
+
+        # Full window, then one refused regime, then successful ones.
+        mock_engine = mocker.MagicMock()
+        mock_engine.run_strategy_backtest.side_effect = [mock_backtest_result, None] + [mock_backtest_result] * 50
+        mock_backtesting_engine.return_value = mock_engine
+
+        # Act
+        result_json = backtesting_tool._run(symbol="AAPL", strategy="sma_crossover", include_regime_analysis=True)
+
+        # Assert
+        assert "NoneType" not in result_json
+        result = json.loads(result_json)
+        regimes_identified = len(backtesting_tool._identify_market_regimes(mock_benchmark_data))
+        assert len(result["regime_analysis"]) == regimes_identified - 1
+        assert all(r["strategy_return"] == approx(25.5) for r in result["regime_analysis"])
 
 
 class TestBacktestingToolFactory:

--- a/tests/unit/tools/test_quantitative_backtesting_analyzer.py
+++ b/tests/unit/tools/test_quantitative_backtesting_analyzer.py
@@ -1,0 +1,75 @@
+"""Unit tests for perform_backtesting (quantitative analysis tool's backtest path)."""
+
+import json
+from datetime import datetime
+
+import pandas as pd
+
+from finwiz.schemas.tools import QuantitativeAnalysisInput
+from finwiz.tools.quantitative_backtesting_analyzer import perform_backtesting
+
+
+def _input_data() -> QuantitativeAnalysisInput:
+    return QuantitativeAnalysisInput(symbol="AAPL", asset_class="stock", analysis_type="backtest")
+
+
+def _price_data() -> pd.DataFrame:
+    dates = pd.date_range(start="2024-01-01", periods=30, freq="D")
+    return pd.DataFrame({"Close": [100.0 + i for i in range(30)]}, index=dates)
+
+
+def test_returns_named_refusal_when_series_too_short_to_backtest(mocker):
+    """A short series is a refusal by name, never an internal NoneType message.
+
+    ``run_strategy_backtest`` returns None when the fetched series is shorter
+    than the strategy's lookback plus warm-up. Reading attributes off that None
+    used to raise AttributeError, which the shared except turned into
+    "Backtesting error: 'NoneType' object has no attribute 'strategy_name'" --
+    an internal detail handed to an agent in place of the reason.
+    """
+    engine = mocker.MagicMock()
+    engine.run_strategy_backtest.return_value = None
+
+    result = perform_backtesting(_price_data(), _input_data(), datetime(2024, 1, 1), datetime(2024, 1, 30), engine)
+
+    assert "NoneType" not in result
+    assert "AAPL" in result
+    assert "Insufficient data" in result
+    # The bar count the strategy needs: long_period 50 + 10-bar warm-up buffer.
+    assert "60" in result
+
+
+def test_returns_backtest_json_when_engine_produces_a_result(mocker):
+    """The success path still serialises the engine result unchanged."""
+    engine = mocker.MagicMock()
+    backtest = engine.run_strategy_backtest.return_value
+    backtest.strategy_name = "SimpleMovingAverageStrategy"
+    backtest.total_return = 25.5
+    backtest.annualized_return = 12.8
+    backtest.sharpe_ratio = 1.25
+    backtest.max_drawdown = -8.5
+    backtest.total_trades = 35
+    backtest.win_rate = 0.65
+    backtest.volatility = 16.2
+    backtest.var_95 = -2.1
+    backtest.start_date = datetime(2024, 1, 1)
+    backtest.end_date = datetime(2024, 1, 30)
+    backtest.initial_capital = 100000.0
+    backtest.final_value = 125500.0
+
+    result = json.loads(perform_backtesting(_price_data(), _input_data(), datetime(2024, 1, 1), datetime(2024, 1, 30), engine))
+
+    assert result["symbol"] == "AAPL"
+    assert result["strategy_name"] == "SimpleMovingAverageStrategy"
+    assert result["total_return"] == 25.5
+
+
+def test_reports_engine_failures_as_errors(mocker):
+    """A raise is still an error -- only the short-series case is a refusal."""
+    engine = mocker.MagicMock()
+    engine.run_strategy_backtest.side_effect = RuntimeError("cerebro exploded")
+
+    result = perform_backtesting(_price_data(), _input_data(), datetime(2024, 1, 1), datetime(2024, 1, 30), engine)
+
+    assert "Backtesting error" in result
+    assert "cerebro exploded" in result

--- a/tests/unit/tools/test_quantitative_comprehensive_analyzer.py
+++ b/tests/unit/tools/test_quantitative_comprehensive_analyzer.py
@@ -160,11 +160,16 @@ class TestBacktestFailureIsolation:
         assert result["backtest_result"]["volatility"] == 10.0
         assert result["performance_metrics"] is None
         assert result["technical_analysis"] is not None
-        # risk_metrics is sourced from the backtest only, unscaled -- no
-        # mixing with perf_metrics' fractional scale (see module docstring
-        # and generate_recommendation's docstring for why that mixing is
-        # unsafe: BacktestResult figures are percent-scaled, PerformanceMetrics
-        # figures are fractional, and only volatility has a normalizer).
+        # risk_metrics is sourced from the backtest only, passed through
+        # exactly as BacktestResult reports it (percent-scaled -- -3.0 here
+        # means a -3% drawdown) -- no mixing with perf_metrics' fractional
+        # scale (see generate_recommendation's docstring for why that mixing
+        # is unsafe: only volatility has a normalizer, max_drawdown does
+        # not). DeepAnalysisDataCollector._flatten_recursive additionally
+        # excludes this whole risk_metrics block from the scorer's flat dict
+        # (Task 15 review round 2) precisely because it is percent-scaled
+        # and would otherwise be misread against the scorer's fractional
+        # thresholds -- see test_deep_analysis_data_collector.py::TestFlattenExcludesPercentScaledDuplicates.
         assert result["quantitative_recommendation"]["risk_metrics"]["max_drawdown"] == -3.0
         assert result["quantitative_recommendation"]["risk_metrics"]["volatility"] == 10.0
 

--- a/tests/unit/tools/test_quantitative_comprehensive_analyzer.py
+++ b/tests/unit/tools/test_quantitative_comprehensive_analyzer.py
@@ -1,0 +1,190 @@
+"""Unit tests for perform_comprehensive_analysis in quantitative_comprehensive_analyzer.py.
+
+Technical analysis, backtesting, and performance analysis are three
+independent computations over the same price history. Before this fix, all
+three lived inside one shared try/except: a refusal or crash in ANY of them
+-- for example a backtest whose series is shorter than the strategy's
+lookback window -- discarded the OTHER TWO as well, even though they had
+already succeeded independently. That is the actual mechanism behind
+"drops the holding's entire quantitative payload": volatility comes from
+performance_metrics, not from the backtest, so a backtest-side failure used
+to take volatility down with it for no reason connected to volatility
+itself. See Task 15.
+"""
+
+import json
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from finwiz.quantitative.performance import PerformanceAnalyzer
+from finwiz.quantitative.technical import TechnicalAnalysisEngine
+from finwiz.schemas.tools import QuantitativeAnalysisInput
+from finwiz.tools.quantitative_comprehensive_analyzer import perform_comprehensive_analysis
+
+
+def _ohlcv(rows: int) -> pd.DataFrame:
+    """Deterministic synthetic OHLCV data -- no loop-grown series, no network."""
+    idx = pd.bdate_range("2024-01-01", periods=rows)
+    rng = np.random.default_rng(0)
+    close = 100 + np.cumsum(rng.normal(0, 1, rows))
+    close = np.maximum(close, 1.0)
+    return pd.DataFrame(
+        {
+            "Open": close * 0.99,
+            "High": close * 1.01,
+            "Low": close * 0.98,
+            "Close": close,
+            "Volume": rng.integers(1000, 5000, rows).astype(float),
+        },
+        index=idx,
+    )
+
+
+@pytest.fixture
+def input_data() -> QuantitativeAnalysisInput:
+    return QuantitativeAnalysisInput(symbol="TEST", asset_class="stock")
+
+
+@pytest.fixture
+def date_range() -> tuple[datetime, datetime]:
+    end_date = datetime(2024, 6, 1)
+    start_date = end_date - timedelta(days=90)
+    return start_date, end_date
+
+
+@pytest.fixture
+def technical_engine() -> TechnicalAnalysisEngine:
+    return TechnicalAnalysisEngine()
+
+
+@pytest.fixture
+def performance_analyzer() -> PerformanceAnalyzer:
+    return PerformanceAnalyzer()
+
+
+class TestBacktestFailureIsolation:
+    """A backtest refusal or crash must not discard technical/performance results."""
+
+    def test_backtest_none_preserves_performance_volatility(self, mocker, input_data, date_range, technical_engine, performance_analyzer):
+        """run_strategy_backtest returning None (a short-series refusal, per
+        Task 15's backtesting.py fix) must still yield a valid comprehensive
+        result with performance_metrics.volatility populated -- that is
+        where the scorer reads volatility from (deep_analysis_data_collector
+        .flatten_collected_data), not from backtest_result."""
+        start_date, end_date = date_range
+        data = _ohlcv(65)
+        backtesting_engine = mocker.Mock()
+        backtesting_engine.run_strategy_backtest.return_value = None
+
+        result_json = perform_comprehensive_analysis(
+            data,
+            input_data,
+            start_date,
+            end_date,
+            technical_engine,
+            backtesting_engine,
+            performance_analyzer,
+        )
+
+        result = json.loads(result_json)
+        assert result["backtest_result"] is None
+        assert result["performance_metrics"]["volatility"] is not None
+        assert result["technical_analysis"] is not None
+
+    def test_backtest_exception_preserves_performance_volatility(self, mocker, input_data, date_range, technical_engine, performance_analyzer):
+        """Whatever the exact exception a crashing backtest raises (an
+        IndexError shaped like the 2026-08-15 run's "index N is out of
+        bounds for axis 0 with size N", a bare "list index out of range",
+        or anything else), it must not discard technical/performance
+        analysis that already succeeded independently."""
+        start_date, end_date = date_range
+        data = _ohlcv(65)
+        backtesting_engine = mocker.Mock()
+        backtesting_engine.run_strategy_backtest.side_effect = IndexError("index 65 is out of bounds for axis 0 with size 65")
+
+        result_json = perform_comprehensive_analysis(
+            data,
+            input_data,
+            start_date,
+            end_date,
+            technical_engine,
+            backtesting_engine,
+            performance_analyzer,
+        )
+
+        result = json.loads(result_json)
+        assert result["backtest_result"] is None
+        assert result["performance_metrics"]["volatility"] is not None
+
+    def test_performance_failure_preserves_backtest_and_technical(self, mocker, input_data, date_range, technical_engine):
+        """The isolation cuts both ways: a performance-analysis failure must
+        not discard a backtest result that already succeeded."""
+        start_date, end_date = date_range
+        data = _ohlcv(65)
+        backtesting_engine = mocker.Mock()
+        fake_backtest_result = mocker.Mock(
+            strategy_name="SimpleMovingAverageStrategy",
+            symbol="TEST",
+            total_return=1.0,
+            annualized_return=2.0,
+            sharpe_ratio=0.5,
+            max_drawdown=-3.0,
+            total_trades=1,
+            win_rate=1.0,
+            volatility=10.0,
+            var_95=None,
+            start_date=start_date,
+            end_date=end_date,
+            initial_capital=100000.0,
+            final_value=101000.0,
+        )
+        backtesting_engine.run_strategy_backtest.return_value = fake_backtest_result
+        performance_analyzer = mocker.Mock()
+        performance_analyzer.analyze_performance.side_effect = ZeroDivisionError("division by zero")
+
+        result_json = perform_comprehensive_analysis(
+            data,
+            input_data,
+            start_date,
+            end_date,
+            technical_engine,
+            backtesting_engine,
+            performance_analyzer,
+        )
+
+        result = json.loads(result_json)
+        assert result["backtest_result"] is not None
+        assert result["backtest_result"]["volatility"] == 10.0
+        assert result["performance_metrics"] is None
+        assert result["technical_analysis"] is not None
+
+    def test_all_three_failing_returns_a_clean_error_not_a_crash(self, mocker, input_data, date_range):
+        """When technical, backtest, and performance analysis all fail, the
+        function returns an error string rather than propagating an
+        unhandled exception up to the caller."""
+        start_date, end_date = date_range
+        data = _ohlcv(65)
+        technical_engine = mocker.Mock()
+        technical_engine.analyze_symbol.side_effect = RuntimeError("boom")
+        backtesting_engine = mocker.Mock()
+        backtesting_engine.run_strategy_backtest.side_effect = RuntimeError("boom")
+        performance_analyzer = mocker.Mock()
+        performance_analyzer.analyze_performance.side_effect = RuntimeError("boom")
+
+        result = perform_comprehensive_analysis(
+            data,
+            input_data,
+            start_date,
+            end_date,
+            technical_engine,
+            backtesting_engine,
+            performance_analyzer,
+        )
+
+        assert isinstance(result, str)
+        assert "error" in result.lower()
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result)

--- a/tests/unit/tools/test_quantitative_comprehensive_analyzer.py
+++ b/tests/unit/tools/test_quantitative_comprehensive_analyzer.py
@@ -160,6 +160,13 @@ class TestBacktestFailureIsolation:
         assert result["backtest_result"]["volatility"] == 10.0
         assert result["performance_metrics"] is None
         assert result["technical_analysis"] is not None
+        # risk_metrics is sourced from the backtest only, unscaled -- no
+        # mixing with perf_metrics' fractional scale (see module docstring
+        # and generate_recommendation's docstring for why that mixing is
+        # unsafe: BacktestResult figures are percent-scaled, PerformanceMetrics
+        # figures are fractional, and only volatility has a normalizer).
+        assert result["quantitative_recommendation"]["risk_metrics"]["max_drawdown"] == -3.0
+        assert result["quantitative_recommendation"]["risk_metrics"]["volatility"] == 10.0
 
     def test_all_three_failing_returns_a_clean_error_not_a_crash(self, mocker, input_data, date_range):
         """When technical, backtest, and performance analysis all fail, the
@@ -188,3 +195,109 @@ class TestBacktestFailureIsolation:
         assert "error" in result.lower()
         with pytest.raises(json.JSONDecodeError):
             json.loads(result)
+
+
+class TestNoFabricatedRiskMetrics:
+    """Review round 1, Critical: a fabricated 0.0 in risk_metrics used to
+    leak into the scorer's flat dict (via
+    DeepAnalysisDataCollector._flatten_recursive, which walks the whole
+    quantitative_analysis payload and picks up the first "volatility" key it
+    finds anywhere -- including quantitative_recommendation.risk_metrics)
+    and defeat three of this plan's own defenses at once: Task 4/5's
+    price-history volatility fallback (which only fires when the field is
+    genuinely absent), and the Task 6 critical-field gate (which only
+    refuses a holding by name when the field is missing). A 0.0 satisfies
+    both checks and scores an unanalyzable holding as the safest one in the
+    portfolio. These tests verify the fix end to end, through the real
+    downstream consumers, not just perform_comprehensive_analysis in
+    isolation."""
+
+    def test_short_series_omits_risk_metrics_and_gate_refuses_by_name(self, mocker, input_data, date_range, technical_engine, performance_analyzer):
+        """Reproduces the reviewer's scenario with real engines, nothing
+        mocked: a single row of data is enough for analyze_symbol to
+        succeed trivially (no indicator has enough history to fire, so
+        there are simply no signals), but too short for the backtest
+        (needs >= 60 bars, refuses with None) and too short for
+        analyze_performance (pct_change().dropna() on 1 row yields 0
+        returns, raising ZeroDivisionError internally).
+
+        Verifies, through the real DeepAnalysisDataCollector.flatten_collected_data
+        and the real critical_fields_config.validate_critical_fields -- not just
+        perform_comprehensive_analysis's own JSON -- that:
+        1. quantitative_recommendation.risk_metrics has no volatility/max_drawdown key.
+        2. The flattened dict the scorer receives has no "volatility" key.
+        3. The critical-field gate raises CriticalFieldError naming volatility
+           as (missing), not as an invalid/absurd value -- i.e. the holding is
+           refused by name, not scored as risk-free.
+        """
+        from finwiz.config.critical_fields_config import CriticalFieldError, validate_critical_fields
+        from finwiz.orchestrators.deep_analysis_data_collector import DeepAnalysisDataCollector
+
+        start_date, end_date = date_range
+        data = _ohlcv(1)
+        backtesting_engine = mocker.Mock()
+        backtesting_engine.run_strategy_backtest.return_value = None
+
+        result_json = perform_comprehensive_analysis(
+            data,
+            input_data,
+            start_date,
+            end_date,
+            technical_engine,
+            backtesting_engine,
+            performance_analyzer,
+        )
+
+        result = json.loads(result_json)
+        assert result["backtest_result"] is None
+        assert result["performance_metrics"] is None
+        assert result["technical_analysis"] is not None
+
+        risk_metrics = result["quantitative_recommendation"]["risk_metrics"]
+        assert "volatility" not in risk_metrics, f"fabricated volatility leaked into risk_metrics: {risk_metrics}"
+        assert "max_drawdown" not in risk_metrics, f"fabricated max_drawdown leaked into risk_metrics: {risk_metrics}"
+
+        # Downstream: the real flattener the scorer's data collector uses.
+        collector = DeepAnalysisDataCollector(state=mocker.MagicMock())
+        collected = {
+            "ticker": "TEST",
+            "asset_class": "stock",
+            "ticker_info": {"beta": 1.0},  # short-circuits the network-hitting beta fallback
+            "quantitative_analysis": result,
+        }
+        flattened = collector.flatten_collected_data(collected)
+        assert "volatility" not in flattened, f"fabricated volatility reached the scorer's flat dict: {flattened.get('volatility')}"
+
+        # The gate: refuses by name, not silently passes a fabricated zero.
+        with pytest.raises(CriticalFieldError) as exc_info:
+            validate_critical_fields("TEST", "stock", flattened)
+        assert "volatility (missing)" in exc_info.value.missing_fields
+
+    def test_technical_failure_does_not_fabricate_signal_or_counts(self, mocker, input_data, date_range, performance_analyzer):
+        """When technical analysis fails, technical_signal must not present
+        the fabricated "HOLD" as if it were a computed neutral signal, and
+        bullish/bearish signal counts must not be fabricated as 0 -- both
+        looked like real computed values before this fix."""
+        start_date, end_date = date_range
+        data = _ohlcv(65)
+        technical_engine = mocker.Mock()
+        technical_engine.analyze_symbol.side_effect = RuntimeError("boom")
+        backtesting_engine = mocker.Mock()
+        backtesting_engine.run_strategy_backtest.return_value = None
+
+        result_json = perform_comprehensive_analysis(
+            data,
+            input_data,
+            start_date,
+            end_date,
+            technical_engine,
+            backtesting_engine,
+            performance_analyzer,
+        )
+
+        result = json.loads(result_json)
+        assert result["technical_analysis"] is None
+        recommendation = result["quantitative_recommendation"]
+        assert recommendation["technical_signal"] == "N/A"
+        assert "bullish_signals" not in recommendation["key_indicators"]
+        assert "bearish_signals" not in recommendation["key_indicators"]

--- a/tests/unit/utils/test_json_to_html_converter.py
+++ b/tests/unit/utils/test_json_to_html_converter.py
@@ -373,3 +373,11 @@ class TestParseRawOutput:
         # Assert
         assert result["formula"] == "a=b+c"
         assert result["equation"] == "x=1"
+
+    def test_should_not_map_the_retired_discovery_latest_name(self, converter):
+        """discovery_latest.json has no writer anywhere; the mapping entry is dead (task-11, 11a)."""
+        assert "discovery_latest.json" not in converter.TEMPLATE_MAPPING
+
+    def test_should_still_map_discovery_output_glob_to_the_same_template(self, converter):
+        """The glob pattern discovery actually writes files under stays mapped."""
+        assert converter.TEMPLATE_MAPPING["discovery_output_*.json"] == "discovery_latest.html"

--- a/uv.lock
+++ b/uv.lock
@@ -1146,10 +1146,10 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.14.1" },
+    { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "backtrader", specifier = ">=1.9.78.123" },
     { name = "beautifulsoup4", specifier = ">=4.15.0" },
-    { name = "crewai", specifier = ">=1.15.4" },
+    { name = "crewai", specifier = ">=1.15.12" },
     { name = "crewai-custom-tools", git = "https://github.com/fjacquet/crewai-custom-tools.git?rev=v0.6.0" },
     { name = "empyrical-reloaded", specifier = ">=0.5.12" },
     { name = "fear-and-greed", specifier = ">=0.4" },
@@ -1163,7 +1163,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.94.1" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "numpy", specifier = ">=2.5.1" },
-    { name = "pandas", specifier = ">=2.3.2" },
+    { name = "pandas", specifier = ">=3.0.5" },
     { name = "plotly", specifier = ">=6.8.0" },
     { name = "psutil", specifier = ">=7.2.2" },
     { name = "pyportfolioopt", specifier = ">=1.6.0" },
@@ -1181,7 +1181,7 @@ requires-dist = [
 dev = [
     { name = "bandit", specifier = ">=1.8.6" },
     { name = "cyclonedx-bom", specifier = ">=7.3.1" },
-    { name = "faker", specifier = ">=33.1.0" },
+    { name = "faker", specifier = ">=40.36.0" },
     { name = "hypothesis", specifier = ">=6.155.7" },
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "pandas-stubs", specifier = ">=3.0.3.260530" },


### PR DESCRIPTION
Implements §4 of `docs/superpowers/specs/2026-08-15-report-rethink-design.md` — the pipeline half of the report rethink. Plan B (the report itself) is not in this branch.

## Why

A family financial report presented partial results as authoritative: 22 of 64 holdings lost to un-retried Perplexity rate limits, 3 more to a derivable field treated as missing, an 11-ticker discovery universe rendered as "0 New Opportunities Identified", and hardcoded `VTI`/`VXUS`/`BND` "A+" opportunities injected into `a_plus_*.json` on any pipeline exception.

The governing rule throughout: **recover what is derivable, refuse by name what is not.** Never an assumption, a fabrication, or a confident zero presented as a measurement.

## What changed

| Area | Change |
|---|---|
| Perplexity resilience | Retry with exponential backoff + jitter; a loop-agnostic process-wide concurrency throttle; `TransientStageError` so the declared `@stage(retries=1)` is actually reachable |
| Cache | Stale horizon 14d → 90d, so an old fact-pack can still rescue a rate-limited run |
| Volatility | Derived from real `price_history` before the critical-field gate; `beta`'s hardcoded `1.0` deliberately left *after* the gate so it cannot rescue a holding |
| Validation | Percent-scaled volatility normalised instead of rejected; non-finite (`NaN`/`inf`) refused; a present-but-absurd value reports `(invalid value: N)`, not `(missing)` |
| Discovery | Ticker hygiene applied to the mined universe; seed-ETF override precedence bug fixed; a 50-candidate floor with the shortfall logged rather than scanned silently |
| Fabrication | The hardcoded A+ fallback deleted from all three discovery analyzers; a broken run now reports as broken instead of logging `✅ ... 0 opportunities found` |
| Dangling reads | `discovery_latest.json` retired — one reader rewired to the real producer and shape, two that never had a producer now refuse by name |
| Diagnostics | Full pre-filter scored candidate list persisted, so a zero is auditable |
| Factor score | Calibrated so a genuinely strong candidate can reach the C floor; a mediocre one still cannot |
| Cache metadata | Snapshot before serialising, `default=str` added — a datetime silently corrupted the file before |
| Quantitative | Technical / backtest / performance isolated, so one phase's failure no longer discards the other two; absent risk figures omitted rather than substituted with `0.0` |

## Testing

`make check` green end to end: **4901 passed, 31 skipped, 0 failures** (baseline 4802), plus lint, mypy, unittest.mock ban, file-size, docs-validate, stage contract, complexity, dead code.

Every task was implemented TDD and reviewed by an independent agent against named risks; findings were re-reviewed until closed. Several tests were mutation-verified — the fix was temporarily reverted to confirm the test actually fails without it.

## What this branch does NOT deliver

- **Full-run verification.** The plan's Task 16 (a real `crewai flow kickoff`) has not run. The coverage claim is unverified against live data.
- **Discovery surfacing opportunities.** `factor * fit` can only shrink a standalone score, so a calibrated-strong candidate still lands below the actionability floor at ordinary portfolio fit. A-band alternative sourcing is structurally unreachable while `fit < 0.85`. This is measured, not suspected — see the ledger.
- **The five out-of-bounds errors in spec §4.5.** Three agents independently failed to reproduce them; a fourth searched and found no out-of-bounds path at all. They are almost certainly stale entries from an accumulating error log. A genuine structural defect was fixed in that area instead.
- **Throttling `strategic_research`.** It fans out three un-retried Perplexity calls per holding outside the new throttle. Named as a risk in spec §7; filed, not fixed.

Full execution record, including 30 rulings and every parked finding: `.superpowers/sdd/2026-08-15-pipeline-coverage/progress.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014u4DpuRv7j4QV5SGgN5oJn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discovery now sanitizes symbols, honors seed selections, and maintains a broader candidate universe where possible.
  * Complete scored discovery results are saved for review before filtering.
  * Volatility can be derived from available price history when missing.
  * Backtests now identify insufficient historical data and respond clearly.
  * Alternative recommendations filter results by asset class and quality band.

* **Bug Fixes**
  * Improved retry handling and concurrency protection for research requests.
  * Removed fabricated opportunity and risk results when analysis data is unavailable.
  * Discovery and quantitative analyses now report unavailable data explicitly.
  * Extended stale fact-pack and cache usability to 90 days.

* **Documentation**
  * Updated discovery feature-flag guidance and implementation plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->