### PR TITLE
docs: render architecture and flow diagrams as mermaid

### DIFF
--- a/docs/development/DEVELOPER_GUIDE.md
+++ b/docs/development/DEVELOPER_GUIDE.md
@@ -20,42 +20,25 @@ Comprehensive guide for developers contributing to or extending FinWiz.
 
 FinWiz follows a modular, microservices-inspired architecture built on CrewAI's agent framework.
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     Flow Orchestrator                        │
-│                  (CrewAI Flow - Pydantic State)             │
-└────────┬────────────────────────────────────────────┬────────┘
-         │                                            │
-         ▼                                            ▼
-┌──────────────────┐                        ┌──────────────────┐
-│   Orchestrators  │                        │   Crews (AI)     │
-│  (Business Logic)│                        │  (Analysis)      │
-├──────────────────┤                        ├──────────────────┤
-│ • Portfolio Review│                       │ • Stock Crew     │
-│ • Rebalancing    │                        │ • ETF Crew       │
-│ • Decisions      │                        │ • Crypto Crew    │
-└────────┬─────────┘                        │ • Deep Analysis  │
-         │                                  │ • Discovery      │
-         ▼                                  └─────────┬────────┘
-┌──────────────────┐                                 │
-│  Scoring Engine  │                                 ▼
-│   (Python)       │                        ┌──────────────────┐
-├──────────────────┤                        │      Tools       │
-│ • Deep Analysis  │                        ├──────────────────┤
-│ • Portfolio      │                        │ • Quantitative   │
-│ • Risk           │                        │ • Sentiment      │
-└────────┬─────────┘                        │ • Technical      │
-         │                                  │ • Data Access    │
-         ▼                                  └─────────┬────────┘
-┌──────────────────┐                                 │
-│  Reporting       │                                 ▼
-│  (Jinja2)        │                        ┌──────────────────┐
-├──────────────────┤                        │   Integration    │
-│ • HTML Reports   │                        ├──────────────────┤
-│ • Templates      │                        │ • Data Accessor  │
-│ • Formatters     │                        │ • Validation     │
-└──────────────────┘                        │ • Caching        │
-                                            └──────────────────┘
+```mermaid
+flowchart TD
+    Flow["Flow Orchestrator<br/>(CrewAI Flow - Pydantic State)"]
+
+    Orch["Orchestrators (Business Logic)<br/>• Portfolio Review<br/>• Rebalancing<br/>• Decisions"]
+    Crews["Crews (AI) (Analysis)<br/>• Stock Crew<br/>• ETF Crew<br/>• Crypto Crew<br/>• Deep Analysis<br/>• Discovery"]
+
+    Scoring["Scoring Engine (Python)<br/>• Deep Analysis<br/>• Portfolio<br/>• Risk"]
+    Tools["Tools<br/>• Quantitative<br/>• Sentiment<br/>• Technical<br/>• Data Access"]
+
+    Reporting["Reporting (Jinja2)<br/>• HTML Reports<br/>• Templates<br/>• Formatters"]
+    Integration["Integration<br/>• Data Accessor<br/>• Validation<br/>• Caching"]
+
+    Flow --> Orch
+    Flow --> Crews
+    Orch --> Scoring
+    Crews --> Tools
+    Scoring --> Reporting
+    Tools --> Integration
 ```
 
 ### Core Design Principles

--- a/docs/explanations/DATA_QUALITY_AND_FLOW_GUIDE.md
+++ b/docs/explanations/DATA_QUALITY_AND_FLOW_GUIDE.md
@@ -89,46 +89,13 @@ class HoldingDecision(BaseModel):
 
 The system follows a strict data flow from generation to report:
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    1. DATA GENERATION                            │
-│  Crews generate rich analysis with proper grades and scores     │
-└─────────────────────────────────────────────────────────────────┘
-                              ↓
-┌─────────────────────────────────────────────────────────────────┐
-│                    2. DATA STORAGE                               │
-│  Crew outputs stored in output/{crew_name}/ directories         │
-│  - stock_output_*.json                                           │
-│  - etf_output_*.json                                             │
-│  - crypto_output_*.json                                          │
-│  - portfolio_review.json                                         │
-└─────────────────────────────────────────────────────────────────┘
-                              ↓
-┌─────────────────────────────────────────────────────────────────┐
-│                    3. DATA RETRIEVAL                             │
-│  DataConsolidationValidator ensures data can be retrieved       │
-│  - Validates crew data exists                                    │
-│  - Checks data structure integrity                               │
-│  - Fails fast if data missing or corrupted                       │
-└─────────────────────────────────────────────────────────────────┘
-                              ↓
-┌─────────────────────────────────────────────────────────────────┐
-│                    4. DATA CONSOLIDATION                         │
-│  ReportConsolidator merges crew exports into one report          │
-│  - Loads deep analysis exports                                   │
-│  - Validates export structure                                    │
-│  - Tracks per-crew execution status                              │
-│  - Records validation errors in the report                       │
-└─────────────────────────────────────────────────────────────────┘
-                              ↓
-┌─────────────────────────────────────────────────────────────────┐
-│                    5. REPORT GENERATION                          │
-│  ReportDataValidator ensures complete inputs                    │
-│  - Validates all required fields present                         │
-│  - Detects "NOT PROVIDED" placeholders                           │
-│  - Checks for fallback Grade D patterns                          │
-│  - Refuses to generate report if data incomplete                 │
-└─────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    A["1. DATA GENERATION<br/>Crews generate rich analysis with proper grades and scores"]
+    A --> B["2. DATA STORAGE<br/>Crew outputs stored in output/{crew_name}/ directories<br/>- stock_output_*.json<br/>- etf_output_*.json<br/>- crypto_output_*.json<br/>- portfolio_review.json"]
+    B --> C["3. DATA RETRIEVAL<br/>DataConsolidationValidator ensures data can be retrieved<br/>- Validates crew data exists<br/>- Checks data structure integrity<br/>- Fails fast if data missing or corrupted"]
+    C --> D["4. DATA CONSOLIDATION<br/>ReportConsolidator merges crew exports into one report<br/>- Loads deep analysis exports<br/>- Validates export structure<br/>- Tracks per-crew execution status<br/>- Records validation errors in the report"]
+    D --> E["5. REPORT GENERATION<br/>ReportDataValidator ensures complete inputs<br/>- Validates all required fields present<br/>- Detects 'NOT PROVIDED' placeholders<br/>- Checks for fallback Grade D patterns<br/>- Refuses to generate report if data incomplete"]
 ```
 
 ### Data Generation Phase

--- a/docs/explanations/index.md
+++ b/docs/explanations/index.md
@@ -163,53 +163,34 @@ Understand design decisions and trade-offs:
 
 ### System Architecture
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     Flow Orchestrator                        │
-│                  (CrewAI Flow - Pydantic State)             │
-└────────┬────────────────────────────────────────────┬────────┘
-         │                                            │
-         ▼                                            ▼
-┌──────────────────┐                        ┌──────────────────┐
-│   Orchestrators  │                        │   Crews (AI)     │
-│  (Business Logic)│                        │  (Analysis)      │
-└────────┬─────────┘                        └─────────┬────────┘
-         │                                            │
-         ▼                                            ▼
-┌──────────────────┐                        ┌──────────────────┐
-│  Scoring Engine  │                        │      Tools       │
-│   (Python)       │                        │  (Data Access)   │
-└────────┬─────────┘                        └─────────┬────────┘
-         │                                            │
-         ▼                                            ▼
-┌──────────────────┐                        ┌──────────────────┐
-│  Reporting       │                        │   Integration    │
-│  (Jinja2)        │                        │  (Data Sources)  │
-└──────────────────┘                        └──────────────────┘
+```mermaid
+flowchart TD
+    A["Flow Orchestrator<br/>(CrewAI Flow - Pydantic State)"]
+    A --> B["Orchestrators<br/>(Business Logic)"]
+    A --> C["Crews (AI)<br/>(Analysis)"]
+    B --> D["Scoring Engine<br/>(Python)"]
+    C --> E["Tools<br/>(Data Access)"]
+    D --> F["Reporting<br/>(Jinja2)"]
+    E --> G["Integration<br/>(Data Sources)"]
 ```
 
 **Learn More**: [Architecture Overview](ARCHITECTURE.md)
 
 ### Data Flow
 
-```
-Portfolio CSV → Data Accessor → Validation → Cache
-                                                ↓
-                                           Batch Pre-fetch
-                                                ↓
-                                    ┌───────────┴───────────┐
-                                    ▼                       ▼
-                            Deep Analysis           Deep Analysis
-                            Crew #1                  Crew #2
-                                    ↓                       ↓
-                                 Scoring              Scoring
-                                 Engine               Engine
-                                    ↓                       ↓
-                                    └───────────┬───────────┘
-                                                ▼
-                                         Report Generator
-                                                ↓
-                                          HTML Reports
+```mermaid
+flowchart TD
+    A[Portfolio CSV] --> B[Data Accessor]
+    B --> C[Validation]
+    C --> D[Cache]
+    D --> E[Batch Pre-fetch]
+    E --> F["Deep Analysis Crew #1"]
+    E --> G["Deep Analysis Crew #2"]
+    F --> H[Scoring Engine]
+    G --> I[Scoring Engine]
+    H --> J[Report Generator]
+    I --> J
+    J --> K[HTML Reports]
 ```
 
 **Learn More**: [Data Quality Guide](DATA_QUALITY_AND_FLOW_GUIDE.md)

--- a/docs/explanations/python_pipeline/data-flow.md
+++ b/docs/explanations/python_pipeline/data-flow.md
@@ -8,68 +8,51 @@ The pipeline processes data through four sequential stages, with each stage prod
 
 ## Complete Data Flow
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│ Step 1: Deep Analysis (Python Scoring)                      │
-│                                                              │
-│ Portfolio Holdings                                           │
-│        ↓                                                     │
-│ analyze_portfolio_with_python()                             │
-│        ↓                                                     │
-│ For each holding:                                           │
-│   - Fetch real market data (QuantitativeAnalysisTool)      │
-│   - Calculate composite score (DeepAnalysisScorer)         │
-│   - Generate JSON export                                    │
-│   - Generate HTML report                                    │
-│        ↓                                                     │
-│ Output: JSON files in output/{asset_class}/                │
-│         HTML reports per holding                            │
-└─────────────────────────────────────────────────────────────┘
-                         ↓
-┌─────────────────────────────────────────────────────────────┐
-│ Step 2: A+ Discovery Integration                            │
-│                                                              │
-│ integrate_aplus_discovery_with_deep_analysis()              │
-│        ↓                                                     │
-│ Scan output directories:                                    │
-│   - output/stock/*.json                                     │
-│   - output/etf/*.json                                       │
-│   - output/crypto/*.json                                    │
-│        ↓                                                     │
-│ Filter A+ and A grade holdings                              │
-│        ↓                                                     │
-│ Output: Discovery results with opportunities list           │
-└─────────────────────────────────────────────────────────────┘
-                         ↓
-┌─────────────────────────────────────────────────────────────┐
-│ Step 3: Backtesting Pipeline                                │
-│                                                              │
-│ connect_backtesting_to_discovery_results()                  │
-│        ↓                                                     │
-│ Read A+ candidates from discovery                           │
-│        ↓                                                     │
-│ For each candidate:                                         │
-│   - Execute backtesting strategy                            │
-│   - Calculate performance metrics                           │
-│        ↓                                                     │
-│ Output: Backtesting results JSON                            │
-└─────────────────────────────────────────────────────────────┘
-                         ↓
-┌─────────────────────────────────────────────────────────────┐
-│ Step 4: Final Report Generation                             │
-│                                                              │
-│ generate_python_report()                                    │
-│        ↓                                                     │
-│ Consolidate all data:                                       │
-│   - Portfolio review                                        │
-│   - Deep analysis results                                   │
-│   - Discovery opportunities                                 │
-│   - Backtesting metrics                                     │
-│        ↓                                                     │
-│ Assemble HTML from f-string templates (no Jinja2 — see below)│
-│        ↓                                                     │
-│ Output: Final HTML report                                   │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph S1["Step 1: Deep Analysis (Python Scoring)"]
+        A1[Portfolio Holdings]
+        A2["analyze_portfolio_with_python()"]
+        A3["For each holding:<br/>Fetch real market data (QuantitativeAnalysisTool)<br/>Calculate composite score (DeepAnalysisScorer)<br/>Generate JSON export<br/>Generate HTML report"]
+        A4["Output: JSON files in output/{asset_class}/<br/>HTML reports per holding"]
+        A1 --> A2
+        A2 --> A3
+        A3 --> A4
+    end
+
+    subgraph S2["Step 2: A+ Discovery Integration"]
+        B1["integrate_aplus_discovery_with_deep_analysis()"]
+        B2["Scan output directories:<br/>output/stock/*.json<br/>output/etf/*.json<br/>output/crypto/*.json"]
+        B3["Filter A+ and A grade holdings"]
+        B4["Output: Discovery results with opportunities list"]
+        B1 --> B2
+        B2 --> B3
+        B3 --> B4
+    end
+
+    subgraph S3["Step 3: Backtesting Pipeline"]
+        C1["connect_backtesting_to_discovery_results()"]
+        C2["Read A+ candidates from discovery"]
+        C3["For each candidate:<br/>Execute backtesting strategy<br/>Calculate performance metrics"]
+        C4["Output: Backtesting results JSON"]
+        C1 --> C2
+        C2 --> C3
+        C3 --> C4
+    end
+
+    subgraph S4["Step 4: Final Report Generation"]
+        D1["generate_python_report()"]
+        D2["Consolidate all data:<br/>Portfolio review<br/>Deep analysis results<br/>Discovery opportunities<br/>Backtesting metrics"]
+        D3["Assemble HTML from f-string templates (no Jinja2 — see below)"]
+        D4["Output: Final HTML report"]
+        D1 --> D2
+        D2 --> D3
+        D3 --> D4
+    end
+
+    S1 --> S2
+    S2 --> S3
+    S3 --> S4
 ```
 
 ## Stage 1: Deep Analysis

--- a/docs/how-to/BATCH_PROCESSING.md
+++ b/docs/how-to/BATCH_PROCESSING.md
@@ -8,38 +8,17 @@ FinWiz's Batch Processing System revolutionizes portfolio analysis by implementi
 
 ### High-Level Flow
 
-```
-Portfolio Holdings (66 tickers)
-    ↓
-┌─────────────────────────────────────────────────────┐
-│  Phase 1: Batch Data Pre-Fetching (2-5 seconds)    │
-│                                                      │
-│  Yahoo Finance API: All 66 tickers in parallel     │
-│  Alpha Vantage API: Rate-limited requests (optional)│
-│                                                      │
-│  Result: Pre-fetched data cache for all tickers    │
-└─────────────────────────────────────────────────────┘
-    ↓
-┌─────────────────────────────────────────────────────┐
-│  Phase 2: Concurrent Crew Execution (15-35 min)    │
-│                                                      │
-│  Batch 1: [AAPL, MSFT, GOOGL, TSLA, NVDA]         │
-│  Batch 2: [AMZN, META, NFLX, CRM, ADBE]           │
-│  Batch 3: [ORCL, INTC, AMD, QCOM, AVGO]           │
-│  ...                                                │
-│  Batch 14: [Final remaining tickers]               │
-│                                                      │
-│  Each batch: 5 crews running in parallel           │
-│  Zero API latency (uses pre-fetched data)          │
-└─────────────────────────────────────────────────────┘
-    ↓
-┌─────────────────────────────────────────────────────┐
-│  Phase 3: Results Consolidation (< 1 minute)       │
-│                                                      │
-│  Collect all crew results                           │
-│  Generate performance metrics                       │
-│  Create consolidated portfolio analysis             │
-└─────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    Start["Portfolio Holdings (66 tickers)"]
+
+    Phase1["Phase 1: Batch Data Pre-Fetching (2-5 seconds)<br/>Yahoo Finance API: all 66 tickers in parallel<br/>Alpha Vantage API: rate-limited requests (optional)<br/>Result: pre-fetched data cache for all tickers"]
+
+    Phase2["Phase 2: Concurrent Crew Execution (15-35 min)<br/>Batch 1: [AAPL, MSFT, GOOGL, TSLA, NVDA]<br/>Batch 2: [AMZN, META, NFLX, CRM, ADBE]<br/>Batch 3: [ORCL, INTC, AMD, QCOM, AVGO]<br/>...<br/>Batch 14: [Final remaining tickers]<br/>Each batch: 5 crews running in parallel<br/>Zero API latency (uses pre-fetched data)"]
+
+    Phase3["Phase 3: Results Consolidation (&lt; 1 minute)<br/>Collect all crew results<br/>Generate performance metrics<br/>Create consolidated portfolio analysis"]
+
+    Start --> Phase1 --> Phase2 --> Phase3
 ```
 
 ### Key Components

--- a/docs/how-to/PYTHON_SCORING_ENGINE.md
+++ b/docs/how-to/PYTHON_SCORING_ENGINE.md
@@ -16,43 +16,15 @@ The FinWiz Python Scoring Engine is a deterministic, high-performance alternativ
 
 ### Component Architecture
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                 DeepAnalysisScorer                          │
-├─────────────────────────────────────────────────────────────┤
-│  calculate_composite_score()                                │
-│  ├── calculate_fundamental_score() (40% weight)             │
-│  ├── calculate_technical_score() (30% weight)               │
-│  └── calculate_risk_score() (30% weight)                    │
-│                                                             │
-│  assign_grade()                                             │
-│  generate_recommendation()                                  │
-│  generate_rationale()                                       │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                DeepAnalysisResult                           │
-├─────────────────────────────────────────────────────────────┤
-│  • Composite Score (0.0-1.0)                               │
-│  • Component Scores (fundamental, technical, risk)         │
-│  • Grade (A+, A, B, C, D, F)                              │
-│  • Recommendation (BUY, HOLD, SELL)                        │
-│  • Confidence Level (0.0-1.0)                              │
-│  • Detailed Rationale                                      │
-│  • Component Details (all calculations preserved)          │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│            Jinja2 Template Rendering                       │
-├─────────────────────────────────────────────────────────────┤
-│  • Professional HTML Report Generation                     │
-│  • French Language Localization                            │
-│  • Light/Dark Mode Support                                 │
-│  • Responsive Design                                        │
-│  • Asset-Specific Sections                                 │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    Scorer["DeepAnalysisScorer<br/>calculate_composite_score()<br/>• calculate_fundamental_score() (40% weight)<br/>• calculate_technical_score() (30% weight)<br/>• calculate_risk_score() (30% weight)<br/>assign_grade()<br/>generate_recommendation()<br/>generate_rationale()"]
+
+    Result["DeepAnalysisResult<br/>• Composite Score (0.0-1.0)<br/>• Component Scores (fundamental, technical, risk)<br/>• Grade (A+, A, B, C, D, F)<br/>• Recommendation (BUY, HOLD, SELL)<br/>• Confidence Level (0.0-1.0)<br/>• Detailed Rationale<br/>• Component Details (all calculations preserved)"]
+
+    Template["Jinja2 Template Rendering<br/>• Professional HTML Report Generation<br/>• French Language Localization<br/>• Light/Dark Mode Support<br/>• Responsive Design<br/>• Asset-Specific Sections"]
+
+    Scorer --> Result --> Template
 ```
 
 ## Scoring Methodology

--- a/docs/index.md
+++ b/docs/index.md
@@ -268,42 +268,15 @@ Professional-grade quantitative analysis framework:
 
 ## Architecture Overview
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     Flow Orchestrator                        │
-│                  (CrewAI Flow - Pydantic State)             │
-└────────┬────────────────────────────────────────────┬────────┘
-         │                                            │
-         ▼                                            ▼
-┌──────────────────┐                        ┌──────────────────┐
-│   Orchestrators  │                        │   Crews (AI)     │
-│  (Business Logic)│                        │  (Analysis)      │
-├──────────────────┤                        ├──────────────────┤
-│ • Portfolio Review│                       │ • Stock Crew     │
-│ • Rebalancing    │                        │ • ETF Crew       │
-│ • Decisions      │                        │ • Crypto Crew    │
-└────────┬─────────┘                        │ • Deep Analysis  │
-         │                                  │ • Discovery      │
-         ▼                                  └─────────┬────────┘
-┌──────────────────┐                                 │
-│  Scoring Engine  │                                 ▼
-│   (Python)       │                        ┌──────────────────┐
-├──────────────────┤                        │      Tools       │
-│ • Deep Analysis  │                        ├──────────────────┤
-│ • Portfolio      │                        │ • Quantitative   │
-│ • Risk           │                        │ • Sentiment      │
-└────────┬─────────┘                        │ • Technical      │
-         │                                  │ • Data Access    │
-         ▼                                  └─────────┬────────┘
-┌──────────────────┐                                 │
-│  Reporting       │                                 ▼
-│  (Jinja2)        │                        ┌──────────────────┐
-├──────────────────┤                        │   Integration    │
-│ • HTML Reports   │                        ├──────────────────┤
-│ • Templates      │                        │ • Data Accessor  │
-│ • Formatters     │                        │ • Validation     │
-└──────────────────┘                        │ • Caching        │
-                                            └──────────────────┘
+```mermaid
+flowchart TD
+    A["Flow Orchestrator<br/>(CrewAI Flow - Pydantic State)"]
+    A --> B["Orchestrators (Business Logic)<br/>• Portfolio Review<br/>• Rebalancing<br/>• Decisions"]
+    A --> C["Crews (AI) (Analysis)<br/>• Stock Crew<br/>• ETF Crew<br/>• Crypto Crew<br/>• Deep Analysis<br/>• Discovery"]
+    B --> D["Scoring Engine (Python)<br/>• Deep Analysis<br/>• Portfolio<br/>• Risk"]
+    C --> E["Tools<br/>• Quantitative<br/>• Sentiment<br/>• Technical<br/>• Data Access"]
+    D --> F["Reporting (Jinja2)<br/>• HTML Reports<br/>• Templates<br/>• Formatters"]
+    E --> G["Integration<br/>• Data Accessor<br/>• Validation<br/>• Caching"]
 ```
 
 ## Core Design Principles

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ wheels = [
 
 [[package]]
 name = "finwiz"
-version = "5.12.0"
+version = "5.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Seven ASCII box-drawn diagrams across the published docs become mermaid flowcharts. The site already supports mermaid (`mermaid2` plugin + a `pymdownx.superfences` custom fence in `mkdocs.yml`) and already renders it on seven other pages, so this follows the existing pattern rather than introducing one.

## What was deliberately left alone

Fifteen files contain box-drawing characters; eight needed no change at all.

- **Directory trees stay ASCII.** Mermaid is strictly worse than a `├──` tree for a file listing. `QUICK_REFERENCE.md`, `REPORT_FILE_STRUCTURE.md`, `test_structure_evolution.md`, `json-exports.md`, `template_configuration.md`, `setup-deployment-guide.md`, `python_pipeline_integration.md` and `quantitative_analysis.md` are trees, sample JSON, and code — nothing to convert.
- **Markdown tables** are already the right format.
- **Sample terminal output and report mockups** are not diagrams.
- **`docs/superpowers/**`** is untouched. Those specs and plans are records of past work; rewriting them would falsify the record.

## Fidelity

Each conversion is a translation, not a redesign — same nodes, same edges, same direction, same annotations. Specifically preserved: the 40% / 30% / 30% composite weights in the scoring engine diagram, the phase timings in batch processing (`2-5 seconds`, `15-35 min`, `< 1 minute`), and the `(no Jinja2 — see below)` annotation in the data-flow pipeline.

Also included: `chore(release): sync uv.lock to 5.13.0`. The v5.13.0 bump changed `pyproject.toml` only, leaving `uv.lock` recording `5.12.0`, so every `uv run` regenerated it — a permanently dirty tree that made pre-commit roll back unrelated commits. Found while committing this branch.

## Test plan

- `uv run mkdocs build --strict` — exit 0, verified independently after all edits were in place. The mermaid2 plugin log confirms each converted page is picked up (`found 1 diagrams`, `found 2 diagrams`).
- One pre-existing `INFO` line about a broken anchor in `how-to/OPERATIONS_GUIDE.md` (`#feedback-learning-system`) is unrelated to these files and predates the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014u4DpuRv7j4QV5SGgN5oJn