### PR TITLE
fix(reporting): the position count must describe the money beside it

### DIFF
--- a/src/finwiz/reporting/sections/portfolio_summary.py
+++ b/src/finwiz/reporting/sections/portfolio_summary.py
@@ -49,8 +49,21 @@ def generate_allocation_section(portfolio_review: PortfolioReview) -> str:
 """
         )
 
-    n_positions = len(portfolio_review.holdings)
+    # Count what the total is actually made of. ``total_value_eur`` is priced
+    # holdings only (see the field's own description), so captioning it with
+    # ``len(holdings)`` describes the money with the wrong set: a 2026-08-17 run
+    # showed 30 positions summing to 34 046 EUR labelled "64 positions", which
+    # understates the portfolio and inflates every weight via the missing
+    # denominator. The unpriced holdings get their own line rather than
+    # disappearing — a reader who cannot see them cannot question them.
+    n_positions = len(weighted)
     n_classes = len({h.asset_class for h in weighted})
+    n_unpriced = len(portfolio_review.holdings) - n_positions
+    unpriced_note = (
+        f'<div class="hero-meta muted">{n_unpriced} position{"s" if n_unpriced > 1 else ""} non valorisée{"s" if n_unpriced > 1 else ""} — exclue{"s" if n_unpriced > 1 else ""} du total et des pourcentages</div>'
+        if n_unpriced
+        else ""
+    )
 
     # Sort by weight desc so the largest exposure leads.
     rows = sorted(weighted, key=lambda h: h.weight or 0.0, reverse=True)
@@ -77,6 +90,7 @@ def generate_allocation_section(portfolio_review: PortfolioReview) -> str:
       <div class="hero-meta">Valeur totale du portefeuille</div>
       <div class="hero-value num">{_fmt_eur(total)}</div>
       <div class="hero-meta">{n_positions} positions · {n_classes} classes d'actifs</div>
+      {unpriced_note}
     </div>
 
     <h3>📊 Répartition par position</h3>

--- a/tests/unit/reporting/test_allocation_rendering.py
+++ b/tests/unit/reporting/test_allocation_rendering.py
@@ -155,3 +155,64 @@ class TestHoldingsAllocationColumns:
         first_row = tbody.split("</tr>")[0]
         n_td = first_row.count("<td")
         assert n_th == n_td, f"header cols {n_th} != pending row cols {n_td}"
+
+
+class TestTotalAndCountDescribeTheSameSet:
+    """The position count must describe the money shown beside it.
+
+    ``total_value_eur`` is priced holdings only (the schema says so), but the
+    hero captioned it with ``len(holdings)`` — every holding, priced or not. A
+    2026-08-17 run rendered 30 positions summing to 34 046 EUR under the label
+    "64 positions": the total understated the portfolio by roughly half, and
+    every weight was inflated by the missing denominator (ASML shown at 23.3 %).
+    Nothing on the page said so.
+    """
+
+    def test_the_count_matches_the_priced_holdings_the_total_is_built_from(self) -> None:
+        review = PortfolioReview(
+            as_of=datetime(2026, 8, 17),
+            total_value_eur=3000.0,
+            holdings=[
+                _make_holding(ticker="AAA", weight=0.6, eur_value=1800.0),
+                _make_holding(ticker="BBB", weight=0.4, eur_value=1200.0),
+                _make_holding(ticker="NESN.SW"),
+                _make_holding(ticker="UBSG.SW"),
+            ],
+        )
+
+        html = generate_allocation_section(review)
+
+        assert "2 positions" in html
+        assert "4 positions" not in html
+
+    def test_unpriced_holdings_are_disclosed_not_silently_dropped(self) -> None:
+        review = PortfolioReview(
+            as_of=datetime(2026, 8, 17),
+            total_value_eur=3000.0,
+            holdings=[
+                _make_holding(ticker="AAA", weight=1.0, eur_value=3000.0),
+                _make_holding(ticker="NESN.SW"),
+                _make_holding(ticker="UBSG.SW"),
+            ],
+        )
+
+        html = generate_allocation_section(review)
+
+        assert "2" in html
+        assert "non valoris" in html.lower(), "unpriced holdings vanish with no disclosure"
+
+    def test_a_fully_priced_portfolio_says_nothing_extra(self) -> None:
+        """The disclosure must appear only when something is actually missing."""
+        review = PortfolioReview(
+            as_of=datetime(2026, 8, 17),
+            total_value_eur=3000.0,
+            holdings=[
+                _make_holding(ticker="AAA", weight=0.6, eur_value=1800.0),
+                _make_holding(ticker="BBB", weight=0.4, eur_value=1200.0),
+            ],
+        )
+
+        html = generate_allocation_section(review)
+
+        assert "2 positions" in html
+        assert "non valoris" not in html.lower()


### PR DESCRIPTION
Found by the live 64-holding `crewai flow kickoff` on 2026-08-17.

## The defect

`generate_allocation_section` built its two headline numbers from different sets:

```python
n_positions = len(portfolio_review.holdings)   # every holding
weighted    = [h for h in ... if h.weight is not None]
total       = portfolio_review.total_value_eur  # priced holdings only
```

`total_value_eur` is priced holdings only — the field's own description says so — but the hero captioned it with the full holding count.

In that run the report rendered **30 positions summing to 34 046 €, labelled "64 positions"**. Two consequences, both facing a family reader with no way to detect either:

- **The portfolio total understated real wealth by roughly half**, because 34 unpriced holdings contributed nothing.
- **Every weight was inflated by the missing denominator.** ASML displayed at 23.3 % when its true share of the portfolio is far lower — overstating concentration risk in the one view meant to reveal it.

The unpriced holdings simply vanished from the breakdown. Nothing on the page indicated anything was missing.

## The fix

The count now comes from the same set as the total, and holdings that could not be priced get their own line rather than disappearing:

> `2 positions · 1 classes d'actifs`
> `2 positions non valorisées — exclues du total et des pourcentages`

That line appears only when something is actually missing.

This is deliberately independent of *why* prices fail. The upstream cause in that run — asset class guessed from ticker length — was fixed separately in #142. This one makes the report honest regardless: any future pricing failure now shows up instead of silently shrinking the portfolio.

## Test plan

- Three tests added, written before the fix. Two failed against the old code and pass now; the third is a control asserting a fully-priced portfolio gains no extra text, and passed both ways by design.
- `make test`: **5138 passed**, 31 skipped (5135 on main).
- CSS classes used by the new line (`hero-meta`, `muted`) verified present in the stylesheet — an emitted class with no rule is an invisible signal, which this repo has shipped before.

## Not in scope

The disclosure gives a count, not names. Listing which holdings went unpriced is a reasonable follow-up; it needs a design decision about where they belong in the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014u4DpuRv7j4QV5SGgN5oJn