### PR TITLE
ci: harden the Dependabot auto-merge workflow

### DIFF
--- a/.claude/skills/ai-minimalism/SKILL.md
+++ b/.claude/skills/ai-minimalism/SKILL.md
@@ -70,7 +70,7 @@ def generate_html_report(self) -> Task:
 ```python
 def generate_html_report(json_data: dict) -> str:
     """Generate HTML report using Jinja2 template."""
-    template = jinja_env.get_template('report.html')
+    template = jinja_env.get_template("report.html")
     return template.render(data=json_data)
     # CORRECT: Fast, cheap, testable
 ```

--- a/.claude/skills/crewai/SKILL.md
+++ b/.claude/skills/crewai/SKILL.md
@@ -29,10 +29,10 @@ def analyst(self) -> Agent:
     return Agent(
         config=self.agents_config["analyst"],
         tools=get_stock_crew_tools(include_rag=True),
-        reasoning=True,              # For complex analysis
-        max_reasoning_attempts=3,    # Prevent infinite loops
-        allow_delegation=False,      # Only for coordinators
-        verbose=True
+        reasoning=True,  # For complex analysis
+        max_reasoning_attempts=3,  # Prevent infinite loops
+        allow_delegation=False,  # Only for coordinators
+        verbose=True,
     )
 ```
 
@@ -41,13 +41,14 @@ def analyst(self) -> Agent:
 ```python
 from finwiz.utils.agent_validators import final_reporter
 
+
 @final_reporter  # Enforces empty tools
 @agent
 def investment_reporter(self) -> Agent:
     return Agent(
-        config=self.agents_config['investment_reporter'],
+        config=self.agents_config["investment_reporter"],
         tools=[],  # MUST be empty - enforced by decorator
-        verbose=True
+        verbose=True,
     )
 ```
 
@@ -90,10 +91,13 @@ analysis_task:
 from pydantic import BaseModel
 from crewai.flow import Flow, listen, start
 
+
 class FinwizState(BaseModel):
     """Type-safe state with validation."""
+
     analysis_results: Dict[str, Any] = {}
     processing_success: bool = False
+
 
 class FinwizFlow(Flow[FinwizState]):
     @start()
@@ -138,9 +142,9 @@ class FinwizFlow(Flow[FinwizState]):
 crew = Crew(
     agents=[analyst],  # Single agent
     tasks=self.tasks,  # Simple workflow
-    planning=False,    # Avoid overhead
-    reasoning=False,   # Fast execution
-    max_rpm=20
+    planning=False,  # Avoid overhead
+    reasoning=False,  # Fast execution
+    max_rpm=20,
 )
 ```
 
@@ -169,9 +173,9 @@ crew = Crew(
 ```python
 # Get standardized tool set
 tools = get_stock_crew_tools(
-    include_rag=True,           # Include RAG tools
+    include_rag=True,  # Include RAG tools
     include_quantitative=True,  # Include quantitative analysis
-    collection_suffix="stock"   # RAG collection suffix
+    collection_suffix="stock",  # RAG collection suffix
 )
 ```
 

--- a/.claude/skills/development/SKILL.md
+++ b/.claude/skills/development/SKILL.md
@@ -63,9 +63,10 @@ def calculate_sharpe_ratio(returns: list[float], risk_free_rate: float) -> float
     # Implementation with clear logic...
     return sharpe_ratio
 
+
 # ❌ BAD: Unclear names, no error handling
 def calc(r, rf):
-    return (sum(r)/len(r) - rf) / (sum([(x-sum(r)/len(r))**2 for x in r])/len(r))**0.5
+    return (sum(r) / len(r) - rf) / (sum([(x - sum(r) / len(r)) ** 2 for x in r]) / len(r)) ** 0.5
 ```
 
 ## Version Control Standards

--- a/.claude/skills/financial-libraries/SKILL.md
+++ b/.claude/skills/financial-libraries/SKILL.md
@@ -114,7 +114,8 @@ volatility = np.std(returns) * np.sqrt(252)
 
 # FUTURE (Empyrical for calculation)
 from empyrical import annual_volatility
-volatility = annual_volatility(returns, period='daily')
+
+volatility = annual_volatility(returns, period="daily")
 
 # KEEP (custom scoring threshold)
 if volatility <= 0.10:

--- a/.claude/skills/flow-architecture/SKILL.md
+++ b/.claude/skills/flow-architecture/SKILL.md
@@ -31,18 +31,22 @@ The original flow had discovery crews running BEFORE portfolio analysis. This is
 def validate_data_integration(self):
     pass
 
+
 @listen("validate_data_integration")
 def check_portfolio(self):  # Portfolio analysis FIRST
     pass
+
 
 @listen("analyze_and_update_portfolio")
 def check_crypto(self):  # Discovery AFTER
     pass
 
+
 # ❌ WRONG: Discovery before portfolio analysis
 @listen("validate_data_integration")
 def check_crypto(self):  # Discovery crew
     pass
+
 
 @listen(and_("check_crypto", "check_stock", "check_etf"))
 def check_portfolio(self):  # Portfolio analysis
@@ -261,7 +265,7 @@ def investment_reporter(self) -> Agent:
     return Agent(
         config=self.agents_config["investment_reporter"],
         tools=[],  # MUST be empty - enforced by decorator
-        verbose=True
+        verbose=True,
     )
 ```
 

--- a/.claude/skills/output-standards/SKILL.md
+++ b/.claude/skills/output-standards/SKILL.md
@@ -190,10 +190,10 @@ All user-facing content must be in French with:
 @agent
 def investment_reporter(self) -> Agent:
     return Agent(
-        config=self.agents_config['investment_reporter'],
+        config=self.agents_config["investment_reporter"],
         tools=[],  # MUST be empty - no external API calls
         reasoning=False,  # Fast consolidation, no complex reasoning
-        verbose=True
+        verbose=True,
     )
 ```
 
@@ -215,7 +215,7 @@ def generate_final_report(self) -> Task:
         """,
         expected_output="Complete HTML report in French with professional formatting",
         agent=self.investment_reporter(),
-        async_execution=False  # Final task must be synchronous
+        async_execution=False,  # Final task must be synchronous
     )
 ```
 

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -18,8 +18,10 @@ All public functions and methods MUST have complete type annotations:
 def analyze_stock(ticker: str, period: int = 365) -> StockAnalysis:
     return StockAnalysis(ticker=ticker, period=period)
 
+
 def log_analysis(ticker: str) -> None:
     logger.info(f"Analyzing {ticker}")
+
 
 # ❌ WRONG - Missing return type
 def analyze_stock(ticker: str):
@@ -90,22 +92,23 @@ logger.info(f"API key: {api_key}")
 ```python
 from pydantic import BaseModel, Field, field_validator
 
+
 class TickerInput(BaseModel):
     """Validate ticker input with strict security."""
 
     model_config = {
         "str_strip_whitespace": True,
         "str_upper": True,
-        "extra": "forbid"  # Reject unknown fields
+        "extra": "forbid",  # Reject unknown fields
     }
 
-    symbol: str = Field(..., pattern=r'^[A-Z]{1,5}$')
+    symbol: str = Field(..., pattern=r"^[A-Z]{1,5}$")
 
-    @field_validator('symbol')
+    @field_validator("symbol")
     @classmethod
     def validate_ticker(cls, v: str) -> str:
         if not v.isalpha():
-            raise ValueError('Ticker must contain only letters')
+            raise ValueError("Ticker must contain only letters")
         return v.upper()
 ```
 
@@ -155,6 +158,7 @@ from finwiz.utils.rate_limiter import RateLimiter
 
 limiter = RateLimiter(max_calls=20, period=60)
 
+
 @limiter.limit
 async def fetch_stock_data(ticker: str) -> dict:
     return await api_client.get(f"/stock/{ticker}")
@@ -180,10 +184,7 @@ async with httpx.AsyncClient() as client:
 
 ```python
 # ✅ CORRECT - Parameterized queries
-cursor.execute(
-    "SELECT * FROM stocks WHERE ticker = %s",
-    (ticker,)
-)
+cursor.execute("SELECT * FROM stocks WHERE ticker = %s", (ticker,))
 
 # ❌ WRONG - SQL injection risk
 cursor.execute(f"SELECT * FROM stocks WHERE ticker = '{ticker}'")
@@ -194,10 +195,11 @@ cursor.execute(f"SELECT * FROM stocks WHERE ticker = '{ticker}'")
 ```python
 from pathlib import Path
 
+
 # ✅ CORRECT - Validate paths
 def read_report(filename: str) -> str:
     # Validate filename
-    if not filename.replace('-', '').replace('_', '').isalnum():
+    if not filename.replace("-", "").replace("_", "").isalnum():
         raise ValueError("Invalid filename")
 
     # Resolve path safely
@@ -209,6 +211,7 @@ def read_report(filename: str) -> str:
         raise ValueError("Path traversal attempt")
 
     return file_path.read_text()
+
 
 # ❌ WRONG - Path traversal risk
 def read_report(filename: str) -> str:
@@ -222,6 +225,7 @@ def read_report(filename: str) -> str:
 import subprocess
 import shlex
 
+
 # ✅ CORRECT - Safe command execution
 def run_analysis(ticker: str) -> str:
     # Validate input
@@ -229,13 +233,9 @@ def run_analysis(ticker: str) -> str:
         raise ValueError("Invalid ticker")
 
     # Use list form (safer)
-    result = subprocess.run(
-        ["python", "analyze.py", ticker],
-        capture_output=True,
-        text=True,
-        timeout=30
-    )
+    result = subprocess.run(["python", "analyze.py", ticker], capture_output=True, text=True, timeout=30)
     return result.stdout
+
 
 # ❌ WRONG - Command injection risk
 def run_analysis(ticker: str) -> str:
@@ -273,7 +273,7 @@ import httpx
 
 client = httpx.AsyncClient(
     verify=True,  # Verify SSL certificates
-    timeout=30.0
+    timeout=30.0,
 )
 
 # ❌ WRONG - Insecure connection
@@ -284,12 +284,7 @@ client = httpx.AsyncClient(verify=False)
 
 ```python
 # Add security headers
-headers = {
-    "X-Content-Type-Options": "nosniff",
-    "X-Frame-Options": "DENY",
-    "X-XSS-Protection": "1; mode=block",
-    "Strict-Transport-Security": "max-age=31536000; includeSubDomains"
-}
+headers = {"X-Content-Type-Options": "nosniff", "X-Frame-Options": "DENY", "X-XSS-Protection": "1; mode=block", "Strict-Transport-Security": "max-age=31536000; includeSubDomains"}
 ```
 
 ## Security Checklist

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -34,10 +34,11 @@ We have 4 layers of enforcement:
 # ❌ BANNED - Will be blocked by all 4 enforcement layers
 from unittest.mock import Mock, patch, MagicMock, AsyncMock
 
+
 # ✅ REQUIRED - Only acceptable approach
 def test_example(mocker):
-    mock_obj = mocker.patch('module.function')
-    mock_obj.return_value = 'test'
+    mock_obj = mocker.patch("module.function")
+    mock_obj.return_value = "test"
 ```
 
 ## Standard Test Structure
@@ -47,15 +48,15 @@ def test_example(mocker):
 ```python
 def test_should_return_buy_recommendation_when_strong_metrics(mocker):
     # Arrange - Set up test data and mocks
-    mock_api = mocker.patch('finwiz.tools.yahoo_finance_tool.get_data')
-    mock_api.return_value = {'pe_ratio': 15, 'growth': 0.25}
+    mock_api = mocker.patch("finwiz.tools.yahoo_finance_tool.get_data")
+    mock_api.return_value = {"pe_ratio": 15, "growth": 0.25}
 
     # Act - Execute the code under test
-    result = analyze_stock('AAPL')
+    result = analyze_stock("AAPL")
 
     # Assert - Verify the results
-    assert result.recommendation == 'BUY'
-    mock_api.assert_called_once_with('AAPL')
+    assert result.recommendation == "BUY"
+    mock_api.assert_called_once_with("AAPL")
 ```
 
 ## Common Mocking Patterns
@@ -65,53 +66,53 @@ def test_should_return_buy_recommendation_when_strong_metrics(mocker):
 ```python
 def test_should_fetch_stock_data_when_valid_ticker(mocker):
     # Mock external API call
-    mock_get = mocker.patch('finwiz.tools.yahoo_finance_tool.yf.Ticker')
+    mock_get = mocker.patch("finwiz.tools.yahoo_finance_tool.yf.Ticker")
     mock_ticker = mocker.Mock()
-    mock_ticker.info = {'symbol': 'AAPL', 'price': 150.0}
+    mock_ticker.info = {"symbol": "AAPL", "price": 150.0}
     mock_get.return_value = mock_ticker
 
     # Test the function
-    result = get_stock_data('AAPL')
+    result = get_stock_data("AAPL")
 
     # Verify
-    assert result['symbol'] == 'AAPL'
-    assert result['price'] == 150.0
-    mock_get.assert_called_once_with('AAPL')
+    assert result["symbol"] == "AAPL"
+    assert result["price"] == 150.0
+    mock_get.assert_called_once_with("AAPL")
 ```
 
 ### Mock File Operations
 
 ```python
 def test_should_read_config_file(mocker):
-    mock_open = mocker.patch('builtins.open', mocker.mock_open(read_data='{"key": "value"}'))
+    mock_open = mocker.patch("builtins.open", mocker.mock_open(read_data='{"key": "value"}'))
 
-    result = load_config('config.json')
+    result = load_config("config.json")
 
-    assert result['key'] == 'value'
-    mock_open.assert_called_once_with('config.json')
+    assert result["key"] == "value"
+    mock_open.assert_called_once_with("config.json")
 ```
 
 ### Mock Environment Variables
 
 ```python
 def test_should_use_api_key_from_env(mocker):
-    mocker.patch.dict('os.environ', {'API_KEY': 'test_key'})
+    mocker.patch.dict("os.environ", {"API_KEY": "test_key"})
 
     result = get_api_key()
 
-    assert result == 'test_key'
+    assert result == "test_key"
 ```
 
 ### Mock Datetime
 
 ```python
 def test_should_use_current_timestamp(mocker):
-    mock_now = mocker.patch('datetime.datetime')
+    mock_now = mocker.patch("datetime.datetime")
     mock_now.now.return_value = datetime(2025, 3, 10)
 
     result = generate_report()
 
-    assert '2025-03-10' in result.timestamp
+    assert "2025-03-10" in result.timestamp
 ```
 
 ## CrewAI Testing Standards (CRITICAL)
@@ -158,6 +159,7 @@ def test_should_load_agent_configurations_from_yaml(self):
     assert "asset_analyst" in config
     assert "role" in config["asset_analyst"]
 
+
 def test_should_validate_asset_class_parameter(self):
     """Test validation logic without instantiating crew."""
     valid_asset_classes = ["stock", "etf", "crypto"]
@@ -188,6 +190,7 @@ def test_crew_execution(self, mocker):
 from faker import Faker
 
 fake = Faker()
+
 
 def test_portfolio_analysis():
     # Generate realistic test data
@@ -223,10 +226,12 @@ tests/
 def test_should_calculate_score():
     pass
 
+
 # Integration tests
 @pytest.mark.integration
 def test_should_fetch_real_stock_data():
     pass
+
 
 # Slow tests
 @pytest.mark.slow
@@ -298,9 +303,10 @@ If you see `unittest.mock` anywhere:
 # Remove this line
 from unittest.mock import patch
 
+
 # Add mocker parameter
 def test_example(mocker):
-    mock_obj = mocker.patch('module.function')
+    mock_obj = mocker.patch("module.function")
 ```
 
 Apply these testing standards consistently across all FinWiz test code.

--- a/.claude/skills/validation/SKILL.md
+++ b/.claude/skills/validation/SKILL.md
@@ -39,26 +39,27 @@ Configure via `VALIDATION_STRICTNESS` environment variable:
 from pydantic import BaseModel, Field, field_validator
 from typing import Literal
 
+
 class StockAnalysis(BaseModel):
     """Stock analysis with strict validation."""
 
     model_config = {
-        "extra": "forbid",           # Reject unknown fields
-        "str_strip_whitespace": True, # Auto-clean strings
+        "extra": "forbid",  # Reject unknown fields
+        "str_strip_whitespace": True,  # Auto-clean strings
         "validate_assignment": True,  # Validate on assignment
-        "use_enum_values": True      # Use enum values, not names
+        "use_enum_values": True,  # Use enum values, not names
     }
 
-    ticker: str = Field(..., pattern=r'^[A-Z]{1,5}$', description="Stock ticker symbol")
+    ticker: str = Field(..., pattern=r"^[A-Z]{1,5}$", description="Stock ticker symbol")
     recommendation: Literal["BUY", "HOLD", "SELL"] = Field(..., description="Investment recommendation")
     confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence level 0-1")
     risk_score: int = Field(..., ge=1, le=10, description="Risk score 1-10")
 
-    @field_validator('ticker')
+    @field_validator("ticker")
     @classmethod
     def validate_ticker(cls, v: str) -> str:
         if not v.isalpha():
-            raise ValueError('Ticker must contain only letters')
+            raise ValueError("Ticker must contain only letters")
         return v.upper()
 ```
 
@@ -68,19 +69,15 @@ class StockAnalysis(BaseModel):
 class TickerInput(BaseModel):
     """Validate ticker input with strict rules."""
 
-    model_config = {
-        "str_strip_whitespace": True,
-        "str_upper": True,
-        "extra": "forbid"
-    }
+    model_config = {"str_strip_whitespace": True, "str_upper": True, "extra": "forbid"}
 
-    symbol: str = Field(..., pattern=r'^[A-Z]{1,5}$')
+    symbol: str = Field(..., pattern=r"^[A-Z]{1,5}$")
 
-    @field_validator('symbol')
+    @field_validator("symbol")
     @classmethod
     def validate_ticker(cls, v: str) -> str:
         if not v.isalpha():
-            raise ValueError('Ticker must contain only letters')
+            raise ValueError("Ticker must contain only letters")
         return v.upper()
 ```
 
@@ -219,16 +216,17 @@ class DataQuality(BaseModel):
 ```python
 from datetime import datetime, timedelta
 
+
 class DataFreshness(BaseModel):
     """Validate data timestamps and freshness."""
 
     timestamp: datetime = Field(..., description="Data timestamp")
 
-    @field_validator('timestamp')
+    @field_validator("timestamp")
     @classmethod
     def validate_freshness(cls, v: datetime) -> datetime:
         if datetime.now() - v > timedelta(days=30):
-            raise ValueError('Data is stale (>30 days old)')
+            raise ValueError("Data is stale (>30 days old)")
         return v
 ```
 
@@ -243,12 +241,12 @@ class DataSources(BaseModel):
     urls: list[str] = Field(default=[], description="Source URLs where applicable")
     limitations: list[str] = Field(default=[], description="Data limitations")
 
-    @field_validator('as_of_dates')
+    @field_validator("as_of_dates")
     @classmethod
     def validate_dates_match_sources(cls, v, info):
-        sources = info.data.get('sources', [])
+        sources = info.data.get("sources", [])
         if len(v) != len(sources):
-            raise ValueError('Must have as-of date for each source')
+            raise ValueError("Must have as-of date for each source")
         return v
 ```
 
@@ -272,13 +270,7 @@ class ValidationError(BaseModel):
 def handle_validation_error(error: ValidationError) -> dict:
     """Handle validation errors with clear messaging."""
 
-    response = {
-        "error": True,
-        "field": error.field_path,
-        "message": error.message,
-        "suggestion": get_remediation_suggestion(error.error_type),
-        "context": error.context
-    }
+    response = {"error": True, "field": error.field_path, "message": error.message, "suggestion": get_remediation_suggestion(error.error_type), "context": error.context}
 
     # Log for debugging
     logger.error(f"Validation failed: {error.field_path} - {error.message}")
@@ -342,8 +334,8 @@ def analysis_task(self) -> Task:
         description="Analyze stock with validation",
         expected_output="Validated StockAnalysis object",
         output_pydantic=StockAnalysis,  # Automatic validation
-        output_json=True,               # Machine-readable format
-        agent=self.analyst()
+        output_json=True,  # Machine-readable format
+        agent=self.analyst(),
     )
 ```
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,5 +1,14 @@
 name: Dependabot auto-merge
-on: pull_request_target
+
+# pull_request_target is required here, not incidental: on a `pull_request`
+# event a Dependabot PR gets a read-only GITHUB_TOKEN, which cannot enable
+# auto-merge. This is the trigger GitHub's own "Automating Dependabot with
+# GitHub Actions" guidance uses for exactly this job.
+#
+# It is safe here because the job never checks out the PR: there is no
+# `actions/checkout` step, so no untrusted code runs with the write-scoped
+# token. Do not add one.
+on: pull_request_target # zizmor: ignore[dangerous-triggers]
 
 permissions:
   contents: write
@@ -8,7 +17,9 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    # Read the author from the event payload rather than `github.actor`, which
+    # zizmor flags as spoofable (bot-conditions).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --rebase "$PR_URL"

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -101,6 +101,7 @@ from finwiz.tools.logger import get_logger
 
 logger = get_logger(__name__)
 
+
 def calculate_score(data: dict) -> float:
     try:
         if "required_field" not in data:
@@ -132,6 +133,7 @@ def calculate_score(data: dict) -> float:
 from finwiz.tools.logger import get_logger
 
 logger = get_logger(__name__)
+
 
 def process_data(ticker: str):
     logger.info(f"Processing {ticker}")
@@ -304,6 +306,7 @@ __all__ = [
 
 ```python
 from typing import Any
+
 
 def process_data(ticker: str, data: dict[str, Any]) -> dict[str, Any]:
     """Process data with type hints."""

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -123,10 +123,7 @@ def test_should_fetch_data_from_api(mocker):
     """Test API data fetching."""
     # Mock the external API call
     mock_response = {"ticker": "AAPL", "price": 150.0}
-    mock_fetch = mocker.patch(
-        "finwiz.data.adapters.yahoo_adapter.fetch_quote",
-        return_value=mock_response
-    )
+    mock_fetch = mocker.patch("finwiz.data.adapters.yahoo_adapter.fetch_quote", return_value=mock_response)
 
     # Execute
     result = get_stock_data("AAPL")
@@ -139,10 +136,7 @@ def test_should_fetch_data_from_api(mocker):
 def test_should_handle_api_failure(mocker):
     """Test error handling when API fails."""
     # Mock API to raise exception
-    mocker.patch(
-        "finwiz.data.adapters.yahoo_adapter.fetch_quote",
-        side_effect=ConnectionError("API unavailable")
-    )
+    mocker.patch("finwiz.data.adapters.yahoo_adapter.fetch_quote", side_effect=ConnectionError("API unavailable"))
 
     # Execute and assert exception
     with pytest.raises(ConnectionError):
@@ -206,6 +200,7 @@ def fake_stock_data(fake: Faker) -> dict[str, Any]:
 def stock_data():
     """Fixture providing sample stock data."""
     from tests.fixtures import create_stock_data
+
     return create_stock_data()
 ```
 
@@ -350,10 +345,10 @@ def test_should_raise_error_for_invalid_price():
 @pytest.mark.parametrize(
     "rsi,expected_score",
     [
-        (50, 1.0),   # Neutral
-        (30, 0.8),   # Oversold (bullish)
-        (70, 0.8),   # Overbought (bearish)
-        (95, 0.2),   # Extreme overbought
+        (50, 1.0),  # Neutral
+        (30, 0.8),  # Oversold (bullish)
+        (70, 0.8),  # Overbought (bearish)
+        (95, 0.2),  # Extreme overbought
     ],
 )
 def test_should_score_rsi_correctly(rsi, expected_score):
@@ -377,6 +372,7 @@ def test_should_score_rsi_correctly(rsi, expected_score):
 
 ```python
 from pytest import approx
+
 
 def test_should_calculate_composite_score():
     """Test composite score calculation."""
@@ -481,11 +477,12 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=html:htmlcov",
     "--cov-fail-under=65",
-    "--strict-markers",     # Fail on unknown markers
-    "--strict-config",      # Fail on config errors
-    "-ra",                  # Show extra test summary info
-    "--tb=short",           # Shorter traceback format
-    "-m", "not integration" # Skip integration by default
+    "--strict-markers",  # Fail on unknown markers
+    "--strict-config",  # Fail on config errors
+    "-ra",  # Show extra test summary info
+    "--tb=short",  # Shorter traceback format
+    "-m",
+    "not integration",  # Skip integration by default
 ]
 
 filterwarnings = [
@@ -510,12 +507,7 @@ class UnittestMockBlocker:
 
     def load_module(self, fullname: str):
         raise ImportError(
-            "\n\n"
-            "❌ unittest.mock is BANNED in this project!\n"
-            "\n"
-            "✅ Use pytest-mock instead:\n"
-            "   def test_example(mocker):\n"
-            "       mock_obj = mocker.patch('module.function')\n"
+            "\n\n❌ unittest.mock is BANNED in this project!\n\n✅ Use pytest-mock instead:\n   def test_example(mocker):\n       mock_obj = mocker.patch('module.function')\n"
         )
 
 
@@ -526,7 +518,7 @@ sys.meta_path.insert(0, UnittestMockBlocker())
 
 ```python
 # pyproject.toml
-[tool.ruff.lint.flake8-tidy-imports.banned-api]
+[tool.ruff.lint.flake8 - tidy - imports.banned - api]
 "unittest.mock".msg = "Use pytest-mock instead. Import 'mocker' fixture."
 ```
 
@@ -562,6 +554,7 @@ make check-unittest-mock   # Check for unittest.mock violations
 from faker import Faker
 
 fake = Faker()
+
 
 def test_with_faker(fake: Faker):
     """Test with generated data."""

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -107,9 +107,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 
+
 @dataclass
 class NewsArticle:
     """Standardized news article structure."""
+
     ticker: str
     title: str
     summary: str
@@ -117,6 +119,7 @@ class NewsArticle:
     source: str
     published_at: datetime
     sentiment_score: float | None = None  # Filled by sentiment engine
+
 
 class BaseNewsAdapter(ABC):
     """Base class for news source adapters."""
@@ -130,9 +133,7 @@ class BaseNewsAdapter(ABC):
         pass
 
     @abstractmethod
-    async def get_company_news(
-        self, ticker: str, days_back: int = 7, max_articles: int = 20
-    ) -> list[NewsArticle]:
+    async def get_company_news(self, ticker: str, days_back: int = 7, max_articles: int = 20) -> list[NewsArticle]:
         pass
 
     @abstractmethod
@@ -177,9 +178,11 @@ class NewsOrchestrator:
 # In DeepAnalysisOrchestrator or FinwizFlow
 class SessionData:
     """Data collected once per analysis session."""
+
     macro_snapshot: MacroSnapshot | None = None
     fear_greed_index: int | None = None
     economic_calendar: list[EconomicEvent] = []
+
 
 # Collected once at session start
 session_data = SessionData()
@@ -208,16 +211,18 @@ for holding in portfolio:
 **Example:**
 ```python
 # config/features/definitions.py -- add to create_default_flags()
-FeatureFlagConfig(
-    name="news_sentiment",
-    enabled=get_env_bool("FF_NEWS_SENTIMENT_ENABLED", True),
-    strategy=FeatureFlagStrategy.CIRCUIT_BREAKER,
-    fallback_strategy=FallbackStrategy.CACHED_ONLY,
-    circuit_breaker_threshold=3,
-    circuit_breaker_timeout=600,
-    description="Enable Finnhub/gnews/RSS news collection and VADER sentiment scoring",
-    tags={"data", "sentiment"},
-),
+(
+    FeatureFlagConfig(
+        name="news_sentiment",
+        enabled=get_env_bool("FF_NEWS_SENTIMENT_ENABLED", True),
+        strategy=FeatureFlagStrategy.CIRCUIT_BREAKER,
+        fallback_strategy=FallbackStrategy.CACHED_ONLY,
+        circuit_breaker_threshold=3,
+        circuit_breaker_timeout=600,
+        description="Enable Finnhub/gnews/RSS news collection and VADER sentiment scoring",
+        tags={"data", "sentiment"},
+    ),
+)
 ```
 
 ### Pattern 4: VADER Scoring as Pure Function
@@ -231,6 +236,7 @@ FeatureFlagConfig(
 # data/sentiment/sentiment_scorer.py
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 
+
 class VaderSentimentScorer:
     """Deterministic sentiment scoring using VADER lexicon."""
 
@@ -242,9 +248,7 @@ class VaderSentimentScorer:
         scores = self._analyzer.polarity_scores(text)
         return scores["compound"]
 
-    def score_articles(
-        self, articles: list[NewsArticle], source_weights: dict[str, float] | None = None
-    ) -> SentimentResult:
+    def score_articles(self, articles: list[NewsArticle], source_weights: dict[str, float] | None = None) -> SentimentResult:
         """Score and aggregate multiple articles."""
         if not articles:
             return SentimentResult(score=0.0, confidence=0.0, article_count=0)
@@ -256,9 +260,7 @@ class VaderSentimentScorer:
             weighted_scores.append(score * weight)
             article.sentiment_score = score
 
-        avg_score = sum(weighted_scores) / sum(
-            (source_weights or {}).get(a.source, 0.5) for a in articles
-        )
+        avg_score = sum(weighted_scores) / sum((source_weights or {}).get(a.source, 0.5) for a in articles)
         confidence = min(1.0, len(articles) / 10)  # Full confidence at 10+ articles
 
         return SentimentResult(
@@ -328,6 +330,7 @@ class NewsArticle(BaseModel):
     sentiment_score: float | None = None
     source_reliability: float = Field(ge=0.0, le=1.0, default=0.5)
 
+
 class NewsSentimentResult(BaseModel):
     ticker: str
     overall_score: float = Field(ge=-1.0, le=1.0)
@@ -340,18 +343,20 @@ class NewsSentimentResult(BaseModel):
     sources_used: list[str] = Field(default_factory=list)
     analysis_timestamp: datetime
 
+
 # schemas/macro.py
 class MacroSnapshot(BaseModel):
     """Point-in-time macroeconomic data from FRED."""
-    gdp_growth_rate: float | None = None      # FRED: A191RL1Q225SBEA
-    unemployment_rate: float | None = None     # FRED: UNRATE
-    cpi_yoy_change: float | None = None        # FRED: CPIAUCSL
-    fed_funds_rate: float | None = None        # FRED: FEDFUNDS
-    treasury_10y_yield: float | None = None    # FRED: GS10
-    treasury_2y_yield: float | None = None     # FRED: GS2
-    yield_curve_spread: float | None = None    # 10Y - 2Y
-    vix_level: float | None = None             # FRED: VIXCLS
-    fear_greed_index: int | None = None        # CNN Fear & Greed
+
+    gdp_growth_rate: float | None = None  # FRED: A191RL1Q225SBEA
+    unemployment_rate: float | None = None  # FRED: UNRATE
+    cpi_yoy_change: float | None = None  # FRED: CPIAUCSL
+    fed_funds_rate: float | None = None  # FRED: FEDFUNDS
+    treasury_10y_yield: float | None = None  # FRED: GS10
+    treasury_2y_yield: float | None = None  # FRED: GS2
+    yield_curve_spread: float | None = None  # 10Y - 2Y
+    vix_level: float | None = None  # FRED: VIXCLS
+    fear_greed_index: int | None = None  # CNN Fear & Greed
     snapshot_timestamp: datetime
     data_source: str = "FRED"
     confidence: float = Field(ge=0.0, le=1.0, default=0.9)

--- a/docs/development/DEVELOPER_GUIDE.md
+++ b/docs/development/DEVELOPER_GUIDE.md
@@ -53,10 +53,8 @@ flowchart TD
 # ❌ WRONG: Using AI for deterministic calculation
 @task
 def calculate_score(self) -> Task:
-    return Task(
-        description="Calculate composite score using AI",
-        agent=self.analyst()
-    )
+    return Task(description="Calculate composite score using AI", agent=self.analyst())
+
 
 # ✅ CORRECT: Use Python for calculations
 from finwiz.scoring.deep_analysis_scorer import DeepAnalysisScorer
@@ -81,6 +79,7 @@ score = scorer.calculate_composite_score(ticker, asset_class, data)
 ```python
 from pydantic import BaseModel, Field, field_validator
 
+
 class StockAnalysis(BaseModel):
     """Stock analysis output schema."""
 
@@ -89,12 +88,13 @@ class StockAnalysis(BaseModel):
     composite_score: float = Field(..., ge=0.0, le=1.0)
     recommendation: str = Field(..., pattern="^(BUY|HOLD|SELL)$")
 
-    @field_validator('ticker')
+    @field_validator("ticker")
     @classmethod
     def validate_ticker(cls, v: str) -> str:
         if not v or len(v) > 10:
             raise ValueError("Invalid ticker symbol")
         return v.upper()
+
 
 # Use in crew output
 @task
@@ -103,7 +103,7 @@ def analysis_task(self) -> Task:
         description="Analyze stock",
         expected_output="Structured analysis",
         output_pydantic=StockAnalysis,  # Enforces schema
-        agent=self.analyst()
+        agent=self.analyst(),
     )
 ```
 
@@ -121,23 +121,28 @@ def analysis_task(self) -> Task:
 def generate_report(self, data: dict[str, Any]) -> dict[str, Any]:
     # Write analysis to file
     export_path = f"output/reports/{session_id}/analysis.json"
-    with open(export_path, 'w') as f:
+    with open(export_path, "w") as f:
         f.write(json.dumps(data, indent=2))
 
     # Pass path to next crew
     report_crew = ReportCrew()
-    result = report_crew.crew().kickoff(inputs={
-        "analysis_file": export_path  # Path, not data
-    })
+    result = report_crew.crew().kickoff(
+        inputs={
+            "analysis_file": export_path  # Path, not data
+        }
+    )
 
     return {"report_path": result.report_path}
+
 
 # ❌ WRONG: Pass large data directly
 def generate_report(self, data: dict[str, Any]) -> dict[str, Any]:
     report_crew = ReportCrew()
-    result = report_crew.crew().kickoff(inputs={
-        "analysis_data": data  # May exceed context limits
-    })
+    result = report_crew.crew().kickoff(
+        inputs={
+            "analysis_data": data  # May exceed context limits
+        }
+    )
 ```
 
 #### 4. Concurrent Execution
@@ -149,6 +154,7 @@ def generate_report(self, data: dict[str, Any]) -> dict[str, Any]:
 ```python
 import concurrent.futures
 
+
 def analyze_portfolio_concurrent(holdings: list[str]) -> dict[str, Any]:
     """Analyze multiple holdings concurrently."""
 
@@ -156,10 +162,7 @@ def analyze_portfolio_concurrent(holdings: list[str]) -> dict[str, Any]:
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
         # Submit all tasks
-        future_to_ticker = {
-            executor.submit(analyze_holding, ticker): ticker
-            for ticker in holdings
-        }
+        future_to_ticker = {executor.submit(analyze_holding, ticker): ticker for ticker in holdings}
 
         # Collect results as they complete
         for future in concurrent.futures.as_completed(future_to_ticker):
@@ -184,21 +187,14 @@ def analyze_portfolio_concurrent(holdings: list[str]) -> dict[str, Any]:
 class DeepAnalysisCrew:
     @task
     def analyze_task(self) -> Task:
-        return Task(
-            description="Analyze {ticker}",
-            output_pydantic=DeepAnalysisCrewExport,
-            agent=self.analyst()
-        )
+        return Task(description="Analyze {ticker}", output_pydantic=DeepAnalysisCrewExport, agent=self.analyst())
+
 
 # Presentation (Python/Jinja2)
 from finwiz.reporting.deep_analysis_report_generator import DeepAnalysisReportGenerator
 
 generator = DeepAnalysisReportGenerator()
-html_path = generator.generate_crew_report(
-    crew_name="deep_analysis",
-    export_data=analysis_result.model_dump(),
-    output_path="output/reports/AAPL_report.html"
-)
+html_path = generator.generate_crew_report(crew_name="deep_analysis", export_data=analysis_result.model_dump(), output_path="output/reports/AAPL_report.html")
 ```
 
 ### Directory Structure Deep-Dive
@@ -406,6 +402,7 @@ from finwiz.infrastructure.decorators.agent_validators import final_reporter
 from finwiz.infrastructure.decorators.task_decorators import async_task, sync_task
 from finwiz.infrastructure.logging.helpers import CrewLogger
 
+
 class StockCrew:
     """Stock analysis crew."""
 
@@ -425,7 +422,7 @@ class StockCrew:
             max_reasoning_attempts=3,
             allow_delegation=False,
             max_rpm=20,
-            verbose=True
+            verbose=True,
         )
 
     @final_reporter  # Enforces empty tools
@@ -436,38 +433,25 @@ class StockCrew:
             config=self.agents_config["reporter"],
             tools=[],  # MUST be empty
             reasoning=False,
-            verbose=True
+            verbose=True,
         )
 
     @async_task
     @task
     def research_task(self) -> Task:
         """Research task with async execution."""
-        return Task(
-            config=self.tasks_config["research"],
-            agent=self.analyst()
-        )
+        return Task(config=self.tasks_config["research"], agent=self.analyst())
 
     @sync_task  # Final task MUST be sync
     @task
     def report_task(self) -> Task:
         """Generate final report."""
-        return Task(
-            config=self.tasks_config["report"],
-            output_pydantic=StockCrewExport,
-            output_json=True,
-            agent=self.reporter()
-        )
+        return Task(config=self.tasks_config["report"], output_pydantic=StockCrewExport, output_json=True, agent=self.reporter())
 
     @crew
     def crew(self) -> Crew:
         """Create crew with configured agents and tasks."""
-        return Crew(
-            agents=[self.analyst(), self.reporter()],
-            tasks=[self.research_task(), self.report_task()],
-            process=Process.sequential,
-            verbose=True
-        )
+        return Crew(agents=[self.analyst(), self.reporter()], tasks=[self.research_task(), self.report_task()], process=Process.sequential, verbose=True)
 ```
 
 **File**: `src/finwiz/crews/stock_crew/config/agents.yaml`
@@ -559,6 +543,7 @@ from crewai.flow.flow import Flow, listen, start
 from pydantic import BaseModel, Field
 from typing import Any
 
+
 class FinwizState(BaseModel):
     """Type-safe flow state."""
 
@@ -566,6 +551,7 @@ class FinwizState(BaseModel):
     portfolio_review: dict[str, Any] = Field(default_factory=dict)
     deep_analysis_results: dict[str, Any] = Field(default_factory=dict)
     rebalancing_recommendations: dict[str, Any] = Field(default_factory=dict)
+
 
 class FinwizFlow(Flow[FinwizState]):
     """Main FinWiz orchestration flow."""
@@ -647,6 +633,7 @@ Centralized tool initialization eliminates code duplication.
 from typing import List
 from crewai.tools import BaseTool
 
+
 def get_stock_crew_tools(
     include_quantitative: bool = True,
     include_valuation: bool = True,
@@ -667,6 +654,7 @@ def get_stock_crew_tools(
         tools.append(get_valuation_tool())
 
     return tools
+
 
 def get_etf_crew_tools(
     include_quantitative: bool = True,
@@ -702,6 +690,7 @@ Final reporters MUST have empty tools and only consume upstream context.
 ```python
 from finwiz.infrastructure.decorators.agent_validators import final_reporter
 
+
 @final_reporter  # Enforces NO tools
 @agent
 def reporter(self) -> Agent:
@@ -709,8 +698,9 @@ def reporter(self) -> Agent:
         config=self.agents_config["reporter"],
         tools=[],  # Required
         reasoning=False,
-        verbose=True
+        verbose=True,
     )
+
 
 # The decorator will raise an error if tools are provided:
 # ValidationError: Final reporter must have empty tools list
@@ -723,23 +713,19 @@ Use decorators to make async/sync execution explicit.
 ```python
 from finwiz.infrastructure.decorators.task_decorators import async_task, sync_task
 
+
 @async_task
 @task
 def research_task(self) -> Task:
     """Research can run asynchronously."""
-    return Task(
-        config=self.tasks_config["research"],
-        agent=self.researcher()
-    )
+    return Task(config=self.tasks_config["research"], agent=self.researcher())
+
 
 @sync_task  # Final task MUST be sync
 @task
 def final_report_task(self) -> Task:
     """Final task must be synchronous."""
-    return Task(
-        config=self.tasks_config["final_report"],
-        agent=self.reporter()
-    )
+    return Task(config=self.tasks_config["final_report"], agent=self.reporter())
 ```
 
 ### 3. Structured Logging
@@ -749,6 +735,7 @@ Use `CrewLogger` for consistent logging across crews.
 ```python
 from finwiz.infrastructure.logging.helpers import CrewLogger
 import time
+
 
 class StockCrew:
     def __init__(self):
@@ -779,6 +766,7 @@ All crew outputs use Pydantic schemas for validation.
 from pydantic import BaseModel, Field, field_validator
 from typing import Literal
 
+
 class DeepAnalysisCrewExport(BaseModel):
     """Deep analysis export schema."""
 
@@ -797,26 +785,24 @@ class DeepAnalysisCrewExport(BaseModel):
 
     reasoning: str = Field(..., min_length=50)
 
-    @field_validator('ticker')
+    @field_validator("ticker")
     @classmethod
     def validate_ticker(cls, v: str) -> str:
         if not v or len(v) > 10:
             raise ValueError("Invalid ticker symbol")
         return v.upper()
 
+
 # Use in crew
 @task
 def analysis_task(self) -> Task:
-    return Task(
-        description="Analyze ticker",
-        output_pydantic=DeepAnalysisCrewExport,
-        agent=self.analyst()
-    )
+    return Task(description="Analyze ticker", output_pydantic=DeepAnalysisCrewExport, agent=self.analyst())
+
 
 # Save to file
 export = DeepAnalysisCrewExport(...)
 export_path = f"output/reports/{session_id}/analysis.json"
-with open(export_path, 'w') as f:
+with open(export_path, "w") as f:
     f.write(export.model_dump_json(indent=2))
 ```
 
@@ -830,6 +816,7 @@ Use Jinja2 templates (NO AI) for report generation.
 from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
 
+
 class DeepAnalysisReportGenerator:
     """Generate HTML reports from analysis data."""
 
@@ -837,12 +824,7 @@ class DeepAnalysisReportGenerator:
         template_dir = Path(__file__).parent.parent / "templates" / "crew_reports"
         self.env = Environment(loader=FileSystemLoader(template_dir))
 
-    def generate_crew_report(
-        self,
-        crew_name: str,
-        export_data: dict,
-        output_path: str
-    ) -> str:
+    def generate_crew_report(self, crew_name: str, export_data: dict, output_path: str) -> str:
         """Generate HTML report for crew analysis."""
 
         # Load template
@@ -850,15 +832,11 @@ class DeepAnalysisReportGenerator:
 
         # Render with data
         html_content = template.render(
-            ticker=export_data["ticker"],
-            grade=export_data["grade"],
-            score=export_data["composite_score"],
-            recommendation=export_data["recommendation"],
-            **export_data
+            ticker=export_data["ticker"], grade=export_data["grade"], score=export_data["composite_score"], recommendation=export_data["recommendation"], **export_data
         )
 
         # Write to file
-        with open(output_path, 'w') as f:
+        with open(output_path, "w") as f:
             f.write(html_content)
 
         return output_path
@@ -943,6 +921,7 @@ from finwiz.infrastructure.decorators.agent_validators import final_reporter
 from finwiz.infrastructure.decorators.task_decorators import async_task, sync_task
 from finwiz.infrastructure.logging.helpers import CrewLogger
 
+
 class MyCustomCrew:
     """Custom crew for specific analysis."""
 
@@ -957,7 +936,7 @@ class MyCustomCrew:
         from pathlib import Path
 
         config_path = Path(__file__).parent / "config" / "agents.yaml"
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             return yaml.safe_load(f)
 
     def _load_tasks_config(self) -> dict:
@@ -966,62 +945,36 @@ class MyCustomCrew:
         from pathlib import Path
 
         config_path = Path(__file__).parent / "config" / "tasks.yaml"
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             return yaml.safe_load(f)
 
     @agent
     def analyst(self) -> Agent:
         """Primary analyst agent."""
-        return Agent(
-            config=self.agents_config["analyst"],
-            tools=get_stock_crew_tools(),
-            reasoning=True,
-            max_reasoning_attempts=3,
-            allow_delegation=False,
-            max_rpm=20,
-            verbose=True
-        )
+        return Agent(config=self.agents_config["analyst"], tools=get_stock_crew_tools(), reasoning=True, max_reasoning_attempts=3, allow_delegation=False, max_rpm=20, verbose=True)
 
     @final_reporter
     @agent
     def reporter(self) -> Agent:
         """Final report generator."""
-        return Agent(
-            config=self.agents_config["reporter"],
-            tools=[],
-            reasoning=False,
-            verbose=True
-        )
+        return Agent(config=self.agents_config["reporter"], tools=[], reasoning=False, verbose=True)
 
     @async_task
     @task
     def analysis_task(self) -> Task:
         """Main analysis task."""
-        return Task(
-            config=self.tasks_config["analysis"],
-            agent=self.analyst()
-        )
+        return Task(config=self.tasks_config["analysis"], agent=self.analyst())
 
     @sync_task
     @task
     def report_task(self) -> Task:
         """Generate final report."""
-        return Task(
-            config=self.tasks_config["report"],
-            output_pydantic=MyCustomExport,
-            output_json=True,
-            agent=self.reporter()
-        )
+        return Task(config=self.tasks_config["report"], output_pydantic=MyCustomExport, output_json=True, agent=self.reporter())
 
     @crew
     def crew(self) -> Crew:
         """Create crew with configured agents and tasks."""
-        return Crew(
-            agents=[self.analyst(), self.reporter()],
-            tasks=[self.analysis_task(), self.report_task()],
-            process=Process.sequential,
-            verbose=True
-        )
+        return Crew(agents=[self.analyst(), self.reporter()], tasks=[self.analysis_task(), self.report_task()], process=Process.sequential, verbose=True)
 ```
 
 #### 3. Create Agent Configuration
@@ -1101,11 +1054,13 @@ import pytest
 from finwiz.crews.my_custom_crew.my_custom_crew import MyCustomCrew
 from finwiz.schemas.crew_exports import MyCustomExport
 
+
 def test_crew_initialization():
     """Test crew initializes correctly."""
     crew = MyCustomCrew()
     assert crew is not None
     assert crew.logger is not None
+
 
 def test_agents_configuration(mocker):
     """Test agents are configured correctly."""
@@ -1120,18 +1075,16 @@ def test_agents_configuration(mocker):
     assert reporter is not None
     assert len(reporter.tools) == 0  # Final reporter has no tools
 
+
 @pytest.mark.integration
 def test_crew_execution(mocker):
     """Test crew executes successfully."""
     # Mock expensive operations
-    mocker.patch('finwiz.tools.tool_factories.get_stock_crew_tools')
+    mocker.patch("finwiz.tools.tool_factories.get_stock_crew_tools")
 
     crew = MyCustomCrew()
 
-    result = crew.crew().kickoff(inputs={
-        "ticker": "TEST",
-        "asset_class": "stock"
-    })
+    result = crew.crew().kickoff(inputs={"ticker": "TEST", "asset_class": "stock"})
 
     # Validate result
     assert result is not None
@@ -1150,10 +1103,7 @@ def run_custom_analysis(self, data: dict[str, Any]) -> dict[str, Any]:
     from finwiz.crews.my_custom_crew.my_custom_crew import MyCustomCrew
 
     crew = MyCustomCrew()
-    result = crew.crew().kickoff(inputs={
-        "ticker": data["ticker"],
-        "asset_class": "stock"
-    })
+    result = crew.crew().kickoff(inputs={"ticker": data["ticker"], "asset_class": "stock"})
 
     return {"custom_analysis": result.model_dump()}
 ```
@@ -1170,13 +1120,15 @@ FinWiz uses **pytest** with **pytest-mock** for all testing.
 # ❌ WRONG: unittest.mock
 from unittest.mock import Mock, patch
 
+
 def test_example():
-    with patch('module.function') as mock_fn:
+    with patch("module.function") as mock_fn:
         ...
+
 
 # ✅ CORRECT: pytest-mock
 def test_example(mocker):
-    mock_fn = mocker.patch('module.function')
+    mock_fn = mocker.patch("module.function")
     ...
 ```
 
@@ -1211,20 +1163,24 @@ tests/
 ```python
 import pytest
 
+
 @pytest.mark.unit
 def test_unit_example():
     """Fast unit test."""
     pass
+
 
 @pytest.mark.integration
 def test_integration_example():
     """Integration test requiring API keys."""
     pass
 
+
 @pytest.mark.slow
 def test_slow_example():
     """Slow-running test."""
     pass
+
 
 @pytest.mark.performance
 def test_performance_example():
@@ -1253,56 +1209,49 @@ pytest -m "not slow"
 import pytest
 from finwiz.scoring.deep_analysis_scorer import DeepAnalysisScorer
 
+
 @pytest.fixture
 def scorer():
     """Provide scorer instance."""
     return DeepAnalysisScorer()
 
+
 @pytest.fixture
 def stock_data():
     """Provide sample stock data."""
-    return {
-        "roe": 0.25,
-        "debt_to_equity": 0.3,
-        "revenue_growth": 0.15,
-        "profit_margin": 0.22,
-        "pe_ratio": 28.5,
-        "current_ratio": 1.1
-    }
+    return {"roe": 0.25, "debt_to_equity": 0.3, "revenue_growth": 0.15, "profit_margin": 0.22, "pe_ratio": 28.5, "current_ratio": 1.1}
+
 
 def test_calculate_composite_score(scorer, stock_data):
     """Test composite score calculation."""
-    result = scorer.calculate_composite_score(
-        ticker="AAPL",
-        asset_class="stock",
-        data=stock_data
-    )
+    result = scorer.calculate_composite_score(ticker="AAPL", asset_class="stock", data=stock_data)
 
     assert result.grade in ["A+", "A", "B+", "B", "C+", "C", "D", "F"]
     assert 0.0 <= result.composite_score <= 1.0
     assert result.recommendation in ["BUY", "HOLD", "SELL"]
 
+
 def test_invalid_asset_class(scorer, stock_data):
     """Test handling of invalid asset class."""
     with pytest.raises(ValueError, match="Invalid asset_class"):
-        scorer.calculate_composite_score(
-            ticker="AAPL",
-            asset_class="invalid",
-            data=stock_data
-        )
+        scorer.calculate_composite_score(ticker="AAPL", asset_class="invalid", data=stock_data)
+
 
 # Real bands: A+ >= 0.95, A >= 0.85, B+ >= 0.80, B >= 0.75,
 #             C+ >= 0.70, C >= 0.65, D >= 0.50, F < 0.50
-@pytest.mark.parametrize("score,expected_grade", [
-    (0.98, "A+"),
-    (0.88, "A"),
-    (0.82, "B+"),
-    (0.78, "B"),
-    (0.72, "C+"),
-    (0.68, "C"),
-    (0.55, "D"),
-    (0.28, "F"),
-])
+@pytest.mark.parametrize(
+    "score,expected_grade",
+    [
+        (0.98, "A+"),
+        (0.88, "A"),
+        (0.82, "B+"),
+        (0.78, "B"),
+        (0.72, "C+"),
+        (0.68, "C"),
+        (0.55, "D"),
+        (0.28, "F"),
+    ],
+)
 def test_grade_mapping(scorer, score, expected_grade):
     """Test score to grade conversion."""
     grade = scorer.assign_grade(score)
@@ -1314,6 +1263,7 @@ def test_grade_mapping(scorer, score, expected_grade):
 ```python
 import pytest
 from finwiz.integration.accessor import CrewDataAccessor
+
 
 def test_get_stock_data(mocker, tmp_path):
     """Read a crew's persisted output, with the on-disk artifact mocked."""
@@ -1328,6 +1278,7 @@ def test_get_stock_data(mocker, tmp_path):
 
     assert data["symbol"] == "AAPL"
     assert data["currentPrice"] == 175.50
+
 
 def test_missing_data_returns_none(tmp_path):
     """A crew that never wrote its artifact reads back as None, not as zeros."""
@@ -1351,6 +1302,7 @@ import pytest
 from finwiz.crews.stock_crew.stock_crew import StockCrew
 from finwiz.schemas.crew_exports import StockCrewExport
 
+
 def test_stock_crew_initialization():
     """Test stock crew initializes correctly."""
     crew = StockCrew()
@@ -1359,6 +1311,7 @@ def test_stock_crew_initialization():
     assert crew.logger is not None
     assert crew.agents_config is not None
     assert crew.tasks_config is not None
+
 
 def test_agents_have_correct_tools(mocker):
     """Test agents are configured with correct tools."""
@@ -1371,19 +1324,17 @@ def test_agents_have_correct_tools(mocker):
     reporter = crew.reporter()
     assert len(reporter.tools) == 0  # Final reporter has no tools
 
+
 @pytest.mark.integration
 def test_crew_execution_full(mocker):
     """Test full crew execution (integration test)."""
     # Mock expensive API calls
-    mocker.patch('finwiz.tools.tool_factories.get_stock_crew_tools')
-    mocker.patch('finwiz.tools.quantitative_analysis_tool.QuantitativeAnalysisTool._run')
+    mocker.patch("finwiz.tools.tool_factories.get_stock_crew_tools")
+    mocker.patch("finwiz.tools.quantitative_analysis_tool.QuantitativeAnalysisTool._run")
 
     crew = StockCrew()
 
-    result = crew.crew().kickoff(inputs={
-        "ticker": "AAPL",
-        "asset_class": "stock"
-    })
+    result = crew.crew().kickoff(inputs={"ticker": "AAPL", "asset_class": "stock"})
 
     # Validate result structure
     assert result is not None
@@ -1440,15 +1391,16 @@ open htmlcov/index.html
 def analyst(self) -> Agent:
     return Agent(
         reasoning=True,  # Complex multi-step analysis
-        max_reasoning_attempts=3
+        max_reasoning_attempts=3,
     )
+
 
 # ❌ BAD: High-volume execution
 @agent
 def validator(self) -> Agent:
     return Agent(
         reasoning=True,  # Will execute 66+ times - too slow
-        max_reasoning_attempts=3
+        max_reasoning_attempts=3,
     )
 ```
 
@@ -1476,8 +1428,9 @@ def crew(self) -> Crew:
         agents=[self.analyst(), self.researcher(), self.validator(), self.reporter()],
         tasks=[...],  # 6+ tasks
         planning=True,  # Complex, runs once
-        process=Process.sequential
+        process=Process.sequential,
     )
+
 
 # ❌ BAD: High-volume execution
 @crew
@@ -1486,7 +1439,7 @@ def crew(self) -> Crew:
         agents=[self.analyst()],
         tasks=[self.analyze()],
         planning=True,  # Will run 66 times - unnecessary overhead
-        process=Process.sequential
+        process=Process.sequential,
     )
 ```
 
@@ -1511,15 +1464,16 @@ def crew(self) -> Crew:
 def coordinator(self) -> Agent:
     return Agent(
         allow_delegation=True,  # Manages other agents
-        max_rpm=10
+        max_rpm=10,
     )
+
 
 # ❌ BAD: Specialist agent
 @agent
 def analyst(self) -> Agent:
     return Agent(
         allow_delegation=True,  # Specialist shouldn't delegate
-        max_rpm=20
+        max_rpm=20,
     )
 ```
 
@@ -1595,8 +1549,10 @@ def analyze_stock(ticker: str, data: dict[str, Any]) -> dict[str, Any]:
     """Analyze stock with type hints."""
     return {"ticker": ticker}
 
+
 # ❌ WRONG: Old syntax
 from typing import Dict, Any, Optional
+
 
 def analyze_stock(ticker: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return {"ticker": ticker}
@@ -1607,11 +1563,7 @@ def analyze_stock(ticker: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]
 All public modules, classes, and functions require docstrings:
 
 ```python
-def calculate_composite_score(
-    ticker: str,
-    asset_class: str,
-    data: dict[str, Any]
-) -> dict[str, Any]:
+def calculate_composite_score(ticker: str, asset_class: str, data: dict[str, Any]) -> dict[str, Any]:
     """Calculate composite score for asset.
 
     Args:
@@ -1632,9 +1584,7 @@ def calculate_composite_score(
 
     Example:
         >>> scorer = DeepAnalysisScorer()
-        >>> result = scorer.calculate_composite_score(
-        ...     "AAPL", "stock", {"roe": 0.25, "debt_to_equity": 0.3}
-        ... )
+        >>> result = scorer.calculate_composite_score("AAPL", "stock", {"roe": 0.25, "debt_to_equity": 0.3})
         >>> print(result["grade"])
         A
     """

--- a/docs/explanations/DATA_QUALITY_AND_FLOW_GUIDE.md
+++ b/docs/explanations/DATA_QUALITY_AND_FLOW_GUIDE.md
@@ -69,15 +69,17 @@ All data transfers use strict Pydantic v2 models:
 ```python
 from pydantic import BaseModel, Field
 
+
 class HoldingDecision(BaseModel):
     """Strict validation for holding decisions."""
-    ticker: str = Field(..., pattern=r'^[A-Z]{1,5}$')
-    grade: str = Field(..., pattern=r'^(A\+|A|B|C|D|F)$')
+
+    ticker: str = Field(..., pattern=r"^[A-Z]{1,5}$")
+    grade: str = Field(..., pattern=r"^(A\+|A|B|C|D|F)$")
     composite_score: float = Field(..., ge=0.0, le=1.0)
 
     model_config = {
         "extra": "forbid",  # Reject unknown fields
-        "str_strip_whitespace": True
+        "str_strip_whitespace": True,
     }
 ```
 
@@ -109,22 +111,9 @@ flowchart TD
     "ticker": "AAPL",
     "grade": "A+",
     "composite_score": 0.95,
-    "risk": {
-        "score": 2.5,
-        "factors": ["Market volatility", "Sector competition"]
-    },
-    "rationale_bullets": [
-        "Strong fundamentals with 25% revenue growth",
-        "Excellent profit margins above 25%",
-        "Low debt-to-equity ratio of 0.15"
-    ],
-    "citations": [
-        {
-            "source": "SEC 10-K Filing",
-            "url": "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=0000320193",
-            "date": "2024-10-31"
-        }
-    ]
+    "risk": {"score": 2.5, "factors": ["Market volatility", "Sector competition"]},
+    "rationale_bullets": ["Strong fundamentals with 25% revenue growth", "Excellent profit margins above 25%", "Low debt-to-equity ratio of 0.15"],
+    "citations": [{"source": "SEC 10-K Filing", "url": "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=0000320193", "date": "2024-10-31"}],
 }
 ```
 
@@ -159,7 +148,7 @@ validator = DataConsolidationValidator(registry_manager)  # RegistryManager is r
 
 try:
     # Validate all expected crew data exists
-    crew_data = validator.validate_crew_data_retrieval(['stock', 'etf', 'crypto'])
+    crew_data = validator.validate_crew_data_retrieval(["stock", "etf", "crypto"])
 
     # Data successfully retrieved
     for crew_name, data in crew_data.items():
@@ -210,7 +199,7 @@ Users must be able to trust that if they receive a report, it contains accurate 
 
 ```python
 # Fails if crew data missing or corrupted
-validator.validate_crew_data_retrieval(['stock', 'etf', 'crypto'])
+validator.validate_crew_data_retrieval(["stock", "etf", "crypto"])
 # Raises: DataRetrievalError with detailed diagnostics
 ```
 
@@ -226,7 +215,7 @@ merger.merge_deep_analysis_into_holdings(holdings, deep_analysis)
 
 ```python
 # Fails if required fields are missing or contain placeholders
-validator.validate_qualitative_insights(insights)   # -> QualitativeInsights
+validator.validate_qualitative_insights(insights)  # -> QualitativeInsights
 # Raises: ReportValidationError with field-level details
 ```
 
@@ -556,8 +545,8 @@ cat output/stock/stock_output_*.json | jq '.ticker'
 
 ```python
 # Verify ticker matching
-holdings_tickers = set(['AAPL', 'GOOGL', 'MSFT'])
-analysis_tickers = set(['AAPL', 'GOOGL', 'MSFT'])
+holdings_tickers = set(["AAPL", "GOOGL", "MSFT"])
+analysis_tickers = set(["AAPL", "GOOGL", "MSFT"])
 
 missing = holdings_tickers - analysis_tickers
 print(f"Missing analysis for: {missing}")
@@ -591,7 +580,7 @@ required_fields = [
     "discovery_status",
     "backtesting_status",
     "data_availability_summary",
-    "data_availability_summary_formatted"
+    "data_availability_summary_formatted",
 ]
 
 # Check which fields are missing
@@ -782,7 +771,7 @@ for field in required_fields:
    # In crew configuration
    agent = Agent(
        reasoning=True,
-       max_reasoning_attempts=3  # Prevent infinite loops
+       max_reasoning_attempts=3,  # Prevent infinite loops
    )
    ```
 
@@ -849,17 +838,15 @@ Follow the [Manual Verification Steps](#manual-verification-steps) above after e
 metrics_history = []
 for run in runs:
     metrics = DataQualityMetrics.model_validate_json(Path(f"run_{run}_metrics.json").read_text())
-    metrics_history.append({
-        "run": run,
-        "score": metrics.calculate_quality_score(),
-        "fallback_grades": metrics.fallback_grades_count,
-        "placeholder_urls": metrics.placeholder_urls_count
-    })
+    metrics_history.append(
+        {"run": run, "score": metrics.calculate_quality_score(), "fallback_grades": metrics.fallback_grades_count, "placeholder_urls": metrics.placeholder_urls_count}
+    )
 
 # Plot trends
 import matplotlib.pyplot as plt
+
 plt.plot([m["score"] for m in metrics_history])
-plt.axhline(y=0.90, color='r', linestyle='--', label='Threshold')
+plt.axhline(y=0.90, color="r", linestyle="--", label="Threshold")
 plt.title("Data Quality Score Over Time")
 plt.show()
 ```

--- a/docs/explanations/ORCHESTRATOR_INTERACTIONS.md
+++ b/docs/explanations/ORCHESTRATOR_INTERACTIONS.md
@@ -394,9 +394,7 @@ Most orchestrator interactions are synchronous:
 result = self.deep_analysis_orch.run_deep_analysis_on_holdings(holdings)
 
 # Orchestrator calls another orchestrator
-wrapped_result = self.error_handler_orch.execute_crew_with_error_handling(
-    crew_func, "crew_name"
-)
+wrapped_result = self.error_handler_orch.execute_crew_with_error_handling(crew_func, "crew_name")
 ```
 
 ### 2. State-Based Communication
@@ -420,6 +418,7 @@ Flow methods return data for downstream listeners:
 def analyze_holdings(self) -> dict[str, Any]:
     results = self.deep_analysis_orch.run_deep_analysis_on_holdings(holdings)
     return {"analysis": results}  # Passed to next listener
+
 
 @listen("analyze_holdings")
 def match_alternatives(self, analysis_data: dict[str, Any]) -> dict[str, Any]:
@@ -453,9 +452,7 @@ async def run_discovery():
     stock_task = asyncio.create_task(check_stock())
     etf_task = asyncio.create_task(check_etf())
 
-    results = await asyncio.gather(
-        crypto_task, stock_task, etf_task
-    )
+    results = await asyncio.gather(crypto_task, stock_task, etf_task)
     return consolidate_results(results)
 ```
 

--- a/docs/explanations/PYTHON_SCORING_ENGINE.md
+++ b/docs/explanations/PYTHON_SCORING_ENGINE.md
@@ -82,7 +82,7 @@ def calculate_fundamental_score(self, data: dict) -> float:
     base_score = 0.5
 
     # ROE bonus/penalty
-    roe = data.get('roe', 0)
+    roe = data.get("roe", 0)
     if roe > 0.20:  # 20%+
         base_score += 0.3
     elif roe > 0.15:  # 15-20%
@@ -91,14 +91,14 @@ def calculate_fundamental_score(self, data: dict) -> float:
         base_score -= 0.2
 
     # Debt-to-equity penalty
-    debt_equity = data.get('debt_to_equity', 0)
+    debt_equity = data.get("debt_to_equity", 0)
     if debt_equity > 0.5:
         base_score -= 0.2
     elif debt_equity > 0.3:
         base_score -= 0.1
 
     # Growth bonus
-    revenue_growth = data.get('revenue_growth', 0)
+    revenue_growth = data.get("revenue_growth", 0)
     if revenue_growth > 0.15:  # 15%+
         base_score += 0.2
     elif revenue_growth > 0.10:  # 10-15%
@@ -117,7 +117,7 @@ def calculate_technical_score(self, data: dict) -> float:
     base_score = 0.5
 
     # RSI analysis
-    rsi = data.get('rsi', 50)
+    rsi = data.get("rsi", 50)
     if 30 <= rsi <= 70:  # Neutral zone
         base_score += 0.2
     elif rsi < 30:  # Oversold
@@ -126,10 +126,10 @@ def calculate_technical_score(self, data: dict) -> float:
         base_score -= 0.2
 
     # Trend analysis
-    trend = data.get('trend_direction', 'neutral')
-    if trend == 'bullish':
+    trend = data.get("trend_direction", "neutral")
+    if trend == "bullish":
         base_score += 0.3
-    elif trend == 'bearish':
+    elif trend == "bearish":
         base_score -= 0.3
 
     return max(0.0, min(1.0, base_score))
@@ -145,7 +145,7 @@ def calculate_risk_score(self, data: dict) -> int:
     risk_score = 2  # Base moderate risk
 
     # Volatility adjustment
-    volatility = data.get('volatility', 0.2)
+    volatility = data.get("volatility", 0.2)
     if volatility > 0.4:  # High volatility
         risk_score += 2
     elif volatility > 0.3:
@@ -154,7 +154,7 @@ def calculate_risk_score(self, data: dict) -> int:
         risk_score -= 1
 
     # Maximum drawdown adjustment
-    max_drawdown = abs(data.get('max_drawdown', 0.1))
+    max_drawdown = abs(data.get("max_drawdown", 0.1))
     if max_drawdown > 0.3:  # >30% drawdown
         risk_score += 1
     elif max_drawdown < 0.1:  # <10% drawdown
@@ -185,12 +185,12 @@ Investment recommendations follow deterministic rules:
 ```python
 def generate_recommendation(self, composite_score: float, grade: str) -> str:
     """Generate BUY/HOLD/SELL recommendation."""
-    if grade in ['A+', 'A']:
-        return 'BUY'
-    elif grade in ['B', 'C']:
-        return 'HOLD'
+    if grade in ["A+", "A"]:
+        return "BUY"
+    elif grade in ["B", "C"]:
+        return "HOLD"
     else:  # D, F
-        return 'SELL'
+        return "SELL"
 ```
 
 ## Integration Architecture
@@ -210,6 +210,7 @@ def analyze_portfolio_with_python(holdings: list[HoldingDecision], session_id: s
     """Convenience function for Flow integration."""
     analyzer = PortfolioDeepAnalyzer()
     return analyzer.analyze_portfolio_holdings(holdings)
+
 
 def generate_python_report(analysis_data: dict) -> str:
     """Convenience function for report generation."""
@@ -364,7 +365,7 @@ For maximum flexibility, FinWiz supports a hybrid approach:
 
 ```python
 # Optional AI summary after Python scoring
-if os.getenv('DEEP_ANALYSIS_AI_SUMMARY', 'false').lower() == 'true':
+if os.getenv("DEEP_ANALYSIS_AI_SUMMARY", "false").lower() == "true":
     # Python scoring (10-30 seconds, $0)
     python_result = scorer.calculate_composite_score(data)
 

--- a/docs/explanations/REPORT_AGGREGATION_DEVELOPER_GUIDE.md
+++ b/docs/explanations/REPORT_AGGREGATION_DEVELOPER_GUIDE.md
@@ -41,8 +41,10 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Any
 from datetime import datetime
 
+
 class MyNewCrewExport(CrewExportBase):
     """Export schema for MyNewCrew analysis."""
+
     crew_name: str = Field(default="my_new_crew")
 
     # Analysis Results
@@ -65,7 +67,7 @@ class MyNewCrewExport(CrewExportBase):
 
     model_config = {
         "extra": "forbid",  # Reject unknown fields
-        "str_strip_whitespace": True
+        "str_strip_whitespace": True,
     }
 ```
 
@@ -89,6 +91,7 @@ from finwiz.schemas.crew_exports import MyNewCrewExport
 import json
 from pathlib import Path
 
+
 @final_reporter
 @agent
 def investment_reporter(self) -> Agent:
@@ -96,8 +99,9 @@ def investment_reporter(self) -> Agent:
     return Agent(
         config=self.agents_config["investment_reporter"],
         tools=[],  # MUST be empty - enforced by decorator
-        verbose=True
+        verbose=True,
     )
+
 
 @task
 def generate_export_task(self) -> Task:
@@ -117,7 +121,7 @@ def generate_export_task(self) -> Task:
         """,
         expected_output="Validated MyNewCrewExport object saved to JSON",
         agent=self.investment_reporter(),
-        async_execution=False  # Final task must be synchronous
+        async_execution=False,  # Final task must be synchronous
     )
 ```
 
@@ -137,6 +141,7 @@ Update the Flow to call Python HTML generation after crew execution:
 
 from finwiz.tools.html_report_generator import HTMLReportGenerator
 
+
 @listen("initialize_flow")
 def execute_my_new_crew(self) -> dict[str, Any]:
     """Execute MyNewCrew and generate HTML report."""
@@ -150,9 +155,7 @@ def execute_my_new_crew(self) -> dict[str, Any]:
     # Generate HTML from JSON using Python template
     generator = HTMLReportGenerator()
     html_path = generator.generate_crew_report(
-        crew_name="my_new_crew",
-        export_data=json.loads(Path(json_path).read_text()),
-        output_path=json_path.replace("_export.json", "_report.html")
+        crew_name="my_new_crew", export_data=json.loads(Path(json_path).read_text()), output_path=json_path.replace("_export.json", "_report.html")
     )
 
     # Store paths in state
@@ -176,6 +179,7 @@ Update `ReportConsolidator` to handle the new crew type:
 
 from finwiz.schemas.crew_exports import MyNewCrewExport
 
+
 class ReportConsolidator:
     def consolidate_reports(self, crew_export_paths: Dict[str, List[str]]) -> ConsolidatedReportExport:
         """Consolidate all crew exports."""
@@ -184,16 +188,13 @@ class ReportConsolidator:
         # Load MyNewCrew exports
         my_new_analyses = []
         if "my_new_crew" in crew_export_paths:
-            my_new_analyses = self._load_exports(
-                crew_export_paths["my_new_crew"],
-                MyNewCrewExport
-            )
+            my_new_analyses = self._load_exports(crew_export_paths["my_new_crew"], MyNewCrewExport)
 
         # Create consolidated export
         consolidated = ConsolidatedReportExport(
             session_id=self.session_id,
             # ... existing fields ...
-            my_new_analyses=my_new_analyses
+            my_new_analyses=my_new_analyses,
         )
 
         return consolidated
@@ -353,13 +354,9 @@ Update `HTMLReportGenerator` to load your template:
 ```python
 # In src/finwiz/tools/html_report_generator.py
 
+
 class HTMLReportGenerator:
-    def generate_crew_report(
-        self,
-        crew_name: str,
-        export_data: dict,
-        output_path: str
-    ) -> str:
+    def generate_crew_report(self, crew_name: str, export_data: dict, output_path: str) -> str:
         """Generate HTML report from crew export data."""
         # Map crew names to templates
         template_map = {
@@ -379,7 +376,7 @@ class HTMLReportGenerator:
 
         # Save HTML
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(output_path).write_text(html_content, encoding='utf-8')
+        Path(output_path).write_text(html_content, encoding="utf-8")
 
         return output_path
 ```
@@ -393,19 +390,15 @@ To add fields to an existing export schema:
 ```python
 # In src/finwiz/schemas/crew_exports.py
 
+
 class StockCrewExport(CrewExportBase):
     # ... existing fields ...
 
     # Add new field
-    new_metric: float = Field(
-        ...,
-        ge=0.0,
-        le=100.0,
-        description="New metric description"
-    )
+    new_metric: float = Field(..., ge=0.0, le=100.0, description="New metric description")
 
     # Add field validator
-    @field_validator('new_metric')
+    @field_validator("new_metric")
     @classmethod
     def validate_new_metric(cls, v: float) -> float:
         """Validate new metric is reasonable."""
@@ -421,11 +414,13 @@ For complex data structures, create nested Pydantic models:
 ```python
 class DetailedAnalysis(BaseModel):
     """Nested model for detailed analysis."""
+
     metric_1: float
     metric_2: float
     summary: str
 
     model_config = {"extra": "forbid"}
+
 
 class StockCrewExport(CrewExportBase):
     # ... existing fields ...
@@ -441,6 +436,7 @@ When making breaking changes, version your schemas:
 ```python
 class StockCrewExportV2(CrewExportBase):
     """Version 2 of StockCrewExport with breaking changes."""
+
     schema_version: str = Field(default="2.0")
 
     # ... new fields ...
@@ -489,7 +485,7 @@ def generate_html_report(self) -> Task:
 ```python
 def generate_html_report(json_data: dict) -> str:
     """Generate HTML report using Jinja2 template."""
-    template = jinja_env.get_template('report.html')
+    template = jinja_env.get_template("report.html")
     return template.render(data=json_data)
     # CORRECT: Fast, cheap, testable
 ```
@@ -543,6 +539,7 @@ import pytest
 from finwiz.schemas.crew_exports import MyNewCrewExport
 from pydantic import ValidationError
 
+
 def test_should_validate_valid_export():
     """Test that valid export data passes validation."""
     export = MyNewCrewExport(
@@ -555,11 +552,12 @@ def test_should_validate_valid_export():
         rationale="Strong fundamentals and growth prospects",
         data_sources=["Yahoo Finance", "SEC EDGAR"],
         report_html_path="output/reports/session/my_new_crew/AAPL_report.html",
-        report_json_path="output/reports/session/my_new_crew/AAPL_export.json"
+        report_json_path="output/reports/session/my_new_crew/AAPL_export.json",
     )
 
     assert export.ticker == "AAPL"
     assert export.grade == "A"
+
 
 def test_should_reject_invalid_grade():
     """Test that invalid grade is rejected."""
@@ -571,6 +569,7 @@ def test_should_reject_invalid_grade():
         )
 
     assert "grade" in str(exc_info.value)
+
 
 def test_should_reject_extra_fields():
     """Test that extra fields are rejected (extra='forbid')."""
@@ -592,6 +591,7 @@ def test_should_reject_extra_fields():
 import pytest
 from finwiz.tools.html_report_generator import HTMLReportGenerator
 
+
 def test_should_generate_html_from_export(mocker, tmp_path):
     """Test HTML generation from crew export."""
     # Arrange
@@ -605,11 +605,7 @@ def test_should_generate_html_from_export(mocker, tmp_path):
     output_path = tmp_path / "report.html"
 
     # Act
-    result_path = generator.generate_crew_report(
-        crew_name="my_new_crew",
-        export_data=export_data,
-        output_path=str(output_path)
-    )
+    result_path = generator.generate_crew_report(crew_name="my_new_crew", export_data=export_data, output_path=str(output_path))
 
     # Assert
     assert output_path.exists()
@@ -627,6 +623,7 @@ def test_should_generate_html_from_export(mocker, tmp_path):
 import pytest
 from finwiz.reporting.consolidator import ReportConsolidator
 
+
 def test_should_consolidate_crew_exports(mocker, tmp_path):
     """Test consolidation of multiple crew exports."""
     # Arrange
@@ -636,9 +633,7 @@ def test_should_consolidate_crew_exports(mocker, tmp_path):
     stock_export = tmp_path / "stock_export.json"
     stock_export.write_text('{"ticker": "AAPL", "grade": "A", ...}')
 
-    crew_export_paths = {
-        "stock_crew": [str(stock_export)]
-    }
+    crew_export_paths = {"stock_crew": [str(stock_export)]}
 
     # Act
     consolidated = consolidator.consolidate_reports(crew_export_paths)
@@ -661,7 +656,7 @@ class MyNewCrew:
         return Agent(
             config=self.agents_config["investment_reporter"],
             tools=[],  # Enforced empty
-            verbose=True
+            verbose=True,
         )
 
     @task
@@ -670,7 +665,7 @@ class MyNewCrew:
             description="Generate validated export from context",
             expected_output="MyNewCrewExport object saved to JSON",
             agent=self.investment_reporter(),
-            async_execution=False  # Final task must be sync
+            async_execution=False,  # Final task must be sync
         )
 ```
 
@@ -690,9 +685,7 @@ def execute_crew_with_html(self) -> dict[str, Any]:
     # 3. Generate HTML using Python
     generator = HTMLReportGenerator()
     html_path = generator.generate_crew_report(
-        crew_name=crew_name,
-        export_data=json.loads(Path(json_path).read_text()),
-        output_path=json_path.replace("_export.json", "_report.html")
+        crew_name=crew_name, export_data=json.loads(Path(json_path).read_text()), output_path=json_path.replace("_export.json", "_report.html")
     )
 
     # 4. Store paths in state
@@ -712,12 +705,7 @@ def consolidate_reports(crew_export_paths: Dict[str, List[str]]) -> Consolidated
     etf_analyses = _load_exports(crew_export_paths.get("etf_crew", []), ETFCrewExport)
 
     # 2. Create consolidated export
-    consolidated = ConsolidatedReportExport(
-        session_id=session_id,
-        stock_analyses=stock_analyses,
-        etf_analyses=etf_analyses,
-        consolidation_date=datetime.now()
-    )
+    consolidated = ConsolidatedReportExport(session_id=session_id, stock_analyses=stock_analyses, etf_analyses=etf_analyses, consolidation_date=datetime.now())
 
     # 3. Save to JSON
     output_path = f"output/reports/{session_id}/consolidated_report.json"

--- a/docs/explanations/REPORT_FILE_STRUCTURE.md
+++ b/docs/explanations/REPORT_FILE_STRUCTURE.md
@@ -159,6 +159,7 @@ Directories are created automatically before file writes:
 ```python
 from pathlib import Path
 
+
 def ensure_directory(file_path: str) -> None:
     """Ensure parent directory exists for file path."""
     Path(file_path).parent.mkdir(parents=True, exist_ok=True)
@@ -179,6 +180,7 @@ anything (see "Consolidated Files" above).
 def get_export_path(session_id: str, crew_name: str, ticker: str) -> str:
     """Get path for crew export JSON. No timestamp — see File Naming Conventions above."""
     return f"output/reports/{session_id}/{crew_name}/{ticker}_export.json"
+
 
 def get_html_path(session_id: str, crew_name: str, ticker: str) -> str:
     """Get path for crew HTML report. No timestamp — see File Naming Conventions above."""

--- a/docs/explanations/deep_analysis.md
+++ b/docs/explanations/deep_analysis.md
@@ -18,17 +18,13 @@ For quality companies with exceptional fundamentals, adaptive weights (50%/25%/2
 
 ```python
 # Standard weighting (most companies)
-composite_score = (
-    0.40 * fundamental_score +
-    0.30 * technical_score +
-    0.30 * risk_score
-)
+composite_score = 0.40 * fundamental_score + 0.30 * technical_score + 0.30 * risk_score
 
 # Adaptive weighting (quality companies)
 composite_score = (
-    0.50 * fundamental_score +  # +10% emphasis
-    0.25 * technical_score +    # -5% reduction
-    0.25 * risk_score           # -5% reduction
+    0.50 * fundamental_score  # +10% emphasis
+    + 0.25 * technical_score  # -5% reduction
+    + 0.25 * risk_score  # -5% reduction
 )
 ```
 
@@ -68,12 +64,7 @@ Evaluates long-term financial health and business quality.
 ### Fundamental Score Calculation
 
 ```python
-fundamental_score = (
-    0.40 * roe_score +
-    0.30 * debt_score +
-    0.20 * growth_score +
-    0.10 * margin_score
-)
+fundamental_score = 0.40 * roe_score + 0.30 * debt_score + 0.20 * growth_score + 0.10 * margin_score
 ```
 
 ### Key Principles
@@ -98,11 +89,7 @@ Evaluates price momentum, trends, and market sentiment.
 ### Technical Score Calculation
 
 ```python
-technical_score = (
-    0.40 * rsi_score +
-    0.40 * trend_score +
-    0.20 * momentum_score
-)
+technical_score = 0.40 * rsi_score + 0.40 * trend_score + 0.20 * momentum_score
 ```
 
 ### Trend Classification
@@ -127,11 +114,7 @@ Evaluates volatility, downside risk, and market sensitivity.
 ### Risk Score Calculation
 
 ```python
-risk_score = (
-    0.50 * volatility_score +
-    0.30 * drawdown_score +
-    0.20 * beta_score
-)
+risk_score = 0.50 * volatility_score + 0.30 * drawdown_score + 0.20 * beta_score
 ```
 
 ### Key Adjustments
@@ -197,7 +180,7 @@ All metrics undergo validation before scoring:
 
 ```python
 financials = ticker_data.financials
-revenues = financials.loc['Total Revenue'].sort_index(ascending=False)
+revenues = financials.loc["Total Revenue"].sort_index(ascending=False)
 latest = revenues.iloc[0]
 previous = revenues.iloc[1]
 revenue_growth = (latest - previous) / previous

--- a/docs/explanations/design_principles.md
+++ b/docs/explanations/design_principles.md
@@ -53,17 +53,22 @@ Each component has a single, well-defined responsibility:
 # ✅ Good: Single responsibility
 class TickerExistenceValidationTool:
     """Validates ticker symbols only."""
+
     def validate(self, ticker: str) -> ValidationResult:
         pass
 
+
 class StandardizedRiskScoringTool:
     """Calculates risk metrics only."""
+
     def assess_risk(self, data: dict) -> RiskAssessment:
         pass
+
 
 # ❌ Bad: Multiple responsibilities
 class AnalysisTool:
     """Does everything - validation, analysis, risk, reporting."""
+
     def do_everything(self, ticker: str) -> CompleteReport:
         pass
 ```
@@ -75,13 +80,11 @@ Make dependencies clear and manageable:
 ```python
 # ✅ Good: Explicit dependencies
 class StockAnalyzer:
-    def __init__(self,
-                 validator: TickerExistenceValidationTool,
-                 data_source: YahooFinanceTool,
-                 risk_assessor: StandardizedRiskScoringTool):
+    def __init__(self, validator: TickerExistenceValidationTool, data_source: YahooFinanceTool, risk_assessor: StandardizedRiskScoringTool):
         self.validator = validator
         self.data_source = data_source
         self.risk_assessor = risk_assessor
+
 
 # ❌ Bad: Hidden dependencies
 class StockAnalyzer:
@@ -102,8 +105,11 @@ def analyze_stock(ticker: str) -> StockAnalysis:
     analysis = perform_analysis(validated_data)
     return analysis
 
+
 # ❌ Bad: Mutable shared state
 global_data = {}
+
+
 def analyze_stock(ticker: str):
     global_data[ticker] = fetch_data(ticker)
     modify_global_data(ticker)  # Mutation
@@ -120,6 +126,7 @@ class AnalysisTool(Protocol):
         """Analyze a ticker and return structured results."""
         ...
 
+
 # Implementation follows contract
 class StockAnalysisTool:
     def analyze(self, ticker: str) -> AnalysisResult:
@@ -135,14 +142,14 @@ All data structures use Pydantic models with strict validation:
 
 ```python
 class StockAnalysis(BaseModel):
-    ticker: str = Field(..., pattern=r'^[A-Z]{1,5}$')
-    grade: str = Field(..., pattern=r'^(A\+|A|B|C|D|F)$')
+    ticker: str = Field(..., pattern=r"^[A-Z]{1,5}$")
+    grade: str = Field(..., pattern=r"^(A\+|A|B|C|D|F)$")
     composite_score: float = Field(..., ge=0.0, le=1.0)
 
     model_config = ConfigDict(
-        extra='forbid',           # Reject unknown fields
-        str_strip_whitespace=True, # Clean input data
-        validate_assignment=True   # Validate on assignment
+        extra="forbid",  # Reject unknown fields
+        str_strip_whitespace=True,  # Clean input data
+        validate_assignment=True,  # Validate on assignment
     )
 ```
 
@@ -169,8 +176,8 @@ class AnalysisResult(BaseModel):
     data_freshness: Dict[str, datetime]
     stale_data_warning: bool = False
 
-    @model_validator(mode='after')
-    def check_data_freshness(self) -> 'AnalysisResult':
+    @model_validator(mode="after")
+    def check_data_freshness(self) -> "AnalysisResult":
         now = datetime.now()
         for source, timestamp in self.data_freshness.items():
             age_hours = (now - timestamp).total_seconds() / 3600
@@ -185,21 +192,14 @@ Handle missing data transparently:
 
 ```python
 # ✅ Good: Explicit handling of missing data
-def calculate_score(fundamental: Optional[float],
-                   technical: Optional[float]) -> ScoreResult:
+def calculate_score(fundamental: Optional[float], technical: Optional[float]) -> ScoreResult:
     if fundamental is None and technical is None:
-        return ScoreResult(
-            score=None,
-            confidence=0.0,
-            warning="Insufficient data for scoring"
-        )
+        return ScoreResult(score=None, confidence=0.0, warning="Insufficient data for scoring")
 
     # Calculate with available data
     available_scores = [s for s in [fundamental, technical] if s is not None]
     return ScoreResult(
-        score=sum(available_scores) / len(available_scores),
-        confidence=len(available_scores) / 2.0,
-        warning=None if len(available_scores) == 2 else "Partial data used"
+        score=sum(available_scores) / len(available_scores), confidence=len(available_scores) / 2.0, warning=None if len(available_scores) == 2 else "Partial data used"
     )
 ```
 
@@ -213,9 +213,11 @@ Use AI only where human-like reasoning is required:
 # ✅ Good: AI for reasoning tasks
 class InvestmentAnalyst(Agent):
     """Uses AI to interpret complex financial data and market conditions."""
+
     def analyze_investment_thesis(self, data: dict) -> InvestmentThesis:
         # AI reasoning about qualitative factors
         pass
+
 
 # ✅ Good: Python for deterministic tasks
 def calculate_sharpe_ratio(returns: List[float], risk_free_rate: float) -> float:
@@ -232,7 +234,7 @@ Make AI reasoning visible and auditable:
 class AnalysisResult(BaseModel):
     recommendation: str
     reasoning_steps: List[str]  # Show how AI reached conclusion
-    data_sources: List[str]     # Show what data was used
+    data_sources: List[str]  # Show what data was used
     confidence_factors: Dict[str, float]  # Show confidence breakdown
 ```
 
@@ -244,15 +246,18 @@ Limit AI agent scope to prevent hallucinations:
 # ✅ Good: Bounded scope
 class RiskAssessmentAgent(Agent):
     """Focused on risk assessment only."""
+
     tools = [RiskCalculationTool, VolatilityTool]  # Limited tool set
 
     def assess_risk(self, ticker: str) -> RiskAssessment:
         # Focused task with clear boundaries
         pass
 
+
 # ❌ Bad: Unbounded scope
 class GeneralAnalysisAgent(Agent):
     """Does everything - prone to hallucinations."""
+
     tools = [AllTools]  # Too many tools, unclear boundaries
 ```
 
@@ -268,6 +273,7 @@ def analyze_ticker(ticker: str) -> AnalysisResult:
     # Fast path for single ticker
     pass
 
+
 def analyze_portfolio(tickers: List[str]) -> List[AnalysisResult]:
     # Batch processing for multiple tickers
     return [analyze_ticker(t) for t in tickers]
@@ -282,6 +288,7 @@ Cache expensive operations with appropriate TTL:
 def fetch_market_data(ticker: str) -> MarketData:
     # Expensive API call
     pass
+
 
 @cache(ttl=86400)  # 24 hour cache
 def fetch_fundamental_data(ticker: str) -> FundamentalData:
@@ -300,6 +307,7 @@ async def fetch_multiple_tickers(tickers: List[str]) -> Dict[str, MarketData]:
     results = await asyncio.gather(*tasks)
     return dict(zip(tickers, results))
 
+
 # ✅ Good: Sync for CPU-bound
 def calculate_technical_indicators(prices: List[float]) -> TechnicalIndicators:
     # CPU-bound calculation - no need for async
@@ -315,11 +323,12 @@ Detect errors early and communicate clearly:
 ```python
 # ✅ Good: Fail fast with clear error
 def analyze_ticker(ticker: str) -> AnalysisResult:
-    if not re.match(r'^[A-Z]{1,5}$', ticker):
+    if not re.match(r"^[A-Z]{1,5}$", ticker):
         raise ValueError(f"Invalid ticker format: {ticker}. Must be 1-5 uppercase letters.")
 
     # Continue with valid ticker
     pass
+
 
 # ❌ Bad: Silent failure or unclear error
 def analyze_ticker(ticker: str) -> Optional[AnalysisResult]:
@@ -339,12 +348,9 @@ class AnalysisError(Exception):
         self.remediation = remediation
         super().__init__(f"Analysis failed for {ticker}: {reason}. {remediation}")
 
+
 # Usage
-raise AnalysisError(
-    ticker="INVALID",
-    reason="Ticker not found in market data",
-    remediation="Check ticker spelling or try a different symbol"
-)
+raise AnalysisError(ticker="INVALID", reason="Ticker not found in market data", remediation="Check ticker spelling or try a different symbol")
 ```
 
 ### 3. Graceful Recovery
@@ -374,9 +380,9 @@ Validate all external inputs:
 
 ```python
 class TickerInput(BaseModel):
-    ticker: str = Field(..., pattern=r'^[A-Z]{1,5}$')
+    ticker: str = Field(..., pattern=r"^[A-Z]{1,5}$")
 
-    @field_validator('ticker')
+    @field_validator("ticker")
     @classmethod
     def validate_ticker(cls, v: str) -> str:
         # Additional validation logic
@@ -439,6 +445,7 @@ def test_should_return_buy_recommendation_for_strong_stock():
     assert result.recommendation == "BUY"
     assert result.confidence > 0.8
 
+
 # ❌ Bad: Test implementation details
 def test_should_call_risk_calculator_with_correct_parameters():
     # Testing internal method calls instead of behavior
@@ -452,7 +459,7 @@ Mock all external systems and APIs:
 ```python
 def test_should_handle_api_failure_gracefully(mocker):
     # Mock external API to simulate failure
-    mock_api = mocker.patch('finwiz.tools.yahoo_finance_tool.get_data')
+    mock_api = mocker.patch("finwiz.tools.yahoo_finance_tool.get_data")
     mock_api.side_effect = APIError("Service unavailable")
 
     # Test graceful handling
@@ -470,6 +477,7 @@ def test_should_handle_invalid_ticker_format():
     with pytest.raises(ValueError, match="Invalid ticker format"):
         analyze_stock("invalid_ticker")
 
+
 def test_should_handle_missing_data():
     result = analyze_stock_with_missing_data("AAPL")
     assert result.confidence < 0.5
@@ -484,11 +492,11 @@ Write self-documenting code:
 
 ```python
 # ✅ Good: Self-documenting
-def calculate_risk_adjusted_return(returns: List[float],
-                                 risk_free_rate: float) -> float:
+def calculate_risk_adjusted_return(returns: List[float], risk_free_rate: float) -> float:
     """Calculate Sharpe ratio (risk-adjusted return)."""
     excess_returns = [r - risk_free_rate for r in returns]
     return statistics.mean(excess_returns) / statistics.stdev(excess_returns)
+
 
 # ❌ Bad: Unclear purpose
 def calc(data: List[float], rate: float) -> float:
@@ -539,15 +547,17 @@ Maintain compatibility when possible:
 
 ```python
 # ✅ Good: Backward compatible change
-def analyze_stock(ticker: str,
-                 deep_analysis: bool = False,  # New optional parameter
-                 **kwargs) -> AnalysisResult:
+def analyze_stock(
+    ticker: str,
+    deep_analysis: bool = False,  # New optional parameter
+    **kwargs,
+) -> AnalysisResult:
     # Old calls still work, new functionality available
     pass
 
+
 # ❌ Bad: Breaking change
-def analyze_stock(ticker: str,
-                 analysis_type: str) -> AnalysisResult:  # Required new parameter
+def analyze_stock(ticker: str, analysis_type: str) -> AnalysisResult:  # Required new parameter
     # Breaks existing code
     pass
 ```
@@ -562,9 +572,11 @@ Provide migration paths for breaking changes:
 def analyze_stock(ticker: str) -> AnalysisResult:
     return analyze_stock_v2(ticker, legacy_mode=True)
 
+
 # Phase 2: New method with improved interface
 def analyze_stock_v2(ticker: str, options: AnalysisOptions) -> AnalysisResult:
     pass
+
 
 # Phase 3: Remove deprecated method in next major version
 ```

--- a/docs/explanations/investment_methodology.md
+++ b/docs/explanations/investment_methodology.md
@@ -149,17 +149,13 @@ Quality companies receive **50/25/25** weighting (fundamental/technical/risk) in
 
 ```python
 # Standard companies
-composite_score = (
-    0.40 * fundamental_score +
-    0.30 * technical_score +
-    0.30 * risk_score
-)
+composite_score = 0.40 * fundamental_score + 0.30 * technical_score + 0.30 * risk_score
 
 # Quality companies (2+ quality criteria met)
 composite_score = (
-    0.50 * fundamental_score +  # +10% emphasis on fundamentals
-    0.25 * technical_score +    # -5% less weight on technicals
-    0.25 * risk_score           # -5% less weight on short-term risk
+    0.50 * fundamental_score  # +10% emphasis on fundamentals
+    + 0.25 * technical_score  # -5% less weight on technicals
+    + 0.25 * risk_score  # -5% less weight on short-term risk
 )
 ```
 

--- a/docs/explanations/optimization_theory.md
+++ b/docs/explanations/optimization_theory.md
@@ -166,6 +166,7 @@ Optimize for different market regimes:
 ```python
 import numpy as np
 
+
 def calculate_sample_covariance(returns):
     """Calculate sample covariance matrix."""
     return np.cov(returns.T)
@@ -216,6 +217,7 @@ def capm_expected_returns(returns, market_returns, risk_free_rate):
 ```python
 import cvxpy as cp
 
+
 def mean_variance_optimization(mu, Sigma, risk_aversion):
     """Solve mean-variance optimization problem."""
     n = len(mu)
@@ -227,7 +229,7 @@ def mean_variance_optimization(mu, Sigma, risk_aversion):
     # Constraints
     constraints = [
         cp.sum(w) == 1,  # Weights sum to 1
-        w >= 0           # Long-only
+        w >= 0,  # Long-only
     ]
 
     # Solve
@@ -287,8 +289,8 @@ def equal_risk_contribution(cov_matrix):
 
     # Constraints
     constraints = [
-        {'type': 'eq', 'fun': lambda w: np.sum(w) - 1},  # Sum to 1
-        {'type': 'ineq', 'fun': lambda w: w}             # Non-negative
+        {"type": "eq", "fun": lambda w: np.sum(w) - 1},  # Sum to 1
+        {"type": "ineq", "fun": lambda w: w},  # Non-negative
     ]
 
     # Initial guess
@@ -329,11 +331,7 @@ def factor_attribution(portfolio_returns, factor_returns, factor_loadings):
     # Specific return (alpha)
     specific_return = portfolio_returns - factor_contrib
 
-    return {
-        'factor_contributions': factor_contrib,
-        'specific_return': specific_return,
-        'total_return': portfolio_returns
-    }
+    return {"factor_contributions": factor_contrib, "specific_return": specific_return, "total_return": portfolio_returns}
 ```
 
 ## Backtesting Framework
@@ -348,20 +346,16 @@ def walk_forward_backtest(returns, optimization_func, window=252, rebalance_freq
 
     for t in range(window, len(returns), rebalance_freq):
         # Training data
-        train_data = returns.iloc[t-window:t]
+        train_data = returns.iloc[t - window : t]
 
         # Optimize portfolio
         weights = optimization_func(train_data)
 
         # Out-of-sample performance
-        oos_returns = returns.iloc[t:t+rebalance_freq]
+        oos_returns = returns.iloc[t : t + rebalance_freq]
         portfolio_returns = (oos_returns * weights).sum(axis=1)
 
-        results.append({
-            'date': returns.index[t],
-            'weights': weights,
-            'returns': portfolio_returns
-        })
+        results.append({"date": returns.index[t], "weights": weights, "returns": portfolio_returns})
 
     return results
 ```
@@ -384,12 +378,12 @@ def calculate_performance_metrics(returns):
     max_drawdown = drawdown.min()
 
     return {
-        'total_return': total_return,
-        'annualized_return': annualized_return,
-        'volatility': volatility,
-        'sharpe_ratio': sharpe_ratio,
-        'max_drawdown': max_drawdown,
-        'calmar_ratio': annualized_return / abs(max_drawdown)
+        "total_return": total_return,
+        "annualized_return": annualized_return,
+        "volatility": volatility,
+        "sharpe_ratio": sharpe_ratio,
+        "max_drawdown": max_drawdown,
+        "calmar_ratio": annualized_return / abs(max_drawdown),
     }
 ```
 

--- a/docs/explanations/python_pipeline/best-practices.md
+++ b/docs/explanations/python_pipeline/best-practices.md
@@ -11,31 +11,23 @@ Score uniqueness validation ensures that each holding receives a unique score ba
 ### Implementation
 
 ```python
-def _validate_score_uniqueness(
-    self,
-    analysis_results: dict[str, DeepAnalysisResult]
-) -> None:
+def _validate_score_uniqueness(self, analysis_results: dict[str, DeepAnalysisResult]) -> None:
     """Validate that scores are unique across holdings."""
     if len(analysis_results) < 2:
         # Need at least 2 holdings to check uniqueness
         return
 
     # Extract composite scores
-    composite_scores = [
-        result.composite_score
-        for result in analysis_results.values()
-    ]
+    composite_scores = [result.composite_score for result in analysis_results.values()]
 
     # Calculate standard deviation
     import statistics
+
     composite_std = statistics.stdev(composite_scores)
 
     # Check for identical scores (std dev < 0.03 indicates hardcoded values)
     if composite_std < 0.03:
-        raise ValueError(
-            f"Score validation failed: All holdings have identical scores "
-            f"(std={composite_std:.4f}). Expected unique scores per ticker."
-        )
+        raise ValueError(f"Score validation failed: All holdings have identical scores (std={composite_std:.4f}). Expected unique scores per ticker.")
 ```
 
 ### Best Practices
@@ -54,21 +46,14 @@ Fetching real market data ensures analysis is based on actual market conditions,
 ### Implementation
 
 ```python
-def _extract_holding_data(
-    self,
-    holding: HoldingDecision
-) -> dict[str, Any] | None:
+def _extract_holding_data(self, holding: HoldingDecision) -> dict[str, Any] | None:
     """Extract real market data from holding for scoring."""
     from finwiz.tools.quantitative_analysis_tool import QuantitativeAnalysisTool
 
     try:
         # Fetch real quantitative data
         quant_tool = QuantitativeAnalysisTool()
-        quant_data = quant_tool._run(
-            symbol=holding.ticker,
-            asset_class=holding.asset_class,
-            analysis_type="performance"
-        )
+        quant_data = quant_tool._run(symbol=holding.ticker, asset_class=holding.asset_class, analysis_type="performance")
 
         # Extract real values
         return {
@@ -100,11 +85,7 @@ Standardized export structure ensures downstream systems can reliably consume an
 ### Implementation
 
 ```python
-def _export_json_files(
-    self,
-    json_exports: dict[str, Any],
-    session_id: str
-) -> dict[str, Any]:
+def _export_json_files(self, json_exports: dict[str, Any], session_id: str) -> dict[str, Any]:
     """Export JSON files to proper output directories."""
     # Create asset class directories
     stock_dir = self.output_dir / "stock"
@@ -156,17 +137,9 @@ Graceful error handling ensures the pipeline continues processing even when indi
 ### Implementation
 
 ```python
-def analyze_portfolio_holdings(
-    self,
-    holdings: list[HoldingDecision],
-    session_id: str
-) -> dict[str, Any]:
+def analyze_portfolio_holdings(self, holdings: list[HoldingDecision], session_id: str) -> dict[str, Any]:
     """Analyze all portfolio holdings with error handling."""
-    results = {
-        "successful_analyses": 0,
-        "failed_analyses": 0,
-        "deep_analysis_results": {}
-    }
+    results = {"successful_analyses": 0, "failed_analyses": 0, "deep_analysis_results": {}}
 
     for holding in holdings:
         try:
@@ -180,11 +153,7 @@ def analyze_portfolio_holdings(
                 continue
 
             # Run analysis
-            analysis_result = self.scorer.calculate_composite_score(
-                ticker=holding.ticker,
-                asset_class=holding.asset_class,
-                data=data
-            )
+            analysis_result = self.scorer.calculate_composite_score(ticker=holding.ticker, asset_class=holding.asset_class, data=data)
 
             # Store result
             results["deep_analysis_results"][holding.ticker] = analysis_result
@@ -248,6 +217,7 @@ While the current implementation processes holdings sequentially, consider these
 # Future: Parallel processing with asyncio
 import asyncio
 
+
 async def analyze_holding_async(holding, session_id):
     """Async analysis for parallel processing."""
     # Fetch data asynchronously
@@ -258,17 +228,16 @@ async def analyze_holding_async(holding, session_id):
 
     return result
 
+
 # Process multiple holdings in parallel
-results = await asyncio.gather(*[
-    analyze_holding_async(h, session_id)
-    for h in holdings
-])
+results = await asyncio.gather(*[analyze_holding_async(h, session_id) for h in holdings])
 ```
 
 ### Caching Strategy
 
 ```python
 from functools import lru_cache
+
 
 @lru_cache(maxsize=1000)
 def get_market_data(ticker: str, date: str) -> dict:
@@ -283,7 +252,7 @@ def get_market_data(ticker: str, date: str) -> dict:
 BATCH_SIZE = 10
 
 for i in range(0, len(holdings), BATCH_SIZE):
-    batch = holdings[i:i + BATCH_SIZE]
+    batch = holdings[i : i + BATCH_SIZE]
     batch_results = analyze_batch(batch, session_id)
 
     # Write results immediately
@@ -301,14 +270,10 @@ for i in range(0, len(holdings), BATCH_SIZE):
 def test_should_calculate_unique_scores_per_ticker(mocker):
     """Test that each ticker gets unique score."""
     # Arrange
-    holdings = [
-        create_holding("AAPL"),
-        create_holding("MSFT"),
-        create_holding("GOOGL")
-    ]
+    holdings = [create_holding("AAPL"), create_holding("MSFT"), create_holding("GOOGL")]
 
     # Mock data fetching to return different values
-    mocker.patch('finwiz.tools.quantitative_analysis_tool.QuantitativeAnalysisTool._run')
+    mocker.patch("finwiz.tools.quantitative_analysis_tool.QuantitativeAnalysisTool._run")
 
     # Act
     results = analyze_portfolio_with_python(holdings, "test_session")
@@ -344,10 +309,7 @@ def test_should_complete_full_pipeline():
 ### Code Documentation
 
 ```python
-def analyze_portfolio_with_python(
-    holdings: list[HoldingDecision],
-    session_id: str
-) -> dict[str, Any]:
+def analyze_portfolio_with_python(holdings: list[HoldingDecision], session_id: str) -> dict[str, Any]:
     """
     Analyze portfolio holdings using pure Python.
 

--- a/docs/explanations/python_pipeline/components.md
+++ b/docs/explanations/python_pipeline/components.md
@@ -28,10 +28,7 @@ The Portfolio Deep Analyzer (`portfolio_deep_analyzer.py`) replaces AI-based Dee
 ```python
 from finwiz.scoring.portfolio_deep_analyzer import analyze_portfolio_with_python
 
-results = analyze_portfolio_with_python(
-    holdings=portfolio_holdings,
-    session_id="analysis_session_123"
-)
+results = analyze_portfolio_with_python(holdings=portfolio_holdings, session_id="analysis_session_123")
 
 # Access results
 print(f"Successful: {results['successful_analyses']}")
@@ -75,9 +72,7 @@ output/crypto/*.json ─┘
 ```python
 from finwiz.orchestrators.discovery.aplus_discovery_integrator import integrate_aplus_discovery_with_deep_analysis
 
-discovery_results = integrate_aplus_discovery_with_deep_analysis(
-    session_id="analysis_session_123"
-)
+discovery_results = integrate_aplus_discovery_with_deep_analysis(session_id="analysis_session_123")
 
 if discovery_results["has_a_plus_analysis"]:
     print(f"Found {discovery_results['total_opportunities_found']} opportunities")
@@ -133,9 +128,7 @@ The Backtesting Pipeline Connector (`backtesting_pipeline_connector.py`) automat
 ```python
 from finwiz.integration.backtesting_pipeline_connector import connect_backtesting_to_discovery_results
 
-backtesting_results = connect_backtesting_to_discovery_results(
-    session_id="analysis_session_123"
-)
+backtesting_results = connect_backtesting_to_discovery_results(session_id="analysis_session_123")
 
 if backtesting_results["backtesting_executed"]:
     print(f"Backtested {backtesting_results['candidates_count']} candidates")
@@ -210,11 +203,7 @@ The Python Report Generator (`python_report_generator.py`) generates comprehensi
 ```python
 from finwiz.reporting.python_report_generator import generate_python_report
 
-report_path = generate_python_report(
-    portfolio_review=portfolio_review,
-    deep_analysis_results=analysis_results,
-    session_id="analysis_session_123"
-)
+report_path = generate_python_report(portfolio_review=portfolio_review, deep_analysis_results=analysis_results, session_id="analysis_session_123")
 
 print(f"Report generated: {report_path}")
 ```

--- a/docs/explanations/python_pipeline/troubleshooting.md
+++ b/docs/explanations/python_pipeline/troubleshooting.md
@@ -62,6 +62,7 @@ The `QuantitativeAnalysisTool` is returning default values instead of real marke
 
    ```python
    import logging
+
    logging.basicConfig(level=logging.DEBUG)
 
    # Run analysis and check logs
@@ -138,10 +139,7 @@ discovery_results["total_opportunities_found"] == 0
 
    ```python
    # Look for A+ or A grades
-   aplus_count = sum(
-       1 for r in analysis_results["deep_analysis_results"].values()
-       if r.grade in ["A+", "A"]
-   )
+   aplus_count = sum(1 for r in analysis_results["deep_analysis_results"].values() if r.grade in ["A+", "A"])
    print(f"Found {aplus_count} A+/A grade holdings")
    ```
 
@@ -384,6 +382,7 @@ Analysis takes longer than expected (> 2 seconds per holding).
    # Cache market data to avoid redundant API calls
    from functools import lru_cache
 
+
    @lru_cache(maxsize=1000)
    def get_cached_data(ticker, date):
        return fetch_market_data(ticker, date)
@@ -395,7 +394,7 @@ Analysis takes longer than expected (> 2 seconds per holding).
    # Process holdings in batches
    BATCH_SIZE = 10
    for i in range(0, len(holdings), BATCH_SIZE):
-       batch = holdings[i:i + BATCH_SIZE]
+       batch = holdings[i : i + BATCH_SIZE]
        process_batch(batch)
    ```
 
@@ -437,6 +436,7 @@ Memory usage increases significantly during analysis.
        for holding in holdings:
            yield analyze_holding(holding)
 
+
    # Process one at a time
    for result in analyze_holdings_generator(holdings):
        export_result(result)
@@ -459,10 +459,7 @@ Memory usage increases significantly during analysis.
 ```python
 import logging
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 # Run analysis with debug logging
 results = analyze_portfolio_with_python(holdings, session_id)

--- a/docs/explanations/recommendation_engine.md
+++ b/docs/explanations/recommendation_engine.md
@@ -262,10 +262,7 @@ consistency_confidence = max(0.5, 1.0 - score_std * 2)
 
 # Data quality: -0.1 per missing field among current_price, volatility, rsi
 data_quality = 1.0
-missing_fields = sum(
-    1 for field in ["current_price", "volatility", "rsi"]
-    if field not in data or data[field] is None
-)
+missing_fields = sum(1 for field in ["current_price", "volatility", "rsi"] if field not in data or data[field] is None)
 data_quality -= missing_fields * 0.1
 
 confidence_level = min(1.0, max(0.3, consistency_confidence * data_quality))

--- a/docs/how-to/BATCH_PROCESSING.md
+++ b/docs/how-to/BATCH_PROCESSING.md
@@ -69,10 +69,7 @@ def execute_deep_analysis_with_prefetch(self) -> dict[str, Any]:
 
     for batch_num, batch_tickers in enumerate(batches):
         # Execute batch concurrently
-        batch_results = await asyncio.gather(*[
-            execute_deep_analysis_crew(ticker, prefetched_data[ticker])
-            for ticker in batch_tickers
-        ])
+        batch_results = await asyncio.gather(*[execute_deep_analysis_crew(ticker, prefetched_data[ticker]) for ticker in batch_tickers])
 
         # Process batch results
         for ticker, result in zip(batch_tickers, batch_results):
@@ -260,6 +257,7 @@ The system monitors memory usage and adjusts batch sizes:
 import psutil
 from finwiz.infrastructure.monitoring.memory_manager import MemoryManager
 
+
 def adjust_batch_size_for_memory(base_batch_size: int) -> int:
     """Adjust batch size based on available memory."""
     memory_manager = MemoryManager()
@@ -297,10 +295,7 @@ async def _fetch_yahoo_finance_batch(self, tickers: list[str]) -> dict[str, Any]
             try:
                 # Process individual ticker data
                 ticker_data = self._process_yahoo_data(ticker, data)
-                results[ticker] = {
-                    "yahoo_finance": ticker_data,
-                    "failed": False
-                }
+                results[ticker] = {"yahoo_finance": ticker_data, "failed": False}
             except Exception as e:
                 # Individual ticker failed - continue with others
                 logger.error(f"Failed to process Yahoo Finance data for {ticker}: {e}")
@@ -406,20 +401,11 @@ state is serialized, not in a standalone report.
    def optimize_for_portfolio_size(portfolio_size: int) -> dict[str, str]:
        """Optimize configuration based on portfolio size."""
        if portfolio_size <= 10:
-           return {
-               "DEEP_ANALYSIS_BATCH_SIZE": "3",
-               "BATCH_PREFETCH_MIN_HOLDINGS": "5"
-           }
+           return {"DEEP_ANALYSIS_BATCH_SIZE": "3", "BATCH_PREFETCH_MIN_HOLDINGS": "5"}
        elif portfolio_size <= 50:
-           return {
-               "DEEP_ANALYSIS_BATCH_SIZE": "5",
-               "BATCH_PREFETCH_MIN_HOLDINGS": "10"
-           }
+           return {"DEEP_ANALYSIS_BATCH_SIZE": "5", "BATCH_PREFETCH_MIN_HOLDINGS": "10"}
        else:
-           return {
-               "DEEP_ANALYSIS_BATCH_SIZE": "8",
-               "BATCH_PREFETCH_MIN_HOLDINGS": "15"
-           }
+           return {"DEEP_ANALYSIS_BATCH_SIZE": "8", "BATCH_PREFETCH_MIN_HOLDINGS": "15"}
    ```
 
 2. **Memory-Based Configuration**:
@@ -441,15 +427,9 @@ state is serialized, not in a standalone report.
    def optimize_for_api_tier(has_premium_alpha_vantage: bool) -> dict[str, str]:
        """Optimize configuration based on API tier."""
        if has_premium_alpha_vantage:
-           return {
-               "ENABLE_ALPHA_VANTAGE": "true",
-               "DEEP_ANALYSIS_BATCH_SIZE": "8"
-           }
+           return {"ENABLE_ALPHA_VANTAGE": "true", "DEEP_ANALYSIS_BATCH_SIZE": "8"}
        else:
-           return {
-               "ENABLE_ALPHA_VANTAGE": "false",
-               "DEEP_ANALYSIS_BATCH_SIZE": "5"
-           }
+           return {"ENABLE_ALPHA_VANTAGE": "false", "DEEP_ANALYSIS_BATCH_SIZE": "5"}
    ```
 
 ## Troubleshooting

--- a/docs/how-to/MEMORY_MANAGEMENT.md
+++ b/docs/how-to/MEMORY_MANAGEMENT.md
@@ -67,7 +67,7 @@ from finwiz.integration.batch_data_prefetcher import BatchDataPreFetcher
 # Alpha Vantage is DISABLED by default (recommended)
 prefetcher = BatchDataPreFetcher(
     session_id="session-123",
-    enable_alpha_vantage=False  # Recommended: Yahoo Finance only
+    enable_alpha_vantage=False,  # Recommended: Yahoo Finance only
 )
 
 # Pre-fetch data (memory is monitored automatically)
@@ -121,6 +121,7 @@ cleanup_result = memory_manager.cleanup_cache()
 from finwiz.integration.batch_data_prefetcher import BatchDataPreFetcher
 from finwiz.infrastructure.monitoring.memory_manager import get_memory_manager
 
+
 class FinwizFlow(Flow[FinwizState]):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -135,7 +136,7 @@ class FinwizFlow(Flow[FinwizState]):
         session_id = self.state.session_id
         self.prefetcher = BatchDataPreFetcher(
             session_id=session_id,
-            enable_alpha_vantage=False  # Yahoo Finance only for speed
+            enable_alpha_vantage=False,  # Yahoo Finance only for speed
         )
 
         # Get memory manager reference
@@ -181,11 +182,7 @@ class FinwizFlow(Flow[FinwizState]):
             logger.warning("Memory constraints were exceeded during execution")
 
         # Store metrics in state
-        self.state.batch_prefetch_metrics = {
-            "memory": memory_metrics,
-            "tickers_analyzed": len(results),
-            "successful": sum(1 for r in results.values() if r.get("success", False))
-        }
+        self.state.batch_prefetch_metrics = {"memory": memory_metrics, "tickers_analyzed": len(results), "successful": sum(1 for r in results.values() if r.get("success", False))}
 
         return {"results": results, "memory_metrics": memory_metrics}
 
@@ -194,10 +191,7 @@ class FinwizFlow(Flow[FinwizState]):
         if self.prefetcher:
             logger.info("Cleaning up batch prefetch cache...")
             cleanup_result = self.prefetcher.cleanup_cache()
-            logger.info(
-                f"Cache cleanup complete: {cleanup_result['files_removed']} files, "
-                f"{cleanup_result['disk_freed_mb']} MB freed"
-            )
+            logger.info(f"Cache cleanup complete: {cleanup_result['files_removed']} files, {cleanup_result['disk_freed_mb']} MB freed")
 ```
 
 ## Memory Monitoring
@@ -297,16 +291,10 @@ cleanup_result = memory_manager.cleanup_cache()
     "within_limit": True,
     "peak_usage_percent": 14.6,
     "samples": [
-        {
-            "stage": "pre-fetch-start",
-            "memory_mb": 100.0,
-            "delta_mb": 0.0,
-            "peak_mb": 100.0,
-            "within_limit": True
-        },
+        {"stage": "pre-fetch-start", "memory_mb": 100.0, "delta_mb": 0.0, "peak_mb": 100.0, "within_limit": True},
         # ... more samples ...
     ],
-    "sample_count": 10
+    "sample_count": 10,
 }
 ```
 
@@ -316,15 +304,7 @@ Memory metrics should be included in batch execution reports:
 
 ```python
 # Save to batch_execution_metrics.json
-metrics = {
-    "execution": {
-        "total_time": 120.5,
-        "tickers_analyzed": 66,
-        "successful": 64
-    },
-    "memory": prefetcher.get_memory_metrics(),
-    "cleanup": cleanup_result
-}
+metrics = {"execution": {"total_time": 120.5, "tickers_analyzed": 66, "successful": 64}, "memory": prefetcher.get_memory_metrics(), "cleanup": cleanup_result}
 
 with open("batch_execution_metrics.json", "w") as f:
     json.dump(metrics, f, indent=2)
@@ -425,6 +405,7 @@ def test_memory_monitoring(tmp_path):
     sample2 = manager.monitor_memory("stage-2")
     assert sample2["peak_mb"] >= sample1["memory_mb"]
 
+
 def test_cache_cleanup(tmp_path):
     """Test cache cleanup functionality."""
     manager = MemoryManager(session_id="test-123")
@@ -438,6 +419,7 @@ def test_cache_cleanup(tmp_path):
     result = manager.cleanup_cache()
     assert result["success"]
     assert not cache_dir.exists()
+
 
 def test_memory_constraints():
     """Test memory constraint validation."""

--- a/docs/how-to/OPERATIONS_GUIDE.md
+++ b/docs/how-to/OPERATIONS_GUIDE.md
@@ -276,10 +276,7 @@ from finwiz.crews.deep_analysis.deep_analysis import DeepAnalysisCrew
 crew = DeepAnalysisCrew()
 
 # Execute analysis
-result = crew.crew().kickoff(inputs={
-    "ticker": "AAPL",
-    "asset_class": "stock"
-})
+result = crew.crew().kickoff(inputs={"ticker": "AAPL", "asset_class": "stock"})
 
 # Access results
 print(f"Grade: {result.grade}")
@@ -289,19 +286,13 @@ print(f"Composite Score: {result.composite_score}")
 **Analyze an ETF:**
 
 ```python
-result = crew.crew().kickoff(inputs={
-    "ticker": "VOO",
-    "asset_class": "etf"
-})
+result = crew.crew().kickoff(inputs={"ticker": "VOO", "asset_class": "etf"})
 ```
 
 **Analyze Crypto:**
 
 ```python
-result = crew.crew().kickoff(inputs={
-    "ticker": "BTC",
-    "asset_class": "crypto"
-})
+result = crew.crew().kickoff(inputs={"ticker": "BTC", "asset_class": "crypto"})
 ```
 
 ### Configuration
@@ -903,7 +894,7 @@ export FINWIZ_FLOW_TIMEOUT=14400
 ```python
 from finwiz.config.resilience_config import get_resilience_config
 
-config = get_resilience_config()   # singleton, built from the environment
+config = get_resilience_config()  # singleton, built from the environment
 ```
 
 If you do construct one directly, all 13 fields are required: `max_retries`,
@@ -1196,8 +1187,8 @@ from finwiz.quantitative.portfolio_monitor import MonitoringRule
 rule = MonitoringRule(
     rule_id="portfolio_monitor",
     rule_name="Standard Portfolio Monitoring",
-    max_deviation_threshold=0.08,     # 8% threshold
-    min_check_interval_hours=1,       # 1-168
+    max_deviation_threshold=0.08,  # 8% threshold
+    min_check_interval_hours=1,  # 1-168
     alert_on_deviation=True,
     alert_on_multiple_positions=True,
     min_positions_for_alert=2,
@@ -1330,16 +1321,16 @@ Configure caching behavior through `CacheConfig`:
 from finwiz.infrastructure.caching.manager import CacheBackend, CacheConfig, CacheManager, CacheStrategy
 
 config = CacheConfig(
-    backend=CacheBackend.HYBRID,        # memory, file, or hybrid
-    default_ttl=2700,                   # 45 minutes default TTL
-    max_memory_items=1000,              # Memory cache size limit
-    max_file_size_mb=100,               # File cache size limit
-    cache_directory="cache",            # Cache file directory
-    strategy=CacheStrategy.TTL,         # Eviction strategy
-    enable_compression=True,            # Compress cached data
-    auto_cleanup=True,                  # Automatic cleanup
-    cleanup_interval=3600,              # Cleanup every hour
-    hit_rate_threshold=0.7              # Minimum effective hit rate
+    backend=CacheBackend.HYBRID,  # memory, file, or hybrid
+    default_ttl=2700,  # 45 minutes default TTL
+    max_memory_items=1000,  # Memory cache size limit
+    max_file_size_mb=100,  # File cache size limit
+    cache_directory="cache",  # Cache file directory
+    strategy=CacheStrategy.TTL,  # Eviction strategy
+    enable_compression=True,  # Compress cached data
+    auto_cleanup=True,  # Automatic cleanup
+    cleanup_interval=3600,  # Cleanup every hour
+    hit_rate_threshold=0.7,  # Minimum effective hit rate
 )
 
 cache = CacheManager(config)
@@ -1542,9 +1533,9 @@ The circuit breaker pattern automatically disables failing services:
 degradation_manager = get_degradation_manager()
 degradation_manager.update_service_config(
     "external_api",
-    error_threshold=5,        # Open circuit after 5 failures
+    error_threshold=5,  # Open circuit after 5 failures
     circuit_breaker_timeout=300,  # Wait 5 minutes before retry
-    recovery_threshold=2      # Close circuit after 2 successes
+    recovery_threshold=2,  # Close circuit after 2 successes
 )
 ```
 

--- a/docs/how-to/PERFORMANCE_CONFIGURATION.md
+++ b/docs/how-to/PERFORMANCE_CONFIGURATION.md
@@ -158,12 +158,7 @@ else:
 The system automatically determines the optimization mode based on configuration:
 
 ```python
-def _determine_optimization_mode(
-    self,
-    use_mini: bool,
-    minimal_tools: bool,
-    ai_summary: bool
-) -> OptimizationMode:
+def _determine_optimization_mode(self, use_mini: bool, minimal_tools: bool, ai_summary: bool) -> OptimizationMode:
     """Determine optimization mode based on configuration."""
     if use_mini and minimal_tools and not ai_summary:
         return OptimizationMode.MAXIMUM_SPEED
@@ -184,11 +179,11 @@ The system tracks comprehensive performance metrics:
 class PerformanceMetrics:
     """Performance metrics tracking."""
 
-    execution_time: float = 0.0      # Total execution time
-    llm_call_count: int = 0          # Number of LLM API calls
-    api_call_count: int = 0          # Number of external API calls
-    cost_estimate: float = 0.0       # Estimated cost in USD
-    ticker: str = ""                 # Analyzed ticker
+    execution_time: float = 0.0  # Total execution time
+    llm_call_count: int = 0  # Number of LLM API calls
+    api_call_count: int = 0  # Number of external API calls
+    cost_estimate: float = 0.0  # Estimated cost in USD
+    ticker: str = ""  # Analyzed ticker
     mode: OptimizationMode = OptimizationMode.BASELINE
 ```
 
@@ -347,29 +342,29 @@ def configure_crew_for_mode(mode: OptimizationMode) -> Dict[str, Any]:
 
     if mode == OptimizationMode.MAXIMUM_SPEED:
         return {
-            "reasoning": False,        # Disable reasoning for speed
-            "planning": False,         # Disable planning for speed
-            "allow_delegation": False, # Disable delegation for speed
-            "max_rpm": 30,            # Higher rate limit
-            "llm": "gpt-4o-mini"       # Faster, cheaper model
+            "reasoning": False,  # Disable reasoning for speed
+            "planning": False,  # Disable planning for speed
+            "allow_delegation": False,  # Disable delegation for speed
+            "max_rpm": 30,  # Higher rate limit
+            "llm": "gpt-4o-mini",  # Faster, cheaper model
         }
 
     elif mode == OptimizationMode.BALANCED:
         return {
-            "reasoning": True,         # Enable reasoning for quality
-            "planning": False,         # Disable planning for speed
-            "allow_delegation": False, # Disable delegation for speed
-            "max_rpm": 20,            # Standard rate limit
-            "llm": "gpt-4o-mini"       # Balanced model
+            "reasoning": True,  # Enable reasoning for quality
+            "planning": False,  # Disable planning for speed
+            "allow_delegation": False,  # Disable delegation for speed
+            "max_rpm": 20,  # Standard rate limit
+            "llm": "gpt-4o-mini",  # Balanced model
         }
 
     else:  # BASELINE
         return {
-            "reasoning": True,         # Full reasoning enabled
-            "planning": True,          # Full planning enabled
+            "reasoning": True,  # Full reasoning enabled
+            "planning": True,  # Full planning enabled
             "allow_delegation": True,  # Full delegation enabled
-            "max_rpm": 15,            # Conservative rate limit
-            "llm": "gpt-4"            # Highest quality model
+            "max_rpm": 15,  # Conservative rate limit
+            "llm": "gpt-4",  # Highest quality model
         }
 ```
 
@@ -464,27 +459,15 @@ def optimize_for_portfolio_size(portfolio_size: int) -> OptimizationConfig:
 
     if portfolio_size <= 5:
         # Small portfolio - use baseline for quality
-        return OptimizationConfig(
-            mode=OptimizationMode.BASELINE,
-            deep_analysis_batch_size=1,
-            risk_assessment_use_mini=False
-        )
+        return OptimizationConfig(mode=OptimizationMode.BASELINE, deep_analysis_batch_size=1, risk_assessment_use_mini=False)
 
     elif portfolio_size <= 20:
         # Medium portfolio - use balanced approach
-        return OptimizationConfig(
-            mode=OptimizationMode.BALANCED,
-            deep_analysis_batch_size=3,
-            deep_analysis_ai_summary=True
-        )
+        return OptimizationConfig(mode=OptimizationMode.BALANCED, deep_analysis_batch_size=3, deep_analysis_ai_summary=True)
 
     else:
         # Large portfolio - use maximum speed
-        return OptimizationConfig(
-            mode=OptimizationMode.MAXIMUM_SPEED,
-            deep_analysis_batch_size=min(8, portfolio_size // 8),
-            deep_analysis_ai_summary=False
-        )
+        return OptimizationConfig(mode=OptimizationMode.MAXIMUM_SPEED, deep_analysis_batch_size=min(8, portfolio_size // 8), deep_analysis_ai_summary=False)
 ```
 
 ### Time-Based Optimization
@@ -497,8 +480,8 @@ def optimize_for_time_constraint(max_time_minutes: int, portfolio_size: int) -> 
 
     estimated_time = {
         OptimizationMode.MAXIMUM_SPEED: portfolio_size * 0.5,  # 30s per ticker
-        OptimizationMode.BALANCED: portfolio_size * 0.75,      # 45s per ticker
-        OptimizationMode.BASELINE: portfolio_size * 8.0        # 8 min per ticker
+        OptimizationMode.BALANCED: portfolio_size * 0.75,  # 45s per ticker
+        OptimizationMode.BASELINE: portfolio_size * 8.0,  # 8 min per ticker
     }
 
     # Choose fastest mode that fits time constraint
@@ -507,10 +490,7 @@ def optimize_for_time_constraint(max_time_minutes: int, portfolio_size: int) -> 
             return OptimizationConfig(mode=mode)
 
     # If no mode fits, use maximum speed with larger batches
-    return OptimizationConfig(
-        mode=OptimizationMode.MAXIMUM_SPEED,
-        deep_analysis_batch_size=min(15, portfolio_size // 4)
-    )
+    return OptimizationConfig(mode=OptimizationMode.MAXIMUM_SPEED, deep_analysis_batch_size=min(15, portfolio_size // 4))
 ```
 
 ### Cost-Based Optimization
@@ -522,9 +502,9 @@ def optimize_for_budget(max_cost_usd: float, portfolio_size: int) -> Optimizatio
     """Optimize configuration for budget constraints."""
 
     estimated_cost = {
-        OptimizationMode.MAXIMUM_SPEED: 0.0,                    # $0 per ticker
-        OptimizationMode.BALANCED: portfolio_size * 0.01,       # $0.01 per ticker
-        OptimizationMode.BASELINE: portfolio_size * 0.075       # $0.075 per ticker
+        OptimizationMode.MAXIMUM_SPEED: 0.0,  # $0 per ticker
+        OptimizationMode.BALANCED: portfolio_size * 0.01,  # $0.01 per ticker
+        OptimizationMode.BASELINE: portfolio_size * 0.075,  # $0.075 per ticker
     }
 
     # Choose most comprehensive mode within budget
@@ -567,6 +547,7 @@ os.environ["ENABLE_ALPHA_VANTAGE"] = "false"  # Disable for speed
 ```python
 # Diagnosis
 import psutil
+
 memory_usage = psutil.virtual_memory().percent
 
 if memory_usage > 80:
@@ -586,9 +567,9 @@ logger.info(f"Reduced batch size from {current_batch_size} to {new_batch_size}")
 # fallback; on failure run_batch_prefetch just returns {} and logs the
 # exception, then deep analysis continues without the prefetched cache)
 import subprocess
-result = subprocess.run(["grep", "Batch prefetch failed", "logs/finwiz.log"],
-                       capture_output=True, text=True)
-failures = result.stdout.strip().split('\n')
+
+result = subprocess.run(["grep", "Batch prefetch failed", "logs/finwiz.log"], capture_output=True, text=True)
+failures = result.stdout.strip().split("\n")
 
 for failure in failures[-5:]:  # Last 5 failures
     logger.info(f"Recent failure: {failure}")
@@ -617,9 +598,9 @@ os.environ["DEEP_ANALYSIS_AI_SUMMARY"] = "false"
 ```python
 # Diagnosis: Check for ticker-specific failures
 import subprocess
-result = subprocess.run(["grep", "Failed to process.*data for", "logs/finwiz.log"],
-                       capture_output=True, text=True)
-failed_tickers = result.stdout.strip().split('\n')
+
+result = subprocess.run(["grep", "Failed to process.*data for", "logs/finwiz.log"], capture_output=True, text=True)
+failed_tickers = result.stdout.strip().split("\n")
 
 # Analyze failure patterns
 ticker_failures = {}

--- a/docs/how-to/PYTHON_SCORING_ENGINE.md
+++ b/docs/how-to/PYTHON_SCORING_ENGINE.md
@@ -35,9 +35,9 @@ The composite score is calculated using a weighted average of three components:
 
 ```python
 composite_score = (
-    0.40 * fundamental_score +  # 40% weight
-    0.30 * technical_score +    # 30% weight
-    0.30 * risk_score          # 30% weight
+    0.40 * fundamental_score  # 40% weight
+    + 0.30 * technical_score  # 30% weight
+    + 0.30 * risk_score  # 30% weight
 )
 ```
 
@@ -88,11 +88,16 @@ composite_score = (
 
 ```python
 # ROE Scoring
-if roe >= 0.20:     score = 1.0  # 20%+
-elif roe >= 0.15:   score = 0.8  # 15-20%
-elif roe >= 0.10:   score = 0.6  # 10-15%
-elif roe >= 0.05:   score = 0.4  # 5-10%
-else:               score = 0.2  # <5%
+if roe >= 0.20:
+    score = 1.0  # 20%+
+elif roe >= 0.15:
+    score = 0.8  # 15-20%
+elif roe >= 0.10:
+    score = 0.6  # 10-15%
+elif roe >= 0.05:
+    score = 0.4  # 5-10%
+else:
+    score = 0.2  # <5%
 ```
 
 ### ETF Scoring (40% Fundamental Weight)
@@ -256,38 +261,29 @@ scorer = DeepAnalysisScorer()
 # Prepare data (from data collection task)
 data = {
     "current_price": 150.0,
-    "roe": 0.25,              # 25% ROE
-    "debt_to_equity": 0.3,    # Low debt
-    "revenue_growth": 0.15,   # 15% growth
-    "rsi": 55.0,              # Neutral RSI
-    "volatility": 0.18,       # 18% volatility
-    "beta": 1.1,              # Slightly aggressive
+    "roe": 0.25,  # 25% ROE
+    "debt_to_equity": 0.3,  # Low debt
+    "revenue_growth": 0.15,  # 15% growth
+    "rsi": 55.0,  # Neutral RSI
+    "volatility": 0.18,  # 18% volatility
+    "beta": 1.1,  # Slightly aggressive
     # ... additional metrics
 }
 
 # Calculate composite score
-result = scorer.calculate_composite_score(
-    ticker="AAPL",
-    asset_class="stock",
-    data=data
-)
+result = scorer.calculate_composite_score(ticker="AAPL", asset_class="stock", data=data)
 
-print(f"Grade: {result.grade}")                    # A
-print(f"Score: {result.composite_score:.2f}")      # 0.78
-print(f"Recommendation: {result.recommendation}")   # BUY
-print(f"Confidence: {result.confidence:.1%}")      # 85%
+print(f"Grade: {result.grade}")  # A
+print(f"Score: {result.composite_score:.2f}")  # 0.78
+print(f"Recommendation: {result.recommendation}")  # BUY
+print(f"Confidence: {result.confidence:.1%}")  # 85%
 ```
 
 ### Complete Analysis Pipeline
 
 ```python
 # Complete analysis with export generation
-result, crew_export = scorer.analyze_and_export(
-    ticker="AAPL",
-    asset_class="stock",
-    collected_data=data,
-    session_id="analysis_2025_01_25"
-)
+result, crew_export = scorer.analyze_and_export(ticker="AAPL", asset_class="stock", collected_data=data, session_id="analysis_2025_01_25")
 
 # Access detailed analysis
 detailed = crew_export["detailed_analysis"]
@@ -311,10 +307,10 @@ from finwiz.scoring.thresholds import get_thresholds
 
 custom = replace(
     get_thresholds(),
-    grade_a_plus=0.97,        # stricter A+
-    grade_a=0.90,             # stricter A
-    buy_threshold=0.90,       # stricter buy
-    sell_threshold=0.55,      # more aggressive sell
+    grade_a_plus=0.97,  # stricter A+
+    grade_a=0.90,  # stricter A
+    buy_threshold=0.90,  # stricter buy
+    sell_threshold=0.55,  # more aggressive sell
 )
 
 scorer = DeepAnalysisScorer(thresholds=custom)
@@ -338,7 +334,6 @@ detailed_analysis = {
         "macd": 0.05,
         # ... all original metrics
     },
-
     # Sentiment data (Requirement 18.22)
     "sentiment_data": {
         "sentiment_score": 0.65,
@@ -346,7 +341,6 @@ detailed_analysis = {
         "article_count": 25,
         "news_sources": ["Reuters", "Bloomberg"],
     },
-
     # Technical indicators (Requirement 18.23)
     "technical_indicators": {
         "support_levels": [145.0, 140.0],
@@ -354,7 +348,6 @@ detailed_analysis = {
         "trend_direction": "uptrend",
         "momentum_indicators": {...},
     },
-
     # Fundamental data (Requirement 18.24)
     "fundamental_data": {
         "revenue": 365000000000,
@@ -362,7 +355,6 @@ detailed_analysis = {
         "sec_filings": {...},
         "financial_statements": {...},
     },
-
     # Calculation results (Requirement 18.25)
     "calculation_results": {
         "composite_score": 0.78,
@@ -371,7 +363,7 @@ detailed_analysis = {
         "risk_score": 0.77,
         "grade": "A",
         "recommendation": "BUY",
-    }
+    },
 }
 ```
 
@@ -409,7 +401,7 @@ def _create_error_result(self, ticker: str, asset_class: str, error_msg: str) ->
         grade="D",
         recommendation="SELL",
         confidence=0.1,
-        rationale=f"Analysis failed: {error_msg}. Default low scores assigned."
+        rationale=f"Analysis failed: {error_msg}. Default low scores assigned.",
     )
 ```
 
@@ -424,10 +416,10 @@ The Python scoring engine has comprehensive unit test coverage:
 def test_should_calculate_stock_fundamental_score_with_excellent_metrics():
     scorer = FundamentalScorer()
     data = {
-        "roe": 0.25,              # 25% ROE -> 1.0 score
-        "debt_to_equity": 0.2,    # Low debt -> 1.0 score
-        "revenue_growth": 0.30,   # 30% growth -> 1.0 score
-        "profit_margin": 0.25     # 25% margin -> 1.0 score
+        "roe": 0.25,  # 25% ROE -> 1.0 score
+        "debt_to_equity": 0.2,  # Low debt -> 1.0 score
+        "revenue_growth": 0.30,  # 30% growth -> 1.0 score
+        "profit_margin": 0.25,  # 25% margin -> 1.0 score
     }
 
     # Public entry point; delegates to the per-asset analyzers.
@@ -497,7 +489,7 @@ def python_scoring_task(self) -> Task:
         agent=self.python_scorer(),
         expected_output="DeepAnalysisResult with scores, grade, recommendation",
         output_pydantic=DeepAnalysisResult,
-        async_execution=False  # Final task must be synchronous
+        async_execution=False,  # Final task must be synchronous
     )
 ```
 
@@ -574,8 +566,8 @@ def validate_scoring_accuracy(python_result, ai_result):
            agents=self.agents,
            tasks=self.tasks,
            reasoning=False,  # Disable for Python scoring
-           planning=False,   # Disable for performance
-           verbose=True
+           planning=False,  # Disable for performance
+           verbose=True,
        )
    ```
 
@@ -623,6 +615,7 @@ assert all(r.grade == results[0].grade for r in results), "Non-deterministic res
 ```python
 # Solution: Check optimization mode
 from finwiz.config.performance.performance_config import OptimizationMode, get_performance_config_manager
+
 config_manager = get_performance_config_manager()
 mode = config_manager.get_mode()
 logger.info(f"Current mode: {mode.value}")
@@ -636,6 +629,7 @@ assert mode == OptimizationMode.MAXIMUM_SPEED
 ```python
 # Enable detailed logging
 import logging
+
 logging.getLogger("finwiz.scoring").setLevel(logging.DEBUG)
 
 # View calculation details

--- a/docs/how-to/template_configuration.md
+++ b/docs/how-to/template_configuration.md
@@ -87,20 +87,18 @@ template_data = {
     "asset_class": "stock",
     "analysis_date": datetime.now(),
     "session_id": "analysis_2025_01_25",
-
     # Scores and Grades
-    "composite_score": 0.78,        # 0.0-1.0
-    "fundamental_score": 0.82,      # 0.0-1.0
-    "technical_score": 0.75,        # 0.0-1.0
-    "risk_score": 0.77,            # 0.0-1.0 (1.0 = low risk)
-    "grade": "A",                  # A+, A, B, C, D, F
-    "recommendation": "BUY",        # BUY, HOLD, SELL
-    "confidence": 0.85,            # 0.0-1.0
+    "composite_score": 0.78,  # 0.0-1.0
+    "fundamental_score": 0.82,  # 0.0-1.0
+    "technical_score": 0.75,  # 0.0-1.0
+    "risk_score": 0.77,  # 0.0-1.0 (1.0 = low risk)
+    "grade": "A",  # A+, A, B, C, D, F
+    "recommendation": "BUY",  # BUY, HOLD, SELL
+    "confidence": 0.85,  # 0.0-1.0
     "rationale": "Strong fundamentals...",
-
     # Component Details
     "fundamental_details": {
-        "roe": 0.25,               # Stock-specific
+        "roe": 0.25,  # Stock-specific
         "debt_to_equity": 0.3,
         "revenue_growth": 0.15,
         "profit_margin": 0.22,
@@ -111,29 +109,14 @@ template_data = {
         # Crypto-specific
         "market_cap": 100000000000,
         "volume_24h": 2000000000,
-        "age_years": 5.2
+        "age_years": 5.2,
     },
-
-    "technical_details": {
-        "rsi": 55.0,
-        "trend_direction": "uptrend",
-        "current_price": 150.0,
-        "moving_avg_50": 145.0,
-        "moving_avg_200": 140.0,
-        "macd_diff": 0.5
-    },
-
-    "risk_details": {
-        "volatility": 0.18,
-        "max_drawdown": -0.15,
-        "beta": 1.1,
-        "beta_deviation": 0.1
-    },
-
+    "technical_details": {"rsi": 55.0, "trend_direction": "uptrend", "current_price": 150.0, "moving_avg_50": 145.0, "moving_avg_200": 140.0, "macd_diff": 0.5},
+    "risk_details": {"volatility": 0.18, "max_drawdown": -0.15, "beta": 1.1, "beta_deviation": 0.1},
     # Metadata
     "data_sources": ["Yahoo Finance", "SEC EDGAR", "Alpha Vantage"],
     "report_html_path": "output/reports/.../report.html",
-    "report_json_path": "output/reports/.../export.json"
+    "report_json_path": "output/reports/.../export.json",
 }
 ```
 
@@ -348,12 +331,7 @@ To add a new section to the template:
 1. **Update data structure**:
 
 ```python
-template_data["performance_data"] = {
-    "sharpe_ratio": 1.25,
-    "sortino_ratio": 1.45,
-    "max_drawdown": -0.15,
-    "calmar_ratio": 0.85
-}
+template_data["performance_data"] = {"sharpe_ratio": 1.25, "sortino_ratio": 1.45, "max_drawdown": -0.15, "calmar_ratio": 0.85}
 ```
 
 ### Custom Filters
@@ -369,9 +347,11 @@ def format_currency(value, currency="USD"):
         return f"€{value:,.2f}"
     return f"{value:,.2f} {currency}"
 
+
 def format_percentage(value, decimals=1):
     """Format percentage values."""
     return f"{value * 100:.{decimals}f}%"
+
 
 def risk_level_text(risk_score):
     """Convert risk score to text."""
@@ -382,10 +362,11 @@ def risk_level_text(risk_score):
     else:
         return "Élevé"
 
+
 # Register filters
-jinja_env.filters['currency'] = format_currency
-jinja_env.filters['percentage'] = format_percentage
-jinja_env.filters['risk_level'] = risk_level_text
+jinja_env.filters["currency"] = format_currency
+jinja_env.filters["percentage"] = format_percentage
+jinja_env.filters["risk_level"] = risk_level_text
 ```
 
 **Usage in templates**:
@@ -456,6 +437,7 @@ arguments and does **not** write a file itself:
 ```python
 from finwiz.reporting.deep_analysis_report_generator import DeepAnalysisReportGenerator
 
+
 class DeepAnalysisReportGenerator:
     """Generate HTML reports from DeepAnalysisResult using Jinja2 templates."""
 
@@ -523,7 +505,7 @@ def test_should_render_deep_analysis_template_with_stock_data():
         risk_score=0.77,
         fundamental_details={"roe": 0.25, "debt_to_equity": 0.3},
         technical_details={"rsi": 55.0, "trend_direction": "uptrend"},
-        risk_details={"volatility": 0.18, "max_drawdown": -0.15}
+        risk_details={"volatility": 0.18, "max_drawdown": -0.15},
     )
 
     # Extra fields merged into the single result_data dict generate_report() expects
@@ -582,21 +564,21 @@ def test_template_accessibility():
     html_content = generate_sample_report()
 
     # Parse HTML
-    soup = BeautifulSoup(html_content, 'html.parser')
+    soup = BeautifulSoup(html_content, "html.parser")
 
     # Check for required accessibility features
-    assert soup.find('html').get('lang') == 'fr'  # Language specified
-    assert soup.find('title') is not None         # Title present
+    assert soup.find("html").get("lang") == "fr"  # Language specified
+    assert soup.find("title") is not None  # Title present
 
     # Check heading hierarchy
-    headings = soup.find_all(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+    headings = soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"])
     assert len(headings) > 0
-    assert headings[0].name == 'h1'  # Starts with h1
+    assert headings[0].name == "h1"  # Starts with h1
 
     # Check alt text for images (if any)
-    images = soup.find_all('img')
+    images = soup.find_all("img")
     for img in images:
-        assert img.get('alt') is not None
+        assert img.get("alt") is not None
 
     # Check color contrast (would need additional tools)
     # Check keyboard navigation (would need browser testing)
@@ -636,6 +618,7 @@ directly instead:
 
 ```python
 import time
+
 
 def monitor_template_performance():
     """Monitor template rendering performance."""
@@ -706,7 +689,7 @@ template_data = {
     "recommendation": result.recommendation,
     # Provide defaults for optional fields
     "data_sources": template_data.get("data_sources", ["Internal Analysis"]),
-    "analysis_date": template_data.get("analysis_date", datetime.now())
+    "analysis_date": template_data.get("analysis_date", datetime.now()),
 }
 ```
 
@@ -736,16 +719,12 @@ Enable template debugging for development:
 # Enable debug mode
 jinja_env = Environment(
     loader=FileSystemLoader(template_dir),
-    autoescape=select_autoescape(['html', 'xml']),
-    undefined=StrictUndefined  # Raise errors for undefined variables
+    autoescape=select_autoescape(["html", "xml"]),
+    undefined=StrictUndefined,  # Raise errors for undefined variables
 )
 
 # Add debug information to templates
-template_data["debug_info"] = {
-    "render_time": datetime.now(),
-    "template_version": "1.0",
-    "data_keys": list(template_data.keys())
-}
+template_data["debug_info"] = {"render_time": datetime.now(), "template_version": "1.0", "data_keys": list(template_data.keys())}
 ```
 
 ## Conclusion

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -176,6 +176,7 @@ else:
 discovery_date_str = data.get("analysis_date") or data.get("discovery_date")
 if discovery_date_str and isinstance(discovery_date_str, str):
     from dateutil import parser
+
     discovery_date = parser.parse(discovery_date_str)
 ```
 
@@ -210,6 +211,7 @@ class StockCrewExport(CrewExportBase):
     risk_assessment: RiskAssessmentStandardized  # Nested object
     # RiskAssessmentStandardized.score is 0-5 scale, not 0-10 (see
     # src/finwiz/schemas/common.py:41 — there is no `risk_score` attribute)
+
 
 # Python Schema (PythonDeepAnalysisResult)
 class PythonDeepAnalysisResult(BaseModel):
@@ -319,22 +321,10 @@ class FinwizState(BaseModel):
     # ... existing fields ...
 
     # Error tracking
-    errors: list[str] = Field(
-        default_factory=list,
-        description="List of error messages from flow execution"
-    )
-    failed_holdings: list[str] = Field(
-        default_factory=list,
-        description="List of tickers that failed analysis"
-    )
-    retry_counts: dict[str, int] = Field(
-        default_factory=dict,
-        description="Retry count per ticker"
-    )
-    timeout_holdings: list[str] = Field(
-        default_factory=list,
-        description="List of tickers that timed out"
-    )
+    errors: list[str] = Field(default_factory=list, description="List of error messages from flow execution")
+    failed_holdings: list[str] = Field(default_factory=list, description="List of tickers that failed analysis")
+    retry_counts: dict[str, int] = Field(default_factory=dict, description="Retry count per ticker")
+    timeout_holdings: list[str] = Field(default_factory=list, description="List of tickers that timed out")
 ```
 
 **Usage in Flow**:

--- a/docs/how-to/use_python_pipeline.md
+++ b/docs/how-to/use_python_pipeline.md
@@ -32,12 +32,8 @@ holdings = [
         grade_description="Grade B - Good quality stock",
         recommended_action="HOLD",
         rationale_bullets=["Strong fundamentals", "Market leader"],
-        risk=RiskAssessmentStandardized(
-            score=2.5,
-            level="Medium",
-            risk_factors=["Market volatility", "Competition"]
-        ),
-        alternatives=[]
+        risk=RiskAssessmentStandardized(score=2.5, level="Medium", risk_factors=["Market volatility", "Competition"]),
+        alternatives=[],
     ),
     # Add more holdings...
 ]
@@ -55,10 +51,7 @@ import time
 session_id = f"analysis_{int(time.time())}"
 
 # Run deep analysis
-analysis_results = analyze_portfolio_with_python(
-    holdings=holdings,
-    session_id=session_id
-)
+analysis_results = analyze_portfolio_with_python(holdings=holdings, session_id=session_id)
 
 # Check results
 print(f"✅ Analyzed {analysis_results['successful_analyses']} holdings")
@@ -74,9 +67,7 @@ Identify A+ and A grade holdings:
 from finwiz.orchestrators.discovery.aplus_discovery_integrator import integrate_aplus_discovery_with_deep_analysis
 
 # Run A+ discovery
-discovery_results = integrate_aplus_discovery_with_deep_analysis(
-    session_id=session_id
-)
+discovery_results = integrate_aplus_discovery_with_deep_analysis(session_id=session_id)
 
 # Check results
 if discovery_results["has_a_plus_analysis"]:
@@ -95,17 +86,13 @@ Run backtesting for A+ candidates:
 from finwiz.integration.backtesting_pipeline_connector import connect_backtesting_to_discovery_results
 
 # Run backtesting
-backtesting_results = connect_backtesting_to_discovery_results(
-    session_id=session_id
-)
+backtesting_results = connect_backtesting_to_discovery_results(session_id=session_id)
 
 # Check results
 if backtesting_results["backtesting_executed"]:
     print(f"🔬 Backtested {backtesting_results['candidates_count']} candidates")
     for result in backtesting_results["results"]:
-        print(f"  {result['ticker']}: {result['annual_return']:.1%} return, "
-              f"Sharpe {result['sharpe_ratio']:.2f}, "
-              f"Max DD {result['max_drawdown']:.1%}")
+        print(f"  {result['ticker']}: {result['annual_return']:.1%} return, Sharpe {result['sharpe_ratio']:.2f}, Max DD {result['max_drawdown']:.1%}")
 else:
     print(f"ℹ️ Backtesting not executed: {backtesting_results.get('reason', 'Unknown')}")
 ```
@@ -120,18 +107,10 @@ from finwiz.schemas.portfolio_review import PortfolioReview
 from datetime import datetime
 
 # Create portfolio review
-portfolio_review = PortfolioReview(
-    as_of=datetime.now(),
-    base_currency="USD",
-    holdings=holdings
-)
+portfolio_review = PortfolioReview(as_of=datetime.now(), base_currency="USD", holdings=holdings)
 
 # Generate report
-report_path = generate_python_report(
-    portfolio_review=portfolio_review,
-    deep_analysis_results=analysis_results,
-    session_id=session_id
-)
+report_path = generate_python_report(portfolio_review=portfolio_review, deep_analysis_results=analysis_results, session_id=session_id)
 
 print(f"📊 Report generated: {report_path}")
 ```
@@ -164,7 +143,7 @@ holdings = [
         recommended_action="BUY",
         rationale_bullets=["AI market leader", "Strong growth"],
         risk=RiskAssessmentStandardized(score=2.8, level="Medium", risk_factors=["Tech volatility"]),
-        alternatives=[]
+        alternatives=[],
     ),
     HoldingDecision(
         ticker="TSLA",
@@ -178,7 +157,7 @@ holdings = [
         recommended_action="BUY",
         rationale_bullets=["EV market leader", "Innovation"],
         risk=RiskAssessmentStandardized(score=3.2, level="High", risk_factors=["Volatility"]),
-        alternatives=[]
+        alternatives=[],
     ),
 ]
 
@@ -191,25 +170,17 @@ print("=" * 60)
 
 # Deep Analysis
 print("\n1️⃣ Running deep analysis...")
-analysis_results = analyze_portfolio_with_python(
-    holdings=holdings,
-    session_id=session_id
-)
-print(f"   ✅ Analyzed {analysis_results['successful_analyses']} holdings in "
-      f"{analysis_results['performance_metrics']['total_execution_time_seconds']:.2f}s")
+analysis_results = analyze_portfolio_with_python(holdings=holdings, session_id=session_id)
+print(f"   ✅ Analyzed {analysis_results['successful_analyses']} holdings in {analysis_results['performance_metrics']['total_execution_time_seconds']:.2f}s")
 
 # A+ Discovery
 print("\n2️⃣ Running A+ discovery...")
-discovery_results = integrate_aplus_discovery_with_deep_analysis(
-    session_id=session_id
-)
+discovery_results = integrate_aplus_discovery_with_deep_analysis(session_id=session_id)
 print(f"   ✅ Found {discovery_results['total_opportunities_found']} A+ opportunities")
 
 # Backtesting
 print("\n3️⃣ Running backtesting...")
-backtesting_results = connect_backtesting_to_discovery_results(
-    session_id=session_id
-)
+backtesting_results = connect_backtesting_to_discovery_results(session_id=session_id)
 if backtesting_results["backtesting_executed"]:
     print(f"   ✅ Backtested {backtesting_results['candidates_count']} candidates")
 else:
@@ -217,16 +188,8 @@ else:
 
 # Report Generation
 print("\n4️⃣ Generating report...")
-portfolio_review = PortfolioReview(
-    as_of=datetime.now(),
-    base_currency="USD",
-    holdings=holdings
-)
-report_path = generate_python_report(
-    portfolio_review=portfolio_review,
-    deep_analysis_results=analysis_results,
-    session_id=session_id
-)
+portfolio_review = PortfolioReview(as_of=datetime.now(), base_currency="USD", holdings=holdings)
+report_path = generate_python_report(portfolio_review=portfolio_review, deep_analysis_results=analysis_results, session_id=session_id)
 print(f"   ✅ Report generated: {report_path}")
 
 print("\n" + "=" * 60)
@@ -265,10 +228,7 @@ logger = logging.getLogger(__name__)
 
 try:
     # Deep Analysis
-    analysis_results = analyze_portfolio_with_python(
-        holdings=holdings,
-        session_id=session_id
-    )
+    analysis_results = analyze_portfolio_with_python(holdings=holdings, session_id=session_id)
 
     if analysis_results["successful_analyses"] == 0:
         logger.warning("No holdings analyzed successfully")
@@ -277,11 +237,7 @@ try:
 except Exception as e:
     logger.error(f"Deep analysis failed: {e}", exc_info=True)
     # Implement fallback strategy
-    analysis_results = {
-        "successful_analyses": 0,
-        "failed_analyses": len(holdings),
-        "deep_analysis_results": {}
-    }
+    analysis_results = {"successful_analyses": 0, "failed_analyses": len(holdings), "deep_analysis_results": {}}
 
 # Continue with remaining pipeline steps...
 ```
@@ -292,22 +248,15 @@ Execute components conditionally:
 
 ```python
 # Always run deep analysis
-analysis_results = analyze_portfolio_with_python(
-    holdings=holdings,
-    session_id=session_id
-)
+analysis_results = analyze_portfolio_with_python(holdings=holdings, session_id=session_id)
 
 # Only run discovery if analysis succeeded
 if analysis_results["successful_analyses"] > 0:
-    discovery_results = integrate_aplus_discovery_with_deep_analysis(
-        session_id=session_id
-    )
+    discovery_results = integrate_aplus_discovery_with_deep_analysis(session_id=session_id)
 
     # Only run backtesting if A+ opportunities found
     if discovery_results["has_a_plus_analysis"]:
-        backtesting_results = connect_backtesting_to_discovery_results(
-            session_id=session_id
-        )
+        backtesting_results = connect_backtesting_to_discovery_results(session_id=session_id)
     else:
         print("ℹ️ No A+ opportunities - skipping backtesting")
         backtesting_results = {"backtesting_executed": False}
@@ -317,11 +266,7 @@ else:
     backtesting_results = {"backtesting_executed": False}
 
 # Always generate report (even with partial data)
-report_path = generate_python_report(
-    portfolio_review=portfolio_review,
-    deep_analysis_results=analysis_results,
-    session_id=session_id
-)
+report_path = generate_python_report(portfolio_review=portfolio_review, deep_analysis_results=analysis_results, session_id=session_id)
 ```
 
 ### Performance Monitoring
@@ -417,6 +362,7 @@ Always use unique session IDs to avoid file conflicts:
 
 ```python
 import time
+
 session_id = f"analysis_{int(time.time())}"
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,11 +121,7 @@ Replace AI-based calculations with deterministic Python for maximum performance:
 from finwiz.scoring.deep_analysis_scorer import DeepAnalysisScorer
 
 scorer = DeepAnalysisScorer()
-result = scorer.calculate_composite_score(
-    ticker="AAPL",
-    asset_class="stock",
-    data={"roe": 0.25, "debt_to_equity": 0.3, "revenue_growth": 0.15}
-)
+result = scorer.calculate_composite_score(ticker="AAPL", asset_class="stock", data={"roe": 0.25, "debt_to_equity": 0.3, "revenue_growth": 0.15})
 
 # Results: Grade: A, Score: 0.78, Recommendation: BUY
 ```

--- a/docs/reference/api/crews.md
+++ b/docs/reference/api/crews.md
@@ -190,8 +190,8 @@ Unified crew for comprehensive analysis of any asset class with detailed grading
 
 ```python
 {
-    "ticker": "AAPL",        # Required: Asset ticker
-    "asset_class": "stock"   # Required: "stock", "etf", or "crypto"
+    "ticker": "AAPL",  # Required: Asset ticker
+    "asset_class": "stock",  # Required: "stock", "etf", or "crypto"
 }
 ```
 
@@ -203,10 +203,7 @@ Unified crew for comprehensive analysis of any asset class with detailed grading
 from finwiz.crews.deep_analysis.deep_analysis import DeepAnalysisCrew
 
 crew = DeepAnalysisCrew()
-result = crew.crew().kickoff(inputs={
-    "ticker": "AAPL",
-    "asset_class": "stock"
-})
+result = crew.crew().kickoff(inputs={"ticker": "AAPL", "asset_class": "stock"})
 
 print(f"Grade: {result.grade}")
 print(f"Composite Score: {result.composite_score}")
@@ -240,7 +237,7 @@ Consolidates analysis results from multiple crews into comprehensive reports.
 ```python
 {
     "analysis_results": [...],  # Results from other crews
-    "report_type": "portfolio"  # Type of report to generate
+    "report_type": "portfolio",  # Type of report to generate
 }
 ```
 
@@ -259,10 +256,7 @@ each output their own schema:
 from finwiz.crews.report_crew.report_crew import ReportCrew
 
 crew = ReportCrew()
-result = crew.crew().kickoff(inputs={
-    "analysis_results": analysis_data,
-    "report_type": "portfolio"
-})
+result = crew.crew().kickoff(inputs={"analysis_results": analysis_data, "report_type": "portfolio"})
 ```
 
 **Agents** (4, not 2 — `report_crew/config/agents.yaml`):
@@ -321,7 +315,7 @@ def crew(self) -> Crew:
         process=Process.sequential,
         verbose=True,
         respect_context_window=True,
-        max_rpm=20  # Rate limiting
+        max_rpm=20,  # Rate limiting
     )
 ```
 
@@ -341,7 +335,7 @@ task_name:
 Configure rate limits to prevent API throttling:
 
 ```python
-max_rpm=20  # Maximum 20 requests per minute
+max_rpm = 20  # Maximum 20 requests per minute
 ```
 
 ### Tool Optimization
@@ -350,11 +344,7 @@ Use minimal tool sets for specific use cases:
 
 ```python
 # Minimal tools for risk assessment
-tools = [
-    QuantitativeAnalysisTool(asset_class=asset_class),
-    TickerExistenceValidationTool(),
-    asset_specific_tool
-]
+tools = [QuantitativeAnalysisTool(asset_class=asset_class), TickerExistenceValidationTool(), asset_specific_tool]
 ```
 
 ## Error Handling
@@ -407,11 +397,11 @@ Always validate inputs before crew execution:
 
 ```python
 # Validate ticker format
-if not re.match(r'^[A-Z]{1,5}$', ticker):
+if not re.match(r"^[A-Z]{1,5}$", ticker):
     raise ValueError(f"Invalid ticker format: {ticker}")
 
 # Validate asset class
-if asset_class not in ['stock', 'etf', 'crypto']:
+if asset_class not in ["stock", "etf", "crypto"]:
     raise ValueError(f"Invalid asset class: {asset_class}")
 ```
 
@@ -421,7 +411,7 @@ Process crew outputs consistently:
 
 ```python
 # Check for successful execution
-if hasattr(result, 'error'):
+if hasattr(result, "error"):
     logger.error(f"Crew execution failed: {result.error}")
     return None
 
@@ -443,7 +433,7 @@ Enable verbose logging for debugging:
 crew = Crew(
     agents=self.agents,
     tasks=self.tasks,
-    verbose=True  # Enable detailed logging
+    verbose=True,  # Enable detailed logging
 )
 ```
 
@@ -485,6 +475,7 @@ Use crews within CrewAI Flows:
 ```python
 from crewai.flow import Flow, start, listen
 
+
 class AnalysisFlow(Flow):
     @start()
     def analyze_stock(self):
@@ -495,10 +486,7 @@ class AnalysisFlow(Flow):
     @listen("analyze_stock")
     def generate_report(self, stock_data):
         crew = ReportCrew()
-        result = crew.crew().kickoff(inputs={
-            "analysis_results": [stock_data["stock_analysis"]],
-            "report_type": "single_asset"
-        })
+        result = crew.crew().kickoff(inputs={"analysis_results": [stock_data["stock_analysis"]], "report_type": "single_asset"})
         return {"report": result}
 ```
 
@@ -509,14 +497,12 @@ Process multiple assets efficiently:
 ```python
 import asyncio
 
+
 async def analyze_portfolio(tickers):
     crews = [StockCrew() for _ in tickers]
 
     # Execute crews in parallel
-    tasks = [
-        crew.crew().kickoff(inputs={"ticker": ticker})
-        for crew, ticker in zip(crews, tickers)
-    ]
+    tasks = [crew.crew().kickoff(inputs={"ticker": ticker}) for crew, ticker in zip(crews, tickers)]
 
     results = await asyncio.gather(*tasks)
     return dict(zip(tickers, results))

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -219,10 +219,10 @@ All schemas use strict validation:
 ```python
 class BaseSchema(BaseModel):
     model_config = ConfigDict(
-        extra='forbid',           # Reject unknown fields
-        str_strip_whitespace=True, # Strip whitespace
+        extra="forbid",  # Reject unknown fields
+        str_strip_whitespace=True,  # Strip whitespace
         validate_assignment=True,  # Validate on assignment
-        use_enum_values=True      # Use enum values
+        use_enum_values=True,  # Use enum values
     )
 ```
 
@@ -234,17 +234,17 @@ Schemas include custom validation logic:
 class TenKInsight(BaseModel):
     ticker: str = Field(..., description="Stock ticker symbol")
 
-    @field_validator('ticker')
+    @field_validator("ticker")
     @classmethod
     def validate_ticker_format(cls, v: str) -> str:
-        if not re.match(r'^[A-Z]{1,5}$', v):
-            raise ValueError('Ticker must be 1-5 uppercase letters')
+        if not re.match(r"^[A-Z]{1,5}$", v):
+            raise ValueError("Ticker must be 1-5 uppercase letters")
         return v.upper()
 
-    @model_validator(mode='after')
-    def validate_score_consistency(self) -> 'TenKInsight':
-        if self.composite_score > 0.95 and self.grade != 'A+':
-            raise ValueError('High composite score must have A+ grade')
+    @model_validator(mode="after")
+    def validate_score_consistency(self) -> "TenKInsight":
+        if self.composite_score > 0.95 and self.grade != "A+":
+            raise ValueError("High composite score must have A+ grade")
         return self
 ```
 
@@ -261,7 +261,7 @@ data = {
     "rationale": "Strong fundamentals with excellent growth prospects and technical momentum",
     "risk_score": 3,
     "analysis_date": "2025-10-26T10:30:00Z",
-    "data_sources": ["SEC EDGAR", "Yahoo Finance"]
+    "data_sources": ["SEC EDGAR", "Yahoo Finance"],
 }
 
 # Create validated instance
@@ -294,9 +294,9 @@ except ValidationError as e:
 @task
 def analysis_task(self) -> Task:
     return Task(
-        config=self.tasks_config['analysis_task'],
+        config=self.tasks_config["analysis_task"],
         output_pydantic=TenKInsight,  # Automatic validation
-        output_json=True
+        output_json=True,
     )
 ```
 
@@ -319,7 +319,7 @@ insight_dict = insight.model_dump()
 # Version-aware schema loading
 def load_analysis_result(data: dict) -> TenKInsight:
     # Handle legacy format
-    if 'version' not in data or data['version'] < '2.0':
+    if "version" not in data or data["version"] < "2.0":
         data = migrate_legacy_format(data)
 
     return TenKInsight.model_validate(data)

--- a/docs/reference/api/tools.md
+++ b/docs/reference/api/tools.md
@@ -175,7 +175,7 @@ Comprehensive quantitative analysis including risk metrics and technical indicat
 ```python
 {
     "ticker": "AAPL",
-    "asset_class": "stock"  # "stock", "etf", or "crypto"
+    "asset_class": "stock",  # "stock", "etf", or "crypto"
 }
 ```
 
@@ -234,11 +234,7 @@ Comprehensive risk analysis for investments (central `crewai_custom_tools` packa
 from crewai_custom_tools import StandardizedRiskScoringTool
 
 tool = StandardizedRiskScoringTool()
-risk = tool.run({
-    "ticker": "AAPL",
-    "asset_class": "stock",
-    "market_data": market_data
-})
+risk = tool.run({"ticker": "AAPL", "asset_class": "stock", "market_data": market_data})
 
 print(f"Risk Score: {risk['risk_score']}")
 print(f"Risk Factors: {risk['risk_factors']}")
@@ -372,12 +368,7 @@ Most tools can be initialized with custom parameters:
 tool = QuantitativeAnalysisTool(asset_class="stock")
 
 # Custom configuration
-tool = QuantitativeAnalysisTool(
-    asset_class="stock",
-    lookback_days=252,
-    confidence_level=0.95,
-    enable_caching=True
-)
+tool = QuantitativeAnalysisTool(asset_class="stock", lookback_days=252, confidence_level=0.95, enable_caching=True)
 ```
 
 ### Tool Factories
@@ -410,34 +401,13 @@ Tools use standardized error handling:
 
 ```python
 # API timeout error
-{
-    "error": "TimeoutError",
-    "message": "API request timed out",
-    "details": {
-        "timeout_seconds": 30,
-        "retry_suggested": True
-    }
-}
+{"error": "TimeoutError", "message": "API request timed out", "details": {"timeout_seconds": 30, "retry_suggested": True}}
 
 # Data validation error
-{
-    "error": "ValidationError",
-    "message": "Invalid ticker format",
-    "details": {
-        "ticker": "INVALID",
-        "expected_format": "1-5 uppercase letters"
-    }
-}
+{"error": "ValidationError", "message": "Invalid ticker format", "details": {"ticker": "INVALID", "expected_format": "1-5 uppercase letters"}}
 
 # Rate limit error
-{
-    "error": "RateLimitError",
-    "message": "API rate limit exceeded",
-    "details": {
-        "retry_after_seconds": 60,
-        "current_limit": "5 requests/minute"
-    }
-}
+{"error": "RateLimitError", "message": "API rate limit exceeded", "details": {"retry_after_seconds": 60, "current_limit": "5 requests/minute"}}
 ```
 
 ### Retry Logic
@@ -477,7 +447,7 @@ Enable caching for expensive operations:
 # Enable caching with TTL
 tool = QuantitativeAnalysisTool(
     enable_caching=True,
-    cache_ttl=3600  # 1 hour
+    cache_ttl=3600,  # 1 hour
 )
 ```
 
@@ -497,6 +467,7 @@ Use async versions for better performance:
 
 ```python
 import asyncio
+
 
 # Async tool execution
 async def analyze_multiple_tickers(tickers):
@@ -526,11 +497,11 @@ Always validate inputs before tool execution:
 
 ```python
 # Validate ticker format
-if not re.match(r'^[A-Z]{1,5}$', ticker):
+if not re.match(r"^[A-Z]{1,5}$", ticker):
     raise ValueError(f"Invalid ticker format: {ticker}")
 
 # Validate asset class
-if asset_class not in ['stock', 'etf', 'crypto']:
+if asset_class not in ["stock", "etf", "crypto"]:
     raise ValueError(f"Invalid asset class: {asset_class}")
 ```
 
@@ -540,12 +511,12 @@ Process tool outputs consistently:
 
 ```python
 # Check for errors
-if 'error' in result:
+if "error" in result:
     logger.error(f"Tool execution failed: {result['error']}")
     return None
 
 # Validate required fields
-required_fields = ['price', 'volume', 'market_cap']
+required_fields = ["price", "volume", "market_cap"]
 missing_fields = [f for f in required_fields if f not in result]
 if missing_fields:
     logger.warning(f"Missing fields: {missing_fields}")
@@ -578,16 +549,10 @@ Use tools within CrewAI crews:
 ```python
 from crewai import Agent, Task, Crew
 
+
 @agent
 def analyst(self) -> Agent:
-    return Agent(
-        config=self.agents_config["analyst"],
-        tools=[
-            YahooFinanceTickerInfoTool(),
-            QuantitativeAnalysisTool(asset_class="stock"),
-            StandardizedRiskScoringTool()
-        ]
-    )
+    return Agent(config=self.agents_config["analyst"], tools=[YahooFinanceTickerInfoTool(), QuantitativeAnalysisTool(asset_class="stock"), StandardizedRiskScoringTool()])
 ```
 
 ### Custom Tool Development
@@ -612,6 +577,7 @@ tool = YahooFinanceTickerInfoTool(timeout=60)
 ```python
 # Solution: Add delays or reduce request frequency
 import time
+
 time.sleep(1)  # Add delay between requests
 ```
 
@@ -620,7 +586,7 @@ time.sleep(1)  # Add delay between requests
 ```python
 # Solution: Validate ticker before tool execution
 validation_tool = TickerExistenceValidationTool()
-if validation_tool.run(ticker)['is_valid']:
+if validation_tool.run(ticker)["is_valid"]:
     result = analysis_tool.run(ticker)
 ```
 

--- a/docs/reference/integration/python_pipeline_integration.md
+++ b/docs/reference/integration/python_pipeline_integration.md
@@ -35,9 +35,7 @@ def integrate_aplus_discovery_with_deep_analysis(session_id: str) -> dict[str, A
 ```python
 from finwiz.orchestrators.discovery.aplus_discovery_integrator import integrate_aplus_discovery_with_deep_analysis
 
-discovery_results = integrate_aplus_discovery_with_deep_analysis(
-    session_id="analysis_session_123"
-)
+discovery_results = integrate_aplus_discovery_with_deep_analysis(session_id="analysis_session_123")
 
 if discovery_results["has_a_plus_analysis"]:
     print(f"Found {discovery_results['total_opportunities_found']} A+ opportunities")
@@ -96,15 +94,12 @@ def connect_backtesting_to_discovery_results(session_id: str) -> dict[str, Any]
 ```python
 from finwiz.integration.backtesting_pipeline_connector import connect_backtesting_to_discovery_results
 
-backtesting_results = connect_backtesting_to_discovery_results(
-    session_id="analysis_session_123"
-)
+backtesting_results = connect_backtesting_to_discovery_results(session_id="analysis_session_123")
 
 if backtesting_results["backtesting_executed"]:
     print(f"Backtested {backtesting_results['candidates_count']} candidates")
     for result in backtesting_results["results"]:
-        print(f"  {result['ticker']}: {result['annual_return']:.1%} return, "
-              f"Sharpe {result['sharpe_ratio']:.2f}")
+        print(f"  {result['ticker']}: {result['annual_return']:.1%} return, Sharpe {result['sharpe_ratio']:.2f}")
 ```
 
 **Data Sources:**
@@ -256,27 +251,16 @@ from finwiz.integration.backtesting_pipeline_connector import connect_backtestin
 from finwiz.reporting.python_report_generator import generate_python_report
 
 # Step 1: Deep Analysis
-analysis_results = analyze_portfolio_with_python(
-    holdings=portfolio_holdings,
-    session_id=session_id
-)
+analysis_results = analyze_portfolio_with_python(holdings=portfolio_holdings, session_id=session_id)
 
 # Step 2: A+ Discovery
-discovery_results = integrate_aplus_discovery_with_deep_analysis(
-    session_id=session_id
-)
+discovery_results = integrate_aplus_discovery_with_deep_analysis(session_id=session_id)
 
 # Step 3: Backtesting
-backtesting_results = connect_backtesting_to_discovery_results(
-    session_id=session_id
-)
+backtesting_results = connect_backtesting_to_discovery_results(session_id=session_id)
 
 # Step 4: Report Generation
-report_path = generate_python_report(
-    portfolio_review=portfolio_review,
-    deep_analysis_results=analysis_results,
-    session_id=session_id
-)
+report_path = generate_python_report(portfolio_review=portfolio_review, deep_analysis_results=analysis_results, session_id=session_id)
 ```
 
 ### Pattern 2: Conditional Execution
@@ -285,22 +269,15 @@ Execute components conditionally based on results:
 
 ```python
 # Always run deep analysis
-analysis_results = analyze_portfolio_with_python(
-    holdings=portfolio_holdings,
-    session_id=session_id
-)
+analysis_results = analyze_portfolio_with_python(holdings=portfolio_holdings, session_id=session_id)
 
 # Only run discovery if analysis succeeded
 if analysis_results["successful_analyses"] > 0:
-    discovery_results = integrate_aplus_discovery_with_deep_analysis(
-        session_id=session_id
-    )
+    discovery_results = integrate_aplus_discovery_with_deep_analysis(session_id=session_id)
 
     # Only run backtesting if A+ opportunities found
     if discovery_results["has_a_plus_analysis"]:
-        backtesting_results = connect_backtesting_to_discovery_results(
-            session_id=session_id
-        )
+        backtesting_results = connect_backtesting_to_discovery_results(session_id=session_id)
 ```
 
 ### Pattern 3: Error Handling
@@ -310,19 +287,14 @@ Implement comprehensive error handling:
 ```python
 try:
     # Deep Analysis
-    analysis_results = analyze_portfolio_with_python(
-        holdings=portfolio_holdings,
-        session_id=session_id
-    )
+    analysis_results = analyze_portfolio_with_python(holdings=portfolio_holdings, session_id=session_id)
 except Exception as e:
     logger.error(f"Deep analysis failed: {e}")
     analysis_results = {"successful_analyses": 0}
 
 try:
     # A+ Discovery
-    discovery_results = integrate_aplus_discovery_with_deep_analysis(
-        session_id=session_id
-    )
+    discovery_results = integrate_aplus_discovery_with_deep_analysis(session_id=session_id)
 except Exception as e:
     logger.error(f"A+ discovery failed: {e}")
     discovery_results = {"has_a_plus_analysis": False}
@@ -330,19 +302,13 @@ except Exception as e:
 try:
     # Backtesting
     if discovery_results.get("has_a_plus_analysis"):
-        backtesting_results = connect_backtesting_to_discovery_results(
-            session_id=session_id
-        )
+        backtesting_results = connect_backtesting_to_discovery_results(session_id=session_id)
 except Exception as e:
     logger.error(f"Backtesting failed: {e}")
     backtesting_results = {"backtesting_executed": False}
 
 # Always generate report (even with partial data)
-report_path = generate_python_report(
-    portfolio_review=portfolio_review,
-    deep_analysis_results=analysis_results,
-    session_id=session_id
-)
+report_path = generate_python_report(portfolio_review=portfolio_review, deep_analysis_results=analysis_results, session_id=session_id)
 ```
 
 ## File Structure

--- a/docs/reference/quantitative_analysis.md
+++ b/docs/reference/quantitative_analysis.md
@@ -81,7 +81,7 @@ result = engine.run_strategy_backtest(
     symbol="AAPL",
     start_date=datetime(2023, 1, 1),
     end_date=datetime(2024, 1, 1),
-    strategy_params={"short_period": 20, "long_period": 50}
+    strategy_params={"short_period": 20, "long_period": 50},
 )
 
 print(f"Total Return: {result.total_return:.2f}%")
@@ -95,6 +95,7 @@ print(f"Max Drawdown: {result.max_drawdown:.2f}%")
 from finwiz.quantitative.backtesting import StrategyFramework
 import backtrader as bt
 
+
 class CustomStrategy(StrategyFramework):
     params = (
         ("period", 20),
@@ -104,9 +105,7 @@ class CustomStrategy(StrategyFramework):
 
     def __init__(self):
         super().__init__()
-        self.sma = bt.indicators.SimpleMovingAverage(
-            self.datas[0], period=self.params.period
-        )
+        self.sma = bt.indicators.SimpleMovingAverage(self.datas[0], period=self.params.period)
 
     def next(self):
         super().next()
@@ -142,16 +141,7 @@ from finwiz.quantitative.technical import TechnicalAnalysisEngine
 engine = TechnicalAnalysisEngine()
 
 # Analyze with multiple indicators
-result = engine.analyze_symbol(
-    data=price_data,
-    symbol="AAPL",
-    timeframe="1d",
-    indicators=[
-        TechnicalIndicator.RSI,
-        TechnicalIndicator.MACD,
-        TechnicalIndicator.BOLLINGER_BANDS
-    ]
-)
+result = engine.analyze_symbol(data=price_data, symbol="AAPL", timeframe="1d", indicators=[TechnicalIndicator.RSI, TechnicalIndicator.MACD, TechnicalIndicator.BOLLINGER_BANDS])
 
 print(f"Overall Signal: {result.overall_signal}")
 print(f"Confidence: {result.overall_confidence:.2f}")
@@ -181,12 +171,7 @@ from finwiz.quantitative import get_performance_analyzer
 analyzer = get_performance_analyzer()
 
 # Analyze strategy performance
-report = analyzer.analyze_performance(
-    returns=strategy_returns,
-    benchmark_returns=benchmark_returns,
-    strategy_name="My Strategy",
-    benchmark_name="S&P 500"
-)
+report = analyzer.analyze_performance(returns=strategy_returns, benchmark_returns=benchmark_returns, strategy_name="My Strategy", benchmark_name="S&P 500")
 
 # Access comprehensive metrics
 metrics = report.performance_metrics
@@ -200,11 +185,7 @@ print(f"VaR (95%): {metrics.var_95:.2f}%")
 
 ```python
 # Optimize portfolio using modern portfolio theory
-optimization_result = analyzer.optimize_portfolio(
-    price_data=price_data,
-    method="max_sharpe",
-    total_portfolio_value=100000
-)
+optimization_result = analyzer.optimize_portfolio(price_data=price_data, method="max_sharpe", total_portfolio_value=100000)
 
 print("Optimal Weights:")
 for asset, weight in optimization_result.weights.items():
@@ -220,9 +201,7 @@ print(f"Sharpe Ratio: {optimization_result.sharpe_ratio:.2f}")
 ### Options Pricing
 
 ```python
-from finwiz.quantitative.derivatives import (
-    DerivativesPricer, OptionParameters, OptionType, PricingModel
-)
+from finwiz.quantitative.derivatives import DerivativesPricer, OptionParameters, OptionType, PricingModel
 
 pricer = DerivativesPricer()
 
@@ -233,7 +212,7 @@ option_params = OptionParameters(
     time_to_expiry=0.25,  # 3 months
     risk_free_rate=0.05,
     volatility=0.20,
-    option_type=OptionType.CALL
+    option_type=OptionType.CALL,
 )
 
 # Price the option
@@ -260,13 +239,7 @@ print(f"Implied Volatility: {implied_vol:.2%}")
 ```python
 from finwiz.quantitative.derivatives import BondParameters
 
-bond_params = BondParameters(
-    face_value=1000.0,
-    coupon_rate=0.05,
-    years_to_maturity=5.0,
-    yield_to_maturity=0.04,
-    coupon_frequency=2
-)
+bond_params = BondParameters(face_value=1000.0, coupon_rate=0.05, years_to_maturity=5.0, yield_to_maturity=0.04, coupon_frequency=2)
 
 bond_result = pricer.price_bond(bond_params)
 
@@ -280,26 +253,15 @@ print(f"Convexity: {bond_result.convexity:.2f}")
 ### Modern Portfolio Theory
 
 ```python
-from finwiz.quantitative.optimization import (
-    PortfolioOptimizer, PortfolioInputs, ObjectiveFunction, OptimizationMethod
-)
+from finwiz.quantitative.optimization import PortfolioOptimizer, PortfolioInputs, ObjectiveFunction, OptimizationMethod
 
 optimizer = PortfolioOptimizer()
 
 # Define portfolio inputs
-inputs = PortfolioInputs(
-    symbols=["AAPL", "MSFT", "GOOGL", "AMZN"],
-    expected_returns=[0.12, 0.10, 0.15, 0.14],
-    covariance_matrix=covariance_matrix,
-    risk_free_rate=0.03
-)
+inputs = PortfolioInputs(symbols=["AAPL", "MSFT", "GOOGL", "AMZN"], expected_returns=[0.12, 0.10, 0.15, 0.14], covariance_matrix=covariance_matrix, risk_free_rate=0.03)
 
 # Optimize for maximum Sharpe ratio
-result = optimizer.optimize_portfolio(
-    inputs=inputs,
-    objective=ObjectiveFunction.MAX_SHARPE,
-    method=OptimizationMethod.MEAN_VARIANCE
-)
+result = optimizer.optimize_portfolio(inputs=inputs, objective=ObjectiveFunction.MAX_SHARPE, method=OptimizationMethod.MEAN_VARIANCE)
 
 print("Optimal Portfolio:")
 for symbol, weight in zip(inputs.symbols, result.optimal_weights):
@@ -352,21 +314,10 @@ SCREENER_MAX_RESULTS=50
 from finwiz.quantitative.config import BacktestConfig, QuantConfig
 
 # Backtesting configuration
-backtest_config = BacktestConfig(
-    initial_capital=100000.0,
-    commission_pct=0.001,
-    stop_loss_pct=0.05,
-    take_profit_pct=0.15,
-    max_drawdown_limit=0.20
-)
+backtest_config = BacktestConfig(initial_capital=100000.0, commission_pct=0.001, stop_loss_pct=0.05, take_profit_pct=0.15, max_drawdown_limit=0.20)
 
 # General quantitative configuration
-quant_config = QuantConfig(
-    risk_free_rate=0.02,
-    confidence_level=0.95,
-    lookback_period=252,
-    min_data_points=50
-)
+quant_config = QuantConfig(risk_free_rate=0.02, confidence_level=0.95, lookback_period=252, min_data_points=50)
 ```
 
 ## Integration with Crews
@@ -383,12 +334,7 @@ tools = [
 ]
 
 # Use in agent task
-result = quantitative_tool.run(
-    symbol="AAPL",
-    asset_class="stock",
-    analysis_type="comprehensive",
-    timeframe="1y"
-)
+result = quantitative_tool.run(symbol="AAPL", asset_class="stock", analysis_type="comprehensive", timeframe="1y")
 ```
 
 ### Enhanced Schemas
@@ -411,7 +357,7 @@ enhanced_analysis = EnhancedStockAnalysis(
     technical_analysis=technical_result,
     backtest_result=backtest_result,
     performance_metrics=performance_metrics,
-    quantitative_recommendation=recommendation
+    quantitative_recommendation=recommendation,
 )
 ```
 
@@ -537,15 +483,18 @@ The quantitative framework leverages FinWiz's intelligent caching system:
 ```python
 # Enable detailed logging
 import logging
-logging.getLogger('finwiz.quantitative').setLevel(logging.DEBUG)
+
+logging.getLogger("finwiz.quantitative").setLevel(logging.DEBUG)
 
 # Validate data quality
 from finwiz.quantitative.data import DataQualityValidator
+
 validator = DataQualityValidator()
 quality_report = validator.validate_data(price_data)
 
 # Check configuration
 from finwiz.quantitative.config import get_quant_config
+
 config = get_quant_config()
 print(f"Risk-free rate: {config.risk_free_rate}")
 ```

--- a/docs/reference/schemas/index.md
+++ b/docs/reference/schemas/index.md
@@ -31,11 +31,7 @@ class BaseAnalysis(BaseModel):
     confidence_level: float = Field(..., ge=0.0, le=1.0)
     data_sources: List[str] = Field(default_factory=list)
 
-    model_config = {
-        "extra": "forbid",
-        "str_strip_whitespace": True,
-        "validate_assignment": True
-    }
+    model_config = {"extra": "forbid", "str_strip_whitespace": True, "validate_assignment": True}
 ```
 
 ### Standardized Risk Assessment
@@ -72,10 +68,10 @@ All schemas use Pydantic v2 strict mode:
 
 ```python
 model_config = {
-    "extra": "forbid",           # Reject unknown fields
-    "str_strip_whitespace": True, # Clean string inputs
+    "extra": "forbid",  # Reject unknown fields
+    "str_strip_whitespace": True,  # Clean string inputs
     "validate_assignment": True,  # Validate on assignment
-    "use_enum_values": True      # Use enum values in output
+    "use_enum_values": True,  # Use enum values in output
 }
 ```
 
@@ -85,7 +81,7 @@ Common validation patterns:
 
 ```python
 # Ticker symbols
-ticker: str = Field(..., pattern=r'^[A-Z]{1,5}$')
+ticker: str = Field(..., pattern=r"^[A-Z]{1,5}$")
 
 # Percentages
 percentage: float = Field(..., ge=0.0, le=1.0)
@@ -103,18 +99,19 @@ rationale: str = Field(..., min_length=50)
 ### Custom Validators
 
 ```python
-@field_validator('ticker')
+@field_validator("ticker")
 @classmethod
 def validate_ticker_format(cls, v: str) -> str:
     if not v.isalpha():
-        raise ValueError('Ticker must contain only letters')
+        raise ValueError("Ticker must contain only letters")
     return v.upper()
 
-@field_validator('price_target')
+
+@field_validator("price_target")
 @classmethod
 def validate_price_target(cls, v: Optional[float]) -> Optional[float]:
     if v is not None and v <= 0:
-        raise ValueError('Price target must be positive')
+        raise ValueError("Price target must be positive")
     return v
 ```
 
@@ -310,7 +307,8 @@ def test_ten_k_insight_validation():
 ```python
 from hypothesis import given, strategies as st
 
-@given(st.text(min_size=1, max_size=5, alphabet=st.characters(whitelist_categories=('Lu',))))
+
+@given(st.text(min_size=1, max_size=5, alphabet=st.characters(whitelist_categories=("Lu",))))
 def test_ticker_validation(ticker):
     try:
         validated = ValidatedTicker(symbol=ticker)

--- a/docs/reference/schemas/relationships.md
+++ b/docs/reference/schemas/relationships.md
@@ -49,7 +49,7 @@ src/` finds no matches — `TenKInsight`, `ETFFactsheet`, and `CryptoThesis`
 all subclass `BaseModel` directly, and their shapes differ considerably:
 
 ```python
-class TenKInsight(BaseModel):      # src/finwiz/schemas/stock.py
+class TenKInsight(BaseModel):  # src/finwiz/schemas/stock.py
     schema_version: int = 1
     ticker: str
     filing_url: str
@@ -59,7 +59,8 @@ class TenKInsight(BaseModel):      # src/finwiz/schemas/stock.py
     sec_citation: str
     # no recommendation, no risk field
 
-class ETFFactsheet(BaseModel):     # src/finwiz/schemas/etf.py
+
+class ETFFactsheet(BaseModel):  # src/finwiz/schemas/etf.py
     schema_version: int = 1
     ticker: str
     issuer: str
@@ -70,7 +71,8 @@ class ETFFactsheet(BaseModel):     # src/finwiz/schemas/etf.py
     top_holdings: list[ETFTopHolding]
     risk: RiskAssessmentStandardized | None = None  # the only one of the three with a risk field
 
-class CryptoThesis(BaseModel):     # src/finwiz/schemas/crypto.py
+
+class CryptoThesis(BaseModel):  # src/finwiz/schemas/crypto.py
     schema_version: int = 1
     symbol: str  # NOT "ticker" — field name differs from the other two
     thesis_bullets: list[str]
@@ -188,9 +190,11 @@ class TenKInsight(BaseModel):
     # ... other fields
     risk_assessment: RiskAssessmentStandardized
 
+
 class ETFFactsheet(BaseModel):
     # ... other fields
     risk_assessment: RiskAssessmentStandardized
+
 
 class CryptoThesis(BaseModel):
     # ... other fields
@@ -246,7 +250,7 @@ Grading system provides consistency across schemas:
 
 ```python
 # Consistent grading scale
-grade_pattern = r'^[A-F][+-]?$'
+grade_pattern = r"^[A-F][+-]?$"
 
 # Used in multiple schemas
 TenKInsight.grade: str = Field(..., pattern=grade_pattern)
@@ -266,7 +270,7 @@ TenKInsight.confidence_level: float
 PortfolioReview.confidence_level: float  # Weighted average
 
 # Discovery inherits from analysis
-InvestmentCandidate.confidence: float    # From underlying analysis
+InvestmentCandidate.confidence: float  # From underlying analysis
 ```
 
 ## Schema Evolution Patterns
@@ -283,7 +287,7 @@ class TenKInsight(BaseModel):
     recommendation: str
 
     # New optional fields (backward compatible)
-    esg_score: Optional[float] = None      # Added in v1.1
+    esg_score: Optional[float] = None  # Added in v1.1
     analyst_coverage: Optional[int] = None  # Added in v1.2
 ```
 
@@ -295,10 +299,7 @@ Schema versions are tracked:
 class BaseSchema(BaseModel):
     schema_version: str = Field(default="1.0")
 
-    model_config = {
-        "extra": "forbid",
-        "validate_assignment": True
-    }
+    model_config = {"extra": "forbid", "validate_assignment": True}
 ```
 
 ### Migration Support
@@ -323,11 +324,7 @@ Create appropriate schema based on asset class:
 ```python
 def create_analysis_schema(asset_class: str, data: dict):
     """Factory function to create appropriate analysis schema"""
-    schema_map = {
-        "stock": TenKInsight,
-        "etf": ETFFactsheet,
-        "crypto": CryptoThesis
-    }
+    schema_map = {"stock": TenKInsight, "etf": ETFFactsheet, "crypto": CryptoThesis}
 
     schema_class = schema_map.get(asset_class)
     if not schema_class:

--- a/docs/setup/CREWAI_STEERING_UPDATE.md
+++ b/docs/setup/CREWAI_STEERING_UPDATE.md
@@ -58,6 +58,7 @@ class MyFlowState(BaseModel):
     counter: int = 0
     # Note: 'id' field automatically added
 
+
 class MyFlow(Flow[MyFlowState]):
     @start()
     def first_method(self):
@@ -103,9 +104,11 @@ class PersistentFlow(Flow[MyState]):
 def init(self):
     return {"initialized": True}
 
+
 @start("init")  # Conditional: after init OR external trigger
 def maybe_begin(self):
     return {"started": True}
+
 
 @listen(and_(init, maybe_begin))  # Wait for BOTH
 def proceed(self):
@@ -123,15 +126,12 @@ def proceed(self):
 **Example**:
 
 ```python
-research_task = Task(
-    description="Research quantum computing",
-    agent=researcher
-)
+research_task = Task(description="Research quantum computing", agent=researcher)
 
 writing_task = Task(
     description="Write article based on research",
     agent=writer,
-    context=[research_task]  # Gets research output
+    context=[research_task],  # Gets research output
 )
 ```
 
@@ -149,19 +149,19 @@ writing_task = Task(
 ```python
 @CrewBase
 class ResearchCrew:
-    agents_config = 'config/agents.yaml'
-    tasks_config = 'config/tasks.yaml'
+    agents_config = "config/agents.yaml"
+    tasks_config = "config/tasks.yaml"
 
     @agent
     def researcher(self) -> Agent:
-        return Agent(config=self.agents_config['researcher'])
+        return Agent(config=self.agents_config["researcher"])
 
     @crew
     def crew(self) -> Crew:
         return Crew(
             agents=self.agents,  # Auto-collected
-            tasks=self.tasks,    # Auto-collected
-            process=Process.sequential
+            tasks=self.tasks,  # Auto-collected
+            process=Process.sequential,
         )
 ```
 
@@ -183,9 +183,7 @@ class PoemFlow(Flow[PoemState]):
         count = data["count"]
 
         # Execute crew
-        result = PoemCrew().crew().kickoff(
-            inputs={"sentence_count": count}
-        )
+        result = PoemCrew().crew().kickoff(inputs={"sentence_count": count})
 
         # Store in state
         self.state.poem = result.raw

--- a/docs/superpowers/plans/2026-04-27-v5.1-trust-spine.md
+++ b/docs/superpowers/plans/2026-04-27-v5.1-trust-spine.md
@@ -254,20 +254,14 @@ class StageProvenance(BaseModel):
     def _check_degraded_only_in_qualify(self) -> "StageProvenance":
         """Invariant I1: only the `qualify` stage may emit DEGRADED."""
         if self.outcome == StageOutcome.DEGRADED and self.stage != "qualify":
-            raise ValueError(
-                f"DEGRADED outcome forbidden for stage '{self.stage}'; "
-                "only 'qualify' may degrade"
-            )
+            raise ValueError(f"DEGRADED outcome forbidden for stage '{self.stage}'; only 'qualify' may degrade")
         return self
 
     @model_validator(mode="after")
     def _check_fallback_implies_degraded(self) -> "StageProvenance":
         """Invariant I3: fallback_used populated ⇒ outcome == DEGRADED."""
         if self.fallback_used is not None and self.outcome != StageOutcome.DEGRADED:
-            raise ValueError(
-                f"fallback_used='{self.fallback_used}' requires outcome=DEGRADED, "
-                f"got {self.outcome}"
-            )
+            raise ValueError(f"fallback_used='{self.fallback_used}' requires outcome=DEGRADED, got {self.outcome}")
         return self
 ```
 
@@ -317,9 +311,7 @@ def test_result_failed_with_payload_raises() -> None:
     with pytest.raises(ValidationError) as excinfo:
         StageResult[_Payload](
             payload=_Payload(value=1),
-            provenance=StageProvenance(
-                stage="collect", outcome=StageOutcome.FAILED, duration_ms=1, reason="boom"
-            ),
+            provenance=StageProvenance(stage="collect", outcome=StageOutcome.FAILED, duration_ms=1, reason="boom"),
         )
     assert "FAILED" in str(excinfo.value)
 
@@ -336,9 +328,7 @@ def test_result_ok_without_payload_raises() -> None:
 def test_result_failed_without_payload_is_valid() -> None:
     r = StageResult[_Payload](
         payload=None,
-        provenance=StageProvenance(
-            stage="collect", outcome=StageOutcome.FAILED, duration_ms=1, reason="boom"
-        ),
+        provenance=StageProvenance(stage="collect", outcome=StageOutcome.FAILED, duration_ms=1, reason="boom"),
     )
     assert r.payload is None
 ```
@@ -371,9 +361,7 @@ class StageResult(BaseModel, Generic[T]):
         if self.provenance.outcome == StageOutcome.FAILED and self.payload is not None:
             raise ValueError("FAILED outcome requires payload=None")
         if self.provenance.outcome != StageOutcome.FAILED and self.payload is None:
-            raise ValueError(
-                f"outcome={self.provenance.outcome} requires payload!=None"
-            )
+            raise ValueError(f"outcome={self.provenance.outcome} requires payload!=None")
         return self
 ```
 
@@ -471,9 +459,7 @@ def test_banner_state_rules(
     expected_state: str,
     expected_block: bool,
 ) -> None:
-    summary = CoverageSummary(
-        analyzed=analyzed, degraded=degraded, failed=failed, total=total
-    )
+    summary = CoverageSummary(analyzed=analyzed, degraded=degraded, failed=failed, total=total)
     banner = TrustBanner.from_coverage(summary)
     assert banner.state == expected_state
     assert banner.block_decisions is expected_block
@@ -481,9 +467,7 @@ def test_banner_state_rules(
 
 
 def test_banner_message_red_includes_warning() -> None:
-    banner = TrustBanner.from_coverage(
-        CoverageSummary(analyzed=1, degraded=0, failed=4, total=5)
-    )
+    banner = TrustBanner.from_coverage(CoverageSummary(analyzed=1, degraded=0, failed=4, total=5))
     assert "NE PAS" in banner.message
 ```
 
@@ -570,17 +554,11 @@ class TrustBanner(BaseModel):
 
         if total == 0 or analyzed == 0:
             state = "blocked"
-            message = (
-                "Aucune analyse complète n'a été produite. "
-                "NE PAS prendre de décisions sur ce rapport."
-            )
+            message = "Aucune analyse complète n'a été produite. NE PAS prendre de décisions sur ce rapport."
             block = True
         elif 2 * failed > total:
             state = "red"
-            message = (
-                f"{failed}/{total} holdings ont échoué. "
-                "NE PAS prendre de décisions sur ce rapport."
-            )
+            message = f"{failed}/{total} holdings ont échoué. NE PAS prendre de décisions sur ce rapport."
             block = True
         elif degraded > 0 or failed > 0:
             state = "amber"
@@ -782,16 +760,8 @@ class RunLedger:
         analyzed = sum(1 for o in terminal.values() if o == StageOutcome.OK)
         # Degraded propagates: emit emits OK but a *prior* qualify was DEGRADED.
         # Count tickers whose qualify was DEGRADED but whose emit was OK.
-        degraded_qualifies = {
-            e.ticker
-            for e in self.entries
-            if e.stage == "qualify" and e.outcome == StageOutcome.DEGRADED
-        }
-        degraded = sum(
-            1
-            for ticker, terminal_outcome in terminal.items()
-            if ticker in degraded_qualifies and terminal_outcome == StageOutcome.OK
-        )
+        degraded_qualifies = {e.ticker for e in self.entries if e.stage == "qualify" and e.outcome == StageOutcome.DEGRADED}
+        degraded = sum(1 for ticker, terminal_outcome in terminal.items() if ticker in degraded_qualifies and terminal_outcome == StageOutcome.OK)
         analyzed_clean = analyzed - degraded
         attempted = self._all_tickers_attempted()
         failed = len(attempted) - analyzed
@@ -865,9 +835,7 @@ class _Payload(BaseModel):
 
 
 def _ctx(tmp_path: Path) -> StageContext:
-    return StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    return StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
 
 
 @stage(name="collect", timeout_s=5, retries=0)
@@ -1024,9 +992,7 @@ def stage(
         ValueError at decoration time if allow_degrade=True for a non-qualify stage.
     """
     if allow_degrade and name != "qualify":
-        raise ValueError(
-            f"allow_degrade=True is only valid for stage 'qualify', got '{name}'"
-        )
+        raise ValueError(f"allow_degrade=True is only valid for stage 'qualify', got '{name}'")
 
     def deco(fn: Callable[P, T | StageResult[T]]) -> Callable[P, StageResult[T]]:
         @wraps(fn)
@@ -1042,9 +1008,7 @@ def stage(
                     raw = fn(*args, **kwargs)
                     result = _coerce_to_stage_result(raw, name=name, t0=t0, attempt=attempt)
                     if not allow_degrade and result.provenance.outcome == StageOutcome.DEGRADED:
-                        raise ValueError(
-                            f"stage '{name}' returned DEGRADED but allow_degrade=False"
-                        )
+                        raise ValueError(f"stage '{name}' returned DEGRADED but allow_degrade=False")
                     _record(ctx, result, started, name)
                     return result
                 except (ValidationError, AssertionError):
@@ -1073,9 +1037,7 @@ def _extract_context(args: tuple[Any, ...]) -> StageContext:
     raise TypeError("stage function must receive a StageContext as positional arg")
 
 
-def _coerce_to_stage_result(
-    raw: Any, *, name: StageName, t0: float, attempt: int
-) -> StageResult[Any]:
+def _coerce_to_stage_result(raw: Any, *, name: StageName, t0: float, attempt: int) -> StageResult[Any]:
     if isinstance(raw, StageResult):
         # Patch retries_used and duration_ms if not set by the body.
         prov = raw.provenance.model_copy(
@@ -1220,9 +1182,11 @@ Replace the `wrapper` portion of `stage(...)` so it dispatches on `inspect.iscor
 # Add at top:
 import inspect
 
+
 # Replace the deco() function with:
 def deco(fn: Callable[P, T | StageResult[T]]) -> Callable[P, StageResult[T]]:
     if inspect.iscoroutinefunction(fn):
+
         @wraps(fn)
         async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> StageResult[T]:
             ctx = _extract_context(args)
@@ -1235,9 +1199,7 @@ def deco(fn: Callable[P, T | StageResult[T]]) -> Callable[P, StageResult[T]]:
                     raw = await asyncio.wait_for(coro, timeout=timeout_s)
                     result = _coerce_to_stage_result(raw, name=name, t0=t0, attempt=attempt)
                     if not allow_degrade and result.provenance.outcome == StageOutcome.DEGRADED:
-                        raise ValueError(
-                            f"stage '{name}' returned DEGRADED but allow_degrade=False"
-                        )
+                        raise ValueError(f"stage '{name}' returned DEGRADED but allow_degrade=False")
                     _record(ctx, result, started, name)
                     return result
                 except (ValidationError, AssertionError):
@@ -1263,9 +1225,7 @@ def deco(fn: Callable[P, T | StageResult[T]]) -> Callable[P, StageResult[T]]:
                 raw = fn(*args, **kwargs)
                 result = _coerce_to_stage_result(raw, name=name, t0=t0, attempt=attempt)
                 if not allow_degrade and result.provenance.outcome == StageOutcome.DEGRADED:
-                    raise ValueError(
-                        f"stage '{name}' returned DEGRADED but allow_degrade=False"
-                    )
+                    raise ValueError(f"stage '{name}' returned DEGRADED but allow_degrade=False")
                 _record(ctx, result, started, name)
                 return result
             except (ValidationError, AssertionError):
@@ -1325,11 +1285,7 @@ def test_check_passes_clean_source(tmp_path: Path) -> None:
     _write(
         tmp_path,
         "ok.py",
-        "import asyncio\n"
-        "async def f():\n"
-        "    await asyncio.gather(*[g()], return_exceptions=True)\n"
-        "async def g():\n"
-        "    return 1\n",
+        "import asyncio\nasync def f():\n    await asyncio.gather(*[g()], return_exceptions=True)\nasync def g():\n    return 1\n",
     )
     violations = check_directory(tmp_path)
     assert violations == []
@@ -1339,8 +1295,7 @@ def test_check_flags_gather_without_return_exceptions(tmp_path: Path) -> None:
     _write(
         tmp_path,
         "bad.py",
-        "import asyncio\nasync def f():\n    await asyncio.gather(*[g()])\n"
-        "async def g():\n    return 1\n",
+        "import asyncio\nasync def f():\n    await asyncio.gather(*[g()])\nasync def g():\n    return 1\n",
     )
     violations = check_directory(tmp_path)
     assert any("return_exceptions=True" in v.message for v in violations)
@@ -1350,9 +1305,7 @@ def test_check_flags_allow_degrade_outside_qualify(tmp_path: Path) -> None:
     _write(
         tmp_path,
         "collect.py",
-        "from finwiz.analysis.stages._resilience import stage\n"
-        "@stage(name='collect', timeout_s=5, retries=0, allow_degrade=True)\n"
-        "def f(ctx): return None\n",
+        "from finwiz.analysis.stages._resilience import stage\n@stage(name='collect', timeout_s=5, retries=0, allow_degrade=True)\ndef f(ctx): return None\n",
     )
     violations = check_directory(tmp_path)
     assert any("allow_degrade" in v.message and "qualify" in v.message for v in violations)
@@ -1362,9 +1315,7 @@ def test_check_allows_allow_degrade_in_qualify(tmp_path: Path) -> None:
     _write(
         tmp_path,
         "qualify.py",
-        "from finwiz.analysis.stages._resilience import stage\n"
-        "@stage(name='qualify', timeout_s=5, retries=0, allow_degrade=True)\n"
-        "def f(ctx): return None\n",
+        "from finwiz.analysis.stages._resilience import stage\n@stage(name='qualify', timeout_s=5, retries=0, allow_degrade=True)\ndef f(ctx): return None\n",
     )
     violations = check_directory(tmp_path)
     assert violations == []
@@ -1521,9 +1472,7 @@ from finwiz.analysis._helpers import (
 
 def test_today_french_returns_long_date_string() -> None:
     out = _today_french()
-    assert any(month in out for month in ["janvier", "février", "mars", "avril",
-                                          "mai", "juin", "juillet", "août",
-                                          "septembre", "octobre", "novembre", "décembre"])
+    assert any(month in out for month in ["janvier", "février", "mars", "avril", "mai", "juin", "juillet", "août", "septembre", "octobre", "novembre", "décembre"])
 
 
 def test_filter_numeric_values_drops_non_numeric() -> None:
@@ -1611,6 +1560,7 @@ from typing import Any
 # Imports it currently uses (datetime, SimpleNamespace, DeepAnalysisDataCollector,
 # SentimentMacroCollector, finwiz.flow_state_models.DeepAnalysisResult, etc.)
 # get hoisted to the top of this file. NO behavior change.
+
 
 def collect_raw_data(
     ctx: Any,  # AnalysisContext — keep current signature exactly
@@ -1827,6 +1777,7 @@ For this task only the **build_verdict** body moves; the pipeline orchestration 
 ```python
 # Within deep_analysis_pipeline.py — replace the final-assembly block of analyze_holding with:
 from finwiz.analysis.stages.emit import build_verdict
+
 ...
 return build_verdict(ctx, enriched)
 ```
@@ -1988,9 +1939,7 @@ def test_collect_returns_stage_result(tmp_path: Path, mocker: Any) -> None:
         "finwiz.analysis.stages.collect._collect_raw_data_inner",
         return_value={"price_history": [1, 2, 3]},
     )
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     result = collect(ctx)
     assert isinstance(result, StageResult)
     assert result.provenance.outcome == StageOutcome.OK
@@ -2003,9 +1952,7 @@ def test_collect_records_ledger_entry(tmp_path: Path, mocker: Any) -> None:
         "finwiz.analysis.stages.collect._collect_raw_data_inner",
         return_value={},
     )
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     collect(ctx)
     assert any(e.stage == "collect" for e in ctx.ledger.entries)
 
@@ -2015,9 +1962,7 @@ def test_collect_failure_becomes_failed_outcome(tmp_path: Path, mocker: Any) -> 
         "finwiz.analysis.stages.collect._collect_raw_data_inner",
         side_effect=RuntimeError("data source down"),
     )
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     result = collect(ctx)
     assert result.payload is None
     assert result.provenance.outcome == StageOutcome.FAILED
@@ -2125,9 +2070,7 @@ def test_quantify_returns_ok_with_quantitative(tmp_path: Path, mocker: Any) -> N
         "finwiz.analysis.stages.quantify._calculate_quantitative_inner",
         return_value=fake,
     )
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     result = quantify(ctx, {})
     assert result.provenance.outcome == StageOutcome.OK
     assert result.payload is fake
@@ -2138,9 +2081,7 @@ def test_quantify_failure_records_failed(tmp_path: Path, mocker: Any) -> None:
         "finwiz.analysis.stages.quantify._calculate_quantitative_inner",
         side_effect=ValueError("scorer error"),
     )
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     result = quantify(ctx, {})
     assert result.payload is None
     assert result.provenance.outcome == StageOutcome.FAILED
@@ -2228,9 +2169,7 @@ def test_qualify_ok_when_ai_returns_valid(tmp_path: Path, mocker: Any) -> None:
         "finwiz.analysis.stages.qualify._try_ai_qualify",
         return_value=fake_qual,
     )
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     quant = QuantitativeAnalysis.model_construct()
     result = qualify(ctx, quant, {})
     assert result.provenance.outcome == StageOutcome.OK
@@ -2332,9 +2271,7 @@ def test_synthesize_returns_ok(tmp_path: Path, mocker: Any) -> None:
         "finwiz.analysis.stages.synthesize._synthesize_inner",
         return_value=enriched,
     )
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     result = synthesize(
         ctx,
         QuantitativeAnalysis.model_construct(),
@@ -2356,9 +2293,7 @@ Run: `uv run pytest tests/unit/analysis/stages/test_synthesize.py -v`
 from finwiz.analysis.stages._resilience import StageContext, stage
 
 
-def _synthesize_inner(
-    ctx: Any, quant: Any, qual: Any, raw: dict[str, Any]
-) -> EnrichedAnalysis:
+def _synthesize_inner(ctx: Any, quant: Any, qual: Any, raw: dict[str, Any]) -> EnrichedAnalysis:
     # original synthesize_enriched_analysis body
     ...
 
@@ -2414,18 +2349,14 @@ from finwiz.schemas.stage_contract import StageOutcome
 def test_emit_ok_returns_verdict(tmp_path: Path, mocker: Any) -> None:
     verdict = DeepAnalysisResult(ticker="AAPL", grade="A", composite_score=0.9, recommendation="BUY")
     mocker.patch("finwiz.analysis.stages.emit._build_verdict_inner", return_value=verdict)
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     result = emit(ctx, EnrichedAnalysis.model_construct())
     assert result.provenance.outcome == StageOutcome.OK
     assert result.payload is verdict
 
 
 def test_emit_pending_returns_na_grade(tmp_path: Path) -> None:
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     pending = _emit_pending(ctx, reason="upstream collect failure")
     assert pending.grade == "N/A"
     assert pending.composite_score == 0.0
@@ -2702,14 +2633,10 @@ from finwiz.schemas.stage_contract import StageOutcome
     failed=st.integers(min_value=0, max_value=100),
     total=st.integers(min_value=0, max_value=300),
 )
-def test_banner_state_is_one_of_four(
-    analyzed: int, degraded: int, failed: int, total: int
-) -> None:
+def test_banner_state_is_one_of_four(analyzed: int, degraded: int, failed: int, total: int) -> None:
     if analyzed + degraded + failed > total:
         return  # invalid input
-    summary = CoverageSummary(
-        analyzed=analyzed, degraded=degraded, failed=failed, total=total
-    )
+    summary = CoverageSummary(analyzed=analyzed, degraded=degraded, failed=failed, total=total)
     banner = TrustBanner.from_coverage(summary)
     assert banner.state in {"green", "amber", "red", "blocked"}
 
@@ -2764,12 +2691,8 @@ The `qualify` stage flips its silent Python fallback to a labeled `DEGRADED` out
 def test_qualify_degraded_when_ai_returns_none(tmp_path: Path, mocker: Any) -> None:
     mocker.patch("finwiz.analysis.stages.qualify._try_ai_qualify", return_value=None)
     fake_proxy = QualitativeInsights.model_construct()
-    mocker.patch(
-        "finwiz.analysis.stages.qualify._python_proxy_qualify", return_value=fake_proxy
-    )
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    mocker.patch("finwiz.analysis.stages.qualify._python_proxy_qualify", return_value=fake_proxy)
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     quant = QuantitativeAnalysis.model_construct()
     result = qualify(ctx, quant, {})
     assert result.provenance.outcome == StageOutcome.DEGRADED
@@ -2794,9 +2717,7 @@ from finwiz.schemas.stage_contract import (
 
 
 @stage(name="qualify", timeout_s=180, retries=2, allow_degrade=True)
-def qualify(
-    ctx: StageContext, quant: Any, raw: dict[str, Any]
-) -> StageResult[QualitativeInsights]:
+def qualify(ctx: StageContext, quant: Any, raw: dict[str, Any]) -> StageResult[QualitativeInsights]:
     """Qualitative stage. Returns OK on AI success, DEGRADED on Python fallback."""
     ai = _try_ai_qualify(ctx, quant, raw)
     if ai is not None:
@@ -2876,9 +2797,7 @@ def test_synthesize_marks_low_confidence_when_qualify_degraded(tmp_path, mocker)
         "finwiz.analysis.stages.synthesize._synthesize_inner",
         return_value=enriched,
     )
-    ctx = StageContext(
-        ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="AAPL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     quant = QuantitativeAnalysis.model_construct()
     qual = QualitativeInsights.model_construct()
     # The orchestrator passes the prior qualify provenance via stage_ctx.extras
@@ -2893,9 +2812,7 @@ def test_synthesize_marks_low_confidence_when_qualify_degraded(tmp_path, mocker)
 
 ```python
 # src/finwiz/analysis/stages/synthesize.py — within _synthesize_inner:
-def _synthesize_inner(
-    ctx: Any, quant: Any, qual: Any, raw: dict[str, Any]
-) -> EnrichedAnalysis:
+def _synthesize_inner(ctx: Any, quant: Any, qual: Any, raw: dict[str, Any]) -> EnrichedAnalysis:
     enriched = ...  # existing synthesis logic
     if isinstance(ctx, StageContext) and ctx.extras.get("qualify_outcome") == StageOutcome.DEGRADED:
         # Mark the enriched analysis's downstream confidence
@@ -2986,11 +2903,7 @@ Find the holding-row template (currently around line 269 — search `Analyse en 
 # In render_holding_row(...) — after the existing grade/score cells:
 def _confidence_badge(holding: DeepAnalysisResult) -> str:
     if getattr(holding, "confidence", "high") == "low":
-        return (
-            '<span class="badge-amber" '
-            'title="Insight IA indisponible — proxy quantitatif Python affiché">'
-            '⚠️ Insight IA indisponible</span>'
-        )
+        return '<span class="badge-amber" title="Insight IA indisponible — proxy quantitatif Python affiché">⚠️ Insight IA indisponible</span>'
     return ""
 ```
 
@@ -3067,7 +2980,7 @@ def render_trust_banner(banner: TrustBanner) -> str:
     cls = _BANNER_CLASS[banner.state]
     return (
         f'<div class="{cls}" data-block-decisions="{str(banner.block_decisions).lower()}">'
-        f'<strong>Couverture:</strong> {banner.analyzed}/{banner.total} '
+        f"<strong>Couverture:</strong> {banner.analyzed}/{banner.total} "
         f"({banner.degraded} dégradés, {banner.failed} échoués). "
         f"{banner.message}"
         f"</div>"
@@ -3134,14 +3047,9 @@ def test_ai_null_never_emits_silent_ok(tmp_path: Path, mocker: Any) -> None:
         "finwiz.analysis.stages.qualify._python_proxy_qualify",
         return_value=QualitativeInsights.model_construct(),
     )
-    ctx = StageContext(
-        ticker="DELL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path)
-    )
+    ctx = StageContext(ticker="DELL", run_id="r1", ledger=RunLedger(run_id="r1", artifact_dir=tmp_path))
     result = qualify(ctx, QuantitativeAnalysis.model_construct(), {})
-    assert result.provenance.outcome == StageOutcome.DEGRADED, (
-        "v0.3.0 regression: AI null must NEVER produce a silent OK — got "
-        f"{result.provenance.outcome}"
-    )
+    assert result.provenance.outcome == StageOutcome.DEGRADED, f"v0.3.0 regression: AI null must NEVER produce a silent OK — got {result.provenance.outcome}"
     assert result.provenance.fallback_used == "python_proxy_qualitative"
 
 
@@ -3248,9 +3156,7 @@ def _ctx(ticker: str, ledger: RunLedger) -> StageContext:
     return StageContext(ticker=ticker, run_id="integ", ledger=ledger)
 
 
-def test_three_holding_pipeline(
-    ledger: RunLedger, mocker: Any, stock_data: Any
-) -> None:
+def test_three_holding_pipeline(ledger: RunLedger, mocker: Any, stock_data: Any) -> None:
     """One holding succeeds, one degrades, one fails — banner is amber."""
     # Holding 1 (HAPPY): everything succeeds.
     # Holding 2 (DEGRADED): AI returns None, Python proxy fills in.
@@ -3264,17 +3170,12 @@ def test_three_holding_pipeline(
             raise RuntimeError("data source down")
         return {"price_history": [1, 2, 3]}
 
-    mocker.patch("finwiz.analysis.stages.collect._collect_raw_data_inner",
-                 side_effect=_collect_for_ticker)
+    mocker.patch("finwiz.analysis.stages.collect._collect_raw_data_inner", side_effect=_collect_for_ticker)
     mocker.patch("finwiz.analysis.stages.qualify._try_ai_qualify", side_effect=_ai_for_ticker)
-    mocker.patch("finwiz.analysis.stages.qualify._python_proxy_qualify",
-                 return_value=_fake_ai_payload())
-    mocker.patch("finwiz.analysis.stages.quantify._calculate_quantitative_inner",
-                 return_value=_fake_quant())
-    mocker.patch("finwiz.analysis.stages.synthesize._synthesize_inner",
-                 return_value=_fake_enriched())
-    mocker.patch("finwiz.analysis.stages.emit._build_verdict_inner",
-                 return_value=_fake_verdict())
+    mocker.patch("finwiz.analysis.stages.qualify._python_proxy_qualify", return_value=_fake_ai_payload())
+    mocker.patch("finwiz.analysis.stages.quantify._calculate_quantitative_inner", return_value=_fake_quant())
+    mocker.patch("finwiz.analysis.stages.synthesize._synthesize_inner", return_value=_fake_enriched())
+    mocker.patch("finwiz.analysis.stages.emit._build_verdict_inner", return_value=_fake_verdict())
 
     for ticker in ("HAPPY_TKR", "DEGRADED_TKR", "FAILED_TKR"):
         ctx = _make_analysis_context(ticker)  # helper that builds AnalysisContext
@@ -3291,28 +3192,31 @@ def test_three_holding_pipeline(
 # Test fixtures (kept inline for readability; engineer may extract to conftest.py)
 def _fake_ai_payload() -> Any:
     from finwiz.schemas.hybrid_analysis import QualitativeInsights
+
     return QualitativeInsights.model_construct()
 
 
 def _fake_quant() -> Any:
     from finwiz.schemas.hybrid_analysis import QuantitativeAnalysis
+
     return QuantitativeAnalysis.model_construct()
 
 
 def _fake_enriched() -> Any:
     from finwiz.schemas.hybrid_analysis import EnrichedAnalysis
+
     return EnrichedAnalysis.model_construct()
 
 
 def _fake_verdict() -> Any:
     from finwiz.flow_state_models import DeepAnalysisResult
-    return DeepAnalysisResult(
-        ticker="x", grade="A", composite_score=0.9, recommendation="BUY"
-    )
+
+    return DeepAnalysisResult(ticker="x", grade="A", composite_score=0.9, recommendation="BUY")
 
 
 def _make_analysis_context(ticker: str) -> Any:
     from finwiz.analysis.deep_analysis_pipeline import AnalysisContext
+
     return AnalysisContext.model_construct(ticker=ticker)
 ```
 

--- a/docs/superpowers/plans/2026-04-30-tactical-price-targets.md
+++ b/docs/superpowers/plans/2026-04-30-tactical-price-targets.md
@@ -212,8 +212,7 @@ class TestConfidence:
             current_price=130.0,
         )
         assert result is not None
-        assert "high" in (result.buy_rationale + result.sell_rationale).lower() or \
-            "élevée" in (result.buy_rationale + result.sell_rationale).lower()
+        assert "high" in (result.buy_rationale + result.sell_rationale).lower() or "élevée" in (result.buy_rationale + result.sell_rationale).lower()
 
     def test_low_confidence_when_history_short(self) -> None:
         # 80 days of history, just over the 60-day floor but below 120 → low confidence.
@@ -363,8 +362,7 @@ def compute_tactical_pricing(
         return None
     if len(price_history) < _MIN_HISTORY_DAYS:
         logger.warning(
-            f"tactical_pricing: insufficient history for {ticker} "
-            f"({len(price_history)} < {_MIN_HISTORY_DAYS} days)",
+            f"tactical_pricing: insufficient history for {ticker} ({len(price_history)} < {_MIN_HISTORY_DAYS} days)",
         )
         return None
     if not _is_history_fresh(price_history):
@@ -412,12 +410,8 @@ def compute_tactical_pricing(
     confidence = _confidence(price_history, target, drift_target_capped, current_price)
     confidence_fr = {"high": "élevée", "medium": "moyenne", "low": "faible"}[confidence]
 
-    buy_rationale = (
-        f"Target {target_method} sur {horizon_months} mois — confiance {confidence_fr}."
-    )
-    sell_rationale = (
-        f"Plancher = max(support technique, prix − 2×ATR) — confiance {confidence_fr}."
-    )
+    buy_rationale = f"Target {target_method} sur {horizon_months} mois — confiance {confidence_fr}."
+    sell_rationale = f"Plancher = max(support technique, prix − 2×ATR) — confiance {confidence_fr}."
 
     return PriceTargets(
         current_price=current_price,
@@ -956,11 +950,7 @@ def _format_target_cell(price_targets, current_price: float | None, kind: str) -
     """
     if price_targets is None or current_price is None or current_price <= 0:
         return '<td class="muted">—</td>'
-    value = (
-        price_targets.buy_target_primary
-        if kind == "target"
-        else price_targets.sell_target_primary
-    )
+    value = price_targets.buy_target_primary if kind == "target" else price_targets.sell_target_primary
     if value is None:
         return '<td class="muted">—</td>'
     delta_pct = (value - current_price) / current_price * 100

--- a/docs/superpowers/plans/2026-06-07-lean-deps-and-sbom.md
+++ b/docs/superpowers/plans/2026-06-07-lean-deps-and-sbom.md
@@ -405,11 +405,11 @@ git commit -m "chore(api): remove unused FastAPI module (drops fastapi/starlette
 Delete these lines from the `dependencies = [ ... ]` array:
 
 ```python
-    "unstructured>=0.18.11",
-    "langchain-community>=0.3.29",
-    "langchain-text-splitters>=0.3.0",
-    "sec-api>=1.0.32",
-    "fastapi>=0.136.1",
+("unstructured>=0.18.11",)
+("langchain-community>=0.3.29",)
+("langchain-text-splitters>=0.3.0",)
+("sec-api>=1.0.32",)
+("fastapi>=0.136.1",)
 ```
 
 - [ ] **Step 2: Remove the now-moot starlette constraint**
@@ -417,7 +417,7 @@ Delete these lines from the `dependencies = [ ... ]` array:
 In the `[tool.uv] constraint-dependencies` array, delete:
 
 ```python
-    "starlette>=1.0.1",
+("starlette>=1.0.1",)
 ```
 
 (Leave urllib3/idna/gitpython/langchain-classic/uv — they are pulled by other deps. Task 5 Step 4 re-checks langchain-classic.)
@@ -427,8 +427,8 @@ In the `[tool.uv] constraint-dependencies` array, delete:
 In `[dependency-groups] dev = [ ... ]`, add:
 
 ```python
-    "cyclonedx-bom>=4.0.0",
-    "pip-audit>=2.7.0",
+("cyclonedx-bom>=4.0.0",)
+("pip-audit>=2.7.0",)
 ```
 
 - [ ] **Step 3: Re-lock and sync**

--- a/docs/superpowers/plans/2026-06-07-test-isolation-and-xdist.md
+++ b/docs/superpowers/plans/2026-06-07-test-isolation-and-xdist.md
@@ -296,7 +296,7 @@ Expected: ALL pass — the autouse reset makes the singleton's starting state in
 In `pyproject.toml`, in `[dependency-groups]` `dev = [ ... ]`, add after `"pytest-timeout>=2.4.0",`:
 
 ```python
-    "pytest-xdist>=3.6.0",
+("pytest-xdist>=3.6.0",)
 ```
 
 - [ ] **Step 2: Lock + sync**

--- a/docs/superpowers/plans/2026-06-08-portfolio-allocation-data.md
+++ b/docs/superpowers/plans/2026-06-08-portfolio-allocation-data.md
@@ -916,11 +916,7 @@ class TestAllocationWiring:
         from finwiz.orchestrators.portfolio_review_orchestrator import build_portfolio_review
 
         stock_csv = tmp_path / "stock.csv"
-        stock_csv.write_text(
-            "Name,Ticker,Currency,Active,Quantity\n"
-            "Apple,AAPL,USD,true,10\n"
-            "Microsoft,MSFT,USD,true,10\n"
-        )
+        stock_csv.write_text("Name,Ticker,Currency,Active,Quantity\nApple,AAPL,USD,true,10\nMicrosoft,MSFT,USD,true,10\n")
 
         mock_validator = mocker.patch("finwiz.orchestrators.portfolio_holdings_processor.TickerExistenceValidationTool")
         mock_validator.return_value._run.return_value = {"valid": True, "meta": {"source": "yahoo"}}
@@ -1119,11 +1115,7 @@ def _rows(path):
 
 def test_rewrites_currency_from_resolver(tmp_path):
     csv_path = tmp_path / "etf.csv"
-    csv_path.write_text(
-        "Name,Ticker,Currency,Active\n"
-        "Amundi EM,Yahoo:AEEM.PA,USD,true\n"
-        "UBS Gold,Yahoo:AUUSI.SW,USD,true\n"
-    )
+    csv_path.write_text("Name,Ticker,Currency,Active\nAmundi EM,Yahoo:AEEM.PA,USD,true\nUBS Gold,Yahoo:AUUSI.SW,USD,true\n")
 
     def resolver(ticker):
         return {"AEEM.PA": "EUR", "AUUSI.SW": "CHF"}.get(ticker)
@@ -1138,11 +1130,7 @@ def test_rewrites_currency_from_resolver(tmp_path):
 
 def test_preserves_other_columns_and_order(tmp_path):
     csv_path = tmp_path / "stock.csv"
-    csv_path.write_text(
-        "Name,Ticker,Currency,Active\n"
-        "Apple,Yahoo:AAPL,USD,true\n"
-        "Nestle,Yahoo:NESN.SW,USD,true\n"
-    )
+    csv_path.write_text("Name,Ticker,Currency,Active\nApple,Yahoo:AAPL,USD,true\nNestle,Yahoo:NESN.SW,USD,true\n")
 
     def resolver(ticker):
         return {"AAPL": "USD", "NESN.SW": "CHF"}.get(ticker)
@@ -1171,11 +1159,7 @@ def test_adds_currency_column_to_crypto(tmp_path):
 
 def test_per_ticker_failure_leaves_row_unchanged(tmp_path):
     csv_path = tmp_path / "stock.csv"
-    csv_path.write_text(
-        "Name,Ticker,Currency,Active\n"
-        "Apple,Yahoo:AAPL,USD,true\n"
-        "Broken,Yahoo:BAD,EUR,true\n"
-    )
+    csv_path.write_text("Name,Ticker,Currency,Active\nApple,Yahoo:AAPL,USD,true\nBroken,Yahoo:BAD,EUR,true\n")
 
     def resolver(ticker):
         return "CHF" if ticker == "AAPL" else None  # BAD unresolved

--- a/docs/superpowers/plans/2026-06-10-simplification-pass2-merge.md
+++ b/docs/superpowers/plans/2026-06-10-simplification-pass2-merge.md
@@ -159,17 +159,13 @@ def test_collect_sentiment_uses_standardized_tool(mocker):
         "top_pos": [],
         "top_neg": [],
     }
-    mock_tool = mocker.patch(
-        "finwiz.orchestrators.deep_analysis_data_collector.StandardizedSentimentAnalysisTool"
-    )
+    mock_tool = mocker.patch("finwiz.orchestrators.deep_analysis_data_collector.StandardizedSentimentAnalysisTool")
     mock_tool.return_value._run.return_value = fake_result
 
     collector = DeepAnalysisDataCollector()
     data = collector._collect_sentiment_data("AAPL", "stock")
 
-    mock_tool.return_value._run.assert_called_once_with(
-        symbol="AAPL", asset_class="stock", max_articles=20, days_back=30
-    )
+    mock_tool.return_value._run.assert_called_once_with(symbol="AAPL", asset_class="stock", max_articles=20, days_back=30)
     assert data["sentiment_score"] == 0.42
     assert data["overall_sentiment"] in {"positive", "bullish"}  # match the file's existing label convention
     assert 0.0 <= data["sentiment_confidence"] <= 1.0
@@ -189,9 +185,7 @@ In `_collect_sentiment_data`, replace the enhanced-tool call:
 ```python
 from finwiz.tools.standardized_sentiment_tool import StandardizedSentimentAnalysisTool  # move to module-level imports
 
-result = StandardizedSentimentAnalysisTool()._run(
-    symbol=ticker, asset_class=asset_class, max_articles=20, days_back=30
-)
+result = StandardizedSentimentAnalysisTool()._run(symbol=ticker, asset_class=asset_class, max_articles=20, days_back=30)
 score = float(result.get("weighted_score") or result.get("mean_score") or 0.0)
 counts = result.get("counts") or {}
 total = max(1, sum(counts.values()))

--- a/docs/superpowers/plans/2026-07-14-central-tools-wave1.md
+++ b/docs/superpowers/plans/2026-07-14-central-tools-wave1.md
@@ -582,9 +582,7 @@ def test_run_returns_answer_envelope(pplx_key, mocker):
 def test_recency_maps_to_search_recency_filter(pplx_key, mocker):
     post = mocker.patch(
         "crewai_custom_tools.tools.web.perplexity.requests.post",
-        return_value=_mock_response(
-            mocker, {"choices": [{"message": {"content": "x"}}], "citations": []}
-        ),
+        return_value=_mock_response(mocker, {"choices": [{"message": {"content": "x"}}], "citations": []}),
     )
     PerplexitySearchTool()._run(query="q", search_recency="week", search_domain_filter=["reddit.com"])
     payload = post.call_args.kwargs["json"]
@@ -634,22 +632,15 @@ class PerplexitySearchInput(BaseModel):
     query: str = Field(..., description="Natural language query to research with Perplexity Sonar.")
     model: str = Field("sonar-pro", description="Perplexity model to use (e.g., sonar-pro).")
     top_k: int | None = Field(5, description="Maximum number of web results to retrieve (1-10 typical).")
-    search_recency: str | None = Field(
-        None, description="Recency filter: 'hour', 'day', 'week', 'month', or 'year'. Empty for default."
-    )
-    search_domain_filter: list[str] | None = Field(
-        None, description="Restrict the search to these domains, e.g. ['reddit.com']."
-    )
+    search_recency: str | None = Field(None, description="Recency filter: 'hour', 'day', 'week', 'month', or 'year'. Empty for default.")
+    search_domain_filter: list[str] | None = Field(None, description="Restrict the search to these domains, e.g. ['reddit.com'].")
 
 
 class PerplexitySearchTool(BaseTool):
     """AI-powered web search with synthesis and citations."""
 
     name: str = "perplexity_search"
-    description: str = (
-        "AI-powered web search using Perplexity API. Returns synthesized answers "
-        "with citations. Requires PERPLEXITY_API_KEY (or legacy PPLX_API_KEY)."
-    )
+    description: str = "AI-powered web search using Perplexity API. Returns synthesized answers with citations. Requires PERPLEXITY_API_KEY (or legacy PPLX_API_KEY)."
     args_schema: type[BaseModel] = PerplexitySearchInput
 
     def model_post_init(self, __context: Any) -> None:
@@ -815,9 +806,7 @@ Expected: FAIL — `ImportError: cannot import name 'perplexity_structured'`
 ```python
 T = TypeVar("T", bound=BaseModel)
 
-_DEFAULT_STRUCTURED_SYSTEM = (
-    "You are a research assistant. Provide concise, evidence-grounded answers with citations."
-)
+_DEFAULT_STRUCTURED_SYSTEM = "You are a research assistant. Provide concise, evidence-grounded answers with citations."
 
 
 async def perplexity_structured(
@@ -1081,9 +1070,7 @@ def test_history_live_result_has_timestamps(mocker):
         {"Open": [1.0, 2.0], "High": [1.5, 2.5], "Low": [0.5, 1.5], "Close": [1.2, 2.2], "Volume": [100, 200]},
         index=pd.to_datetime(["2026-07-01", "2026-07-02"]),
     )
-    mocker.patch.object(
-        history_holdings.yf, "Ticker", return_value=mocker.Mock(history=mocker.Mock(return_value=frame))
-    )
+    mocker.patch.object(history_holdings.yf, "Ticker", return_value=mocker.Mock(history=mocker.Mock(return_value=frame)))
     data = parse_tool_result(history_holdings.YahooFinanceHistoryTool()._run(ticker="AAPL"))
     assert data["data_source"] == "live_api"
     assert "timestamp" in data
@@ -1114,20 +1101,18 @@ Expected: FAIL (`TypeError: unexpected keyword argument 'prefetched_data'`)
 and at the end of the method (replacing `return ok({"summary": summary, "history": history_list[-10:]})`):
 
 ```python
-        payload: dict[str, Any] = {
-            "summary": summary,
-            "history": history_list[-10:],
-            "timestamp": datetime.now(UTC).isoformat(),
-            "data_source": "live_api",
-        }
-        if history_list:
-            try:
-                payload["data_time"] = (
-                    datetime.strptime(history_list[-1]["date"], "%Y-%m-%d").replace(tzinfo=UTC).isoformat()
-                )
-            except ValueError:
-                logger.warning(f"Could not parse latest bar date for {ticker}")
-        return ok(payload)
+payload: dict[str, Any] = {
+    "summary": summary,
+    "history": history_list[-10:],
+    "timestamp": datetime.now(UTC).isoformat(),
+    "data_source": "live_api",
+}
+if history_list:
+    try:
+        payload["data_time"] = datetime.strptime(history_list[-1]["date"], "%Y-%m-%d").replace(tzinfo=UTC).isoformat()
+    except ValueError:
+        logger.warning(f"Could not parse latest bar date for {ticker}")
+return ok(payload)
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -1170,9 +1155,7 @@ def _company_info_mock(mocker, info, financials):
 def test_company_info_calculates_revenue_growth_from_financials(mocker):
     import pandas as pd
 
-    financials = pd.DataFrame(
-        {"2026": [200.0], "2025": [100.0]}, index=["Total Revenue"]
-    )
+    financials = pd.DataFrame({"2026": [200.0], "2025": [100.0]}, index=["Total Revenue"])
     tool = _company_info_mock(
         mocker,
         info={"longName": "Apple", "debtToEquity": 152.41, "revenueGrowth": 0.99},

--- a/docs/superpowers/plans/2026-07-15-central-tools-wave4.md
+++ b/docs/superpowers/plans/2026-07-15-central-tools-wave4.md
@@ -41,8 +41,8 @@
 ```python
 from crewai_custom_tools.core.rate_limiter import get_rate_limiter
 
-await asyncio.to_thread(get_rate_limiter().acquire, "YahooFinance")   # coordinator
-await asyncio.to_thread(get_rate_limiter().acquire, "AlphaVantage")   # prefetcher
+await asyncio.to_thread(get_rate_limiter().acquire, "YahooFinance")  # coordinator
+await asyncio.to_thread(get_rate_limiter().acquire, "AlphaVantage")  # prefetcher
 ```
 
 Central provider strings: "YahooFinance", "AlphaVantage" (registry-backed, bounded by CREWAI_TOOLS_RATE_LIMIT_MAX_WAIT). Premium-tier env vars (`ALPHA_VANTAGE_PREMIUM`, `TWELVE_DATA_PREMIUM`) are already honored by central — finwiz loses no behavior. Any RateLimiter attribute the coordinator exposes (`orchestrator.rate_limiter` — a perf test asserts non-None) must be adapted or the assertion updated (read `test_holding_analyzer_orchestrator_performance.py:55`).

--- a/docs/superpowers/plans/2026-08-16-strategic-posture-coverage.md
+++ b/docs/superpowers/plans/2026-08-16-strategic-posture-coverage.md
@@ -228,11 +228,13 @@ def test_oversized_model_output_is_clamped_not_rejected():
     """
     from finwiz.schemas.hybrid_analysis.strategic import MAX_BULLET_CHARS, PestelAnalysis
 
-    pestel = PestelAnalysis.model_validate({
-        "political": ["x" * 5000, "y" * 5000, "z" * 5000, "w" * 5000, "v" * 5000],
-        "strategic_score": 0.7,
-        "confidence": 0.8,
-    })
+    pestel = PestelAnalysis.model_validate(
+        {
+            "political": ["x" * 5000, "y" * 5000, "z" * 5000, "w" * 5000, "v" * 5000],
+            "strategic_score": 0.7,
+            "confidence": 0.8,
+        }
+    )
 
     assert len(pestel.political) == 3
     assert all(len(b) <= MAX_BULLET_CHARS for b in pestel.political)
@@ -288,29 +290,31 @@ Change `PestelAnalysis`'s six dimension fields from `str` to `list[str]`:
 and replace its `_coerce_dimension` validator:
 
 ```python
-    @field_validator("political", "economic", "social", "technological", "environmental", "legal", mode="before")
-    @classmethod
-    def _clamp_dimension(cls, v: object) -> list[str]:
-        return _clamp_bullets(v, MAX_BULLETS_PESTEL)
+@field_validator("political", "economic", "social", "technological", "environmental", "legal", mode="before")
+@classmethod
+def _clamp_dimension(cls, v: object) -> list[str]:
+    return _clamp_bullets(v, MAX_BULLETS_PESTEL)
 
-    @field_validator("key_threats", "key_opportunities", mode="before")
-    @classmethod
-    def _clamp_key_lists(cls, v: object) -> list[str]:
-        return _clamp_bullets(v, MAX_BULLETS_PESTEL)
+
+@field_validator("key_threats", "key_opportunities", mode="before")
+@classmethod
+def _clamp_key_lists(cls, v: object) -> list[str]:
+    return _clamp_bullets(v, MAX_BULLETS_PESTEL)
 ```
 
 In `SwotAnalysis`:
 
 ```python
-    @field_validator("strengths", "weaknesses", "opportunities", "threats", mode="before")
-    @classmethod
-    def _clamp_lists(cls, v: object) -> list[str]:
-        return _clamp_bullets(v, MAX_BULLETS_SWOT)
+@field_validator("strengths", "weaknesses", "opportunities", "threats", mode="before")
+@classmethod
+def _clamp_lists(cls, v: object) -> list[str]:
+    return _clamp_bullets(v, MAX_BULLETS_SWOT)
 
-    @field_validator("strategic_assessment", mode="before")
-    @classmethod
-    def _clamp_assessment(cls, v: object) -> str:
-        return _clamp_prose(v, MAX_PROSE_CHARS)
+
+@field_validator("strategic_assessment", mode="before")
+@classmethod
+def _clamp_assessment(cls, v: object) -> str:
+    return _clamp_prose(v, MAX_PROSE_CHARS)
 ```
 
 In `ForceRating`:
@@ -460,12 +464,7 @@ def test_every_holding_survives_the_digest():
     from finwiz.analysis.strategic_research import _serialize_holdings
     from finwiz.schemas.hybrid_analysis.strategic import PestelAnalysis, StrategicAnalysis
 
-    holdings = {
-        f"TICK{i}": StrategicAnalysis(
-            pestel=PestelAnalysis(political=["p" * 200] * 3, economic=["e" * 200] * 3, strategic_score=0.6, confidence=0.7)
-        )
-        for i in range(200)
-    }
+    holdings = {f"TICK{i}": StrategicAnalysis(pestel=PestelAnalysis(political=["p" * 200] * 3, economic=["e" * 200] * 3, strategic_score=0.6, confidence=0.7)) for i in range(200)}
 
     payload = _serialize_holdings(holdings)
     parsed = json.loads(payload)
@@ -480,10 +479,7 @@ def test_digest_shrinks_detail_under_budget(mocker):
     from finwiz.schemas.hybrid_analysis.strategic import PestelAnalysis, StrategicAnalysis
 
     mocker.patch.object(strategic_research, "SYNTHESIS_PAYLOAD_BUDGET_CHARS", 5_000)
-    holdings = {
-        f"T{i}": StrategicAnalysis(pestel=PestelAnalysis(political=["p" * 200] * 3, strategic_score=0.6, confidence=0.7))
-        for i in range(100)
-    }
+    holdings = {f"T{i}": StrategicAnalysis(pestel=PestelAnalysis(political=["p" * 200] * 3, strategic_score=0.6, confidence=0.7)) for i in range(100)}
 
     payload = strategic_research._serialize_holdings(holdings)
 
@@ -603,8 +599,12 @@ def test_posture_score_has_no_plausible_default():
 
     with pytest.raises(ValidationError):
         PortfolioStrategicPosture(
-            holdings_covered=64, holdings_total=64, value_covered_pct=100.0,
-            macro_verdict="m", competitive_verdict="c", swot_verdict="s",
+            holdings_covered=64,
+            holdings_total=64,
+            value_covered_pct=100.0,
+            macro_verdict="m",
+            competitive_verdict="c",
+            swot_verdict="s",
         )
 ```
 
@@ -640,8 +640,9 @@ In `PortfolioStrategicPosture`, add the coverage block and the verdicts, and mak
 Extend `_portfolio_prompt` in `strategic_research.py` to request the three verdicts:
 
 ```python
-        "- macro_verdict / competitive_verdict / swot_verdict : UNE phrase chacun, "
-        "200 caractères maximum, compréhensible par un lecteur non financier.\n"
+"- macro_verdict / competitive_verdict / swot_verdict : UNE phrase chacun,"
+
+"200 caractères maximum, compréhensible par un lecteur non financier.\n"
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -705,19 +706,23 @@ Expected: FAIL — `_synthesize_portfolio_strategic` takes no `all_tickers`.
 In `_synthesize_portfolio_strategic`, after `posture = synthesize_portfolio_posture_sync(holdings_models)`:
 
 ```python
-            covered = sorted(holdings_models)
-            uncovered = sorted(set(all_tickers) - set(covered))
-            posture = posture.model_copy(update={
-                "holdings_covered": len(covered),
-                "holdings_total": len(all_tickers),
-                "uncovered_tickers": uncovered,
-            })
+covered = sorted(holdings_models)
+uncovered = sorted(set(all_tickers) - set(covered))
+posture = posture.model_copy(
+    update={
+        "holdings_covered": len(covered),
+        "holdings_total": len(all_tickers),
+        "uncovered_tickers": uncovered,
+    }
+)
 
-            if uncovered:
-                self.logger.error(
-                    "Strategic coverage incomplete: %d/%d holdings. Missing: %s",
-                    len(covered), len(all_tickers), ", ".join(uncovered),
-                )
+if uncovered:
+    self.logger.error(
+        "Strategic coverage incomplete: %d/%d holdings. Missing: %s",
+        len(covered),
+        len(all_tickers),
+        ", ".join(uncovered),
+    )
 ```
 
 Update the call site at `enrichment.py:79` to pass `all_tickers=[h.ticker for h in portfolio_review.holdings if h.ticker]`.
@@ -781,19 +786,16 @@ Expected: FAIL — `_pestel_prompt` takes no `asset_class`.
 Add `asset_class: str = "stock"` to each prompt builder and branch on it. For `_pestel_prompt`:
 
 ```python
-    if asset_class == "etf":
-        focus = (
-            "Pour un ETF, traite : régime réglementaire et fiscal, concentration "
-            "sectorielle et géographique, frais et qualité de réplication, liquidité."
-        )
-    elif asset_class == "crypto":
-        focus = (
-            "Pour un actif crypto, traite : économie du protocole et émission, "
-            "posture réglementaire par juridiction, effets de réseau et activité "
-            "des développeurs, risque de conservation et de contrepartie."
-        )
-    else:
-        focus = "Couvre les six dimensions PESTEL classiques pour l'entreprise."
+if asset_class == "etf":
+    focus = "Pour un ETF, traite : régime réglementaire et fiscal, concentration sectorielle et géographique, frais et qualité de réplication, liquidité."
+elif asset_class == "crypto":
+    focus = (
+        "Pour un actif crypto, traite : économie du protocole et émission, "
+        "posture réglementaire par juridiction, effets de réseau et activité "
+        "des développeurs, risque de conservation et de contrepartie."
+    )
+else:
+    focus = "Couvre les six dimensions PESTEL classiques pour l'entreprise."
 ```
 
 and interpolate `focus` into the returned prompt. Apply the same pattern to `_swot_prompt` and `_porter_prompt` (for ETFs, Porter's forces map to provider competition and fee pressure).
@@ -971,13 +973,20 @@ def test_coverage_leads_the_page():
     """Coverage is the first thing a reader sees, not a footnote."""
     from finwiz.reporting.sections.posture_page import generate_posture_page
 
-    html = generate_posture_page({
-        "holdings_covered": 26, "holdings_total": 64, "value_covered_pct": 38.2,
-        "uncovered_tickers": ["TSLA"], "macro_verdict": "Environnement porteur.",
-        "competitive_verdict": "Moats solides.", "swot_verdict": "Équilibré.",
-        "strategic_score": 0.71, "confidence": 0.83,
-        "macro_environment_summary": "- **Politique** : durcissement",
-    })
+    html = generate_posture_page(
+        {
+            "holdings_covered": 26,
+            "holdings_total": 64,
+            "value_covered_pct": 38.2,
+            "uncovered_tickers": ["TSLA"],
+            "macro_verdict": "Environnement porteur.",
+            "competitive_verdict": "Moats solides.",
+            "swot_verdict": "Équilibré.",
+            "strategic_score": 0.71,
+            "confidence": 0.83,
+            "macro_environment_summary": "- **Politique** : durcissement",
+        }
+    )
 
     assert "26 / 64" in html
     assert html.index("26 / 64") < html.index("Environnement porteur.")
@@ -1063,8 +1072,8 @@ def generate_posture_page(
         cards = f"<section><h2>Par ligne</h2><ul>{rows}</ul></section>"
 
     return (
-        "<!DOCTYPE html><html lang=\"fr\"><head><meta charset=\"utf-8\">"
-        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+        '<!DOCTYPE html><html lang="fr"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
         "<title>Posture Stratégique — FinWiz</title>"
         f"<style>{get_report_css()}</style></head><body>"
         "<h1>Posture Stratégique du Portefeuille</h1>"

--- a/docs/superpowers/plans/2026-08-17-drop-pestel.md
+++ b/docs/superpowers/plans/2026-08-17-drop-pestel.md
@@ -103,10 +103,7 @@ _FRAMEWORK_COLUMNS = (
 Replace the legend so it describes only what the table shows:
 
 ```python
-    legend = (
-        '<p class="muted small">SWOT évalue les forces et faiblesses internes, '
-        "et Porter la solidité de l'avantage concurrentiel.</p>"
-    )
+legend = '<p class="muted small">SWOT évalue les forces et faiblesses internes, et Porter la solidité de l\'avantage concurrentiel.</p>'
 ```
 
 In `portfolio_summary.py`, delete the macro bullet at line 138 (`<li>{render_markdown_inline(posture.get("macro_verdict"))}</li>`), leaving the competitive and SWOT bullets.
@@ -520,17 +517,18 @@ Expected: FAIL — `model_fields` still contains `pestel`, and the legacy compos
 Delete the whole `PestelAnalysis` class and the `pestel` field from `StrategicAnalysis`, then update both composite properties:
 
 ```python
-    @property
-    def composite_strategic_score(self) -> float | None:
-        """Average of the framework scores. None if both are missing."""
-        scores = [f.strategic_score for f in (self.swot, self.five_forces) if f is not None]
-        return sum(scores) / len(scores) if scores else None
+@property
+def composite_strategic_score(self) -> float | None:
+    """Average of the framework scores. None if both are missing."""
+    scores = [f.strategic_score for f in (self.swot, self.five_forces) if f is not None]
+    return sum(scores) / len(scores) if scores else None
 
-    @property
-    def composite_confidence(self) -> float | None:
-        """Average of the framework confidences. None if both are missing."""
-        confs = [f.confidence for f in (self.swot, self.five_forces) if f is not None]
-        return sum(confs) / len(confs) if confs else None
+
+@property
+def composite_confidence(self) -> float | None:
+    """Average of the framework confidences. None if both are missing."""
+    confs = [f.confidence for f in (self.swot, self.five_forces) if f is not None]
+    return sum(confs) / len(confs) if confs else None
 ```
 
 Update the remaining references, all comments or descriptions:

--- a/docs/superpowers/specs/2026-04-27-v5.1-trust-spine-design.md
+++ b/docs/superpowers/specs/2026-04-27-v5.1-trust-spine-design.md
@@ -63,20 +63,22 @@ Defined in `analysis/stages/_contract.py`:
 ```python
 class StageOutcome(StrEnum):
     OK = "ok"
-    DEGRADED = "degraded"   # only valid for QUALIFY stage
+    DEGRADED = "degraded"  # only valid for QUALIFY stage
     FAILED = "failed"
+
 
 class StageProvenance(BaseModel):
     stage: Literal["collect", "quantify", "qualify", "synthesize", "emit"]
     outcome: StageOutcome
-    reason: str | None = None        # human-readable cause
+    reason: str | None = None  # human-readable cause
     duration_ms: int
     retries_used: int = 0
-    fallback_used: str | None = None # e.g. "python_proxy_qualitative"
+    fallback_used: str | None = None  # e.g. "python_proxy_qualitative"
     model_config = ConfigDict(extra="forbid")
 
+
 class StageResult[T](BaseModel):
-    payload: T | None                # None iff outcome == FAILED
+    payload: T | None  # None iff outcome == FAILED
     provenance: StageProvenance
     model_config = ConfigDict(extra="forbid")
 ```
@@ -99,7 +101,7 @@ Defined in `analysis/stages/_ledger.py`:
 
 ```python
 class RunLedgerEntry(BaseModel):
-    run_id: str             # ULID, set once per pipeline kickoff
+    run_id: str  # ULID, set once per pipeline kickoff
     ticker: str
     started_at: datetime
     finished_at: datetime
@@ -108,11 +110,12 @@ class RunLedgerEntry(BaseModel):
     reason: str | None
     fallback_used: str | None
     retries_used: int
-    cost_usd: float = 0.0   # populated for AI stages
+    cost_usd: float = 0.0  # populated for AI stages
+
 
 class RunLedger:
     def record(self, entry: RunLedgerEntry) -> None: ...
-    def coverage(self) -> CoverageSummary: ...                  # (analyzed, degraded, failed, total)
+    def coverage(self) -> CoverageSummary: ...  # (analyzed, degraded, failed, total)
     def failures_for(self, ticker: str) -> list[StageProvenance]: ...
     def to_banner(self) -> TrustBanner: ...
 ```
@@ -127,8 +130,7 @@ The ledger is the *single source of truth* the report consumes. `_failed_holding
 
 ```python
 @stage(name="qualify", timeout_s=180, retries=2, allow_degrade=True)
-def qualify(ctx: AnalysisContext, quant: QuantitativeAnalysis) -> StageResult[QualitativeInsights]:
-    ...
+def qualify(ctx: AnalysisContext, quant: QuantitativeAnalysis) -> StageResult[QualitativeInsights]: ...
 ```
 
 The decorator does five things, and only these:
@@ -158,8 +160,8 @@ class TrustBanner(BaseModel):
     degraded: int
     failed: int
     total: int
-    message: str            # French, user-visible
-    block_decisions: bool   # True iff state in {red, blocked}
+    message: str  # French, user-visible
+    block_decisions: bool  # True iff state in {red, blocked}
 ```
 
 State rules — pure deterministic function of coverage:

--- a/docs/superpowers/specs/2026-08-15-report-rethink-design.md
+++ b/docs/superpowers/specs/2026-08-15-report-rethink-design.md
@@ -127,11 +127,11 @@ Every view model embeds evidence as a mandatory field:
 
 ```python
 class Evidence(BaseModel):
-    covered: int              # items this section actually used
-    total: int                # items it claims to describe
-    basis: list[str] = []     # tickers or sources behind it
-    known: bool = True        # False = measured but not trustworthy
-    missing: list[str] = []   # named gaps
+    covered: int  # items this section actually used
+    total: int  # items it claims to describe
+    basis: list[str] = []  # tickers or sources behind it
+    known: bool = True  # False = measured but not trustworthy
+    missing: list[str] = []  # named gaps
 ```
 
 Renderers enforce it; sections cannot opt out:
@@ -162,9 +162,9 @@ Renderers enforce it; sections cannot opt out:
 
 ```python
 class QualitativeBlock(BaseModel):
-    verdict: str              # 1 sentence, plain French, <=30 words
-    detail: str               # reasoning, plain French prose, <=200 words
-    sources: list[str] = []   # resolved URLs/titles, not [3] markers
+    verdict: str  # 1 sentence, plain French, <=30 words
+    detail: str  # reasoning, plain French prose, <=200 words
+    sources: list[str] = []  # resolved URLs/titles, not [3] markers
 ```
 
 Validators make the essay structurally impossible rather than cleaned up after the fact:

--- a/docs/testing/TEST_GAP_ANALYSIS.md
+++ b/docs/testing/TEST_GAP_ANALYSIS.md
@@ -98,14 +98,14 @@ Prevent this specific bug from recurring:
 
 ```python
 # 1. Unit tests for field tracking (NEW)
-tests/unit/scoring/test_asset_analyzer_field_tracking.py
+tests / unit / scoring / test_asset_analyzer_field_tracking.py
 
 # 2. Integration tests (NEW)
-tests/unit/scoring/test_scorer_metrics_integration.py
+tests / unit / scoring / test_scorer_metrics_integration.py
 
 # 3. Update existing tests (MODIFY)
-tests/unit/scoring/test_deep_analysis_scorer.py  # Add data quality assertions
-tests/unit/scoring/test_fundamental_scorer.py    # Test metrics passing
-tests/unit/scoring/test_technical_scorer.py      # Test metrics passing
-tests/unit/scoring/test_risk_scorer.py           # Test metrics passing
+tests / unit / scoring / test_deep_analysis_scorer.py  # Add data quality assertions
+tests / unit / scoring / test_fundamental_scorer.py  # Test metrics passing
+tests / unit / scoring / test_technical_scorer.py  # Test metrics passing
+tests / unit / scoring / test_risk_scorer.py  # Test metrics passing
 ```

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -213,7 +213,7 @@ grep -i "warning\|error" logs/finwiz.log | tail -n 20
 from finwiz.infrastructure.caching.manager import get_cache_manager
 
 cache = get_cache_manager()
-stats = cache.get_stats()          # returns a plain dict, not an object
+stats = cache.get_stats()  # returns a plain dict, not an object
 print(f"Cache hit rate: {stats['hit_rate']:.2%}")
 print(f"Hits: {stats['hits']}, misses: {stats['misses']}")
 ```

--- a/src/finwiz/analysis/CLAUDE.md
+++ b/src/finwiz/analysis/CLAUDE.md
@@ -68,11 +68,7 @@ The analysis pipeline follows functional programming principles with pure functi
 from finwiz.analysis import analyze_holding
 
 # Analyze a single holding
-result, enriched = analyze_holding(
-    ticker="AAPL",
-    asset_class="stock",
-    company_name="Apple Inc."
-)
+result, enriched = analyze_holding(ticker="AAPL", asset_class="stock", company_name="Apple Inc.")
 
 # result: DeepAnalysisResult for caching/state
 print(f"Grade: {result.grade}, Score: {result.composite_score:.2f}")
@@ -151,17 +147,17 @@ class DeepAnalysisResult(BaseModel):
     ticker: str
     asset_class: str
     crew_name: str
-    composite_score: float          # 0.0-1.0
-    grade: str                      # A+ to F
-    recommendation: str             # BUY, HOLD, SELL
+    composite_score: float  # 0.0-1.0
+    grade: str  # A+ to F
+    recommendation: str  # BUY, HOLD, SELL
     rationale: str
-    data_freshness_hours: float     # >= 0.0
-    confidence_level: float         # 0.0-1.0
+    data_freshness_hours: float  # >= 0.0
+    confidence_level: float  # 0.0-1.0
 
     # optional component scores
     fundamental_score: float | None  # 0.0-1.0
-    technical_score: float | None    # 0.0-1.0
-    risk_score: float | None         # 0.0-5.0  (note: 0-5, not 0-1)
+    technical_score: float | None  # 0.0-1.0
+    risk_score: float | None  # 0.0-5.0  (note: 0-5, not 0-1)
 ```
 
 ### EnrichedAnalysis (Pydantic)
@@ -171,8 +167,8 @@ Used for HTML report generation:
 ```python
 class EnrichedAnalysis(BaseModel):
     ticker: str
-    quantitative: QuantitativeAnalysis   # Python-calculated
-    qualitative: QualitativeInsights     # AI-generated
+    quantitative: QuantitativeAnalysis  # Python-calculated
+    qualitative: QualitativeInsights  # AI-generated
     final_grade: str
     final_score: float
     final_recommendation: str

--- a/src/finwiz/crews/CLAUDE.md
+++ b/src/finwiz/crews/CLAUDE.md
@@ -75,6 +75,7 @@ from crewai import Agent, Crew, Task, agent, crew, task
 from finwiz.tools.tool_factories import get_stock_crew_tools
 from finwiz.infrastructure.decorators.agent_validators import final_reporter
 
+
 @CrewBase
 class StockCrew:
     agents_config = "config/agents.yaml"
@@ -82,13 +83,7 @@ class StockCrew:
 
     @agent
     def analyst(self) -> Agent:
-        return Agent(
-            config=self.agents_config["analyst"],
-            tools=get_stock_crew_tools(),
-            reasoning=True,
-            max_reasoning_attempts=3,
-            verbose=True
-        )
+        return Agent(config=self.agents_config["analyst"], tools=get_stock_crew_tools(), reasoning=True, max_reasoning_attempts=3, verbose=True)
 
     @final_reporter  # Enforces NO tools
     @agent
@@ -96,24 +91,16 @@ class StockCrew:
         return Agent(
             config=self.agents_config["reporter"],
             tools=[],  # MUST be empty
-            verbose=True
+            verbose=True,
         )
 
     @task
     def analysis_task(self) -> Task:
-        return Task(
-            config=self.tasks_config["analysis"],
-            agent=self.analyst()
-        )
+        return Task(config=self.tasks_config["analysis"], agent=self.analyst())
 
     @crew
     def crew(self) -> Crew:
-        return Crew(
-            agents=self.agents,
-            tasks=self.tasks,
-            process=Process.sequential,
-            verbose=True
-        )
+        return Crew(agents=self.agents, tasks=self.tasks, process=Process.sequential, verbose=True)
 ```
 
 ## Critical Rules

--- a/src/finwiz/exceptions/CLAUDE.md
+++ b/src/finwiz/exceptions/CLAUDE.md
@@ -35,6 +35,7 @@ from finwiz.exceptions import (
 # Or from specific module
 from finwiz.exceptions.orchestrator import PortfolioRebalancingError
 
+
 def rebalance_portfolio(symbols: list[str]) -> dict:
     try:
         prices = fetch_prices(symbols)

--- a/src/finwiz/flows/CLAUDE.md
+++ b/src/finwiz/flows/CLAUDE.md
@@ -52,6 +52,7 @@ crewai flow kickoff    # Run full pipeline
 
 ```python
 from finwiz.flows.orchestrator import FinwizFlow, plot
+
 plot()  # Visualize flow structure
 ```
 

--- a/src/finwiz/integration/CLAUDE.md
+++ b/src/finwiz/integration/CLAUDE.md
@@ -43,9 +43,7 @@ whole-crew artifacts — there is no per-ticker accessor.
 from finwiz.integration import CrewDataIntegrationManager
 
 manager = CrewDataIntegrationManager(output_dir=Path("output"))
-data = manager.get_crew_data_with_freshness_check(
-    crew_name="stock_crew", max_age_hours=24, warn_on_stale=True
-)
+data = manager.get_crew_data_with_freshness_check(crew_name="stock_crew", max_age_hours=24, warn_on_stale=True)
 ```
 
 For a plain read without the freshness check, use `CrewDataAccessor`:

--- a/src/finwiz/orchestrators/CLAUDE.md
+++ b/src/finwiz/orchestrators/CLAUDE.md
@@ -95,10 +95,10 @@ and reads its inputs from that state — nothing is passed per-call.
 from finwiz.orchestrators import DeepAnalysisOrchestrator, DiscoveryOrchestrator
 
 deep_orch = DeepAnalysisOrchestrator(state)
-results = await deep_orch.analyze_and_update_portfolio()   # async
+results = await deep_orch.analyze_and_update_portfolio()  # async
 
 discovery_orch = DiscoveryOrchestrator(state)
-opportunities = discovery_orch.check_investment_discovery()   # no arguments
+opportunities = discovery_orch.check_investment_discovery()  # no arguments
 ```
 
 ## Related Modules

--- a/src/finwiz/quantitative/CLAUDE.md
+++ b/src/finwiz/quantitative/CLAUDE.md
@@ -90,9 +90,9 @@ result = engine.run_strategy_backtest(
     symbol="AAPL",
     start_date=start,
     end_date=end,
-    strategy_params={...},          # optional
-    benchmark_symbol="SPY",         # optional
-)                                    # -> BacktestResult | None
+    strategy_params={...},  # optional
+    benchmark_symbol="SPY",  # optional
+)  # -> BacktestResult | None
 
 # Several strategies over one symbol
 results = engine.run_multi_strategy_backtest(
@@ -107,7 +107,7 @@ result = optimizer.optimize_portfolio(
     inputs=portfolio_inputs,
     objective=ObjectiveFunction.MAX_SHARPE,
     method=OptimizationMethod.MEAN_VARIANCE,
-)                                    # -> OptimizationResult
+)  # -> OptimizationResult
 ```
 
 ## Related Modules

--- a/src/finwiz/schemas/CLAUDE.md
+++ b/src/finwiz/schemas/CLAUDE.md
@@ -154,6 +154,7 @@ Data provenance for a fetch is carried by `DataLineage`, a dataclass in
 from pydantic import BaseModel, Field
 from typing import Literal
 
+
 class CrewExportBase(BaseModel):
     """Base schema for all crew exports."""
 
@@ -184,7 +185,7 @@ export = StockCrewExport(
 
 # Save to JSON
 export_path = f"output/reports/{session_id}/stock/{ticker}_export.json"
-with open(export_path, 'w') as f:
+with open(export_path, "w") as f:
     f.write(export.model_dump_json(indent=2))
 ```
 
@@ -219,6 +220,7 @@ json_str = model.model_dump_json(indent=2)
 
 # Manual (fallback)
 import json
+
 json_str = json.dumps(data, default=str, indent=2)
 ```
 

--- a/src/finwiz/templates/CLAUDE.md
+++ b/src/finwiz/templates/CLAUDE.md
@@ -42,7 +42,7 @@ Templates are rendered through a shared Jinja2 environment — there is no
 ```python
 from finwiz.reporting.base_report_generator import create_report_jinja_env
 
-env = create_report_jinja_env(template_dir)   # autoescape=True, trim/lstrip_blocks
+env = create_report_jinja_env(template_dir)  # autoescape=True, trim/lstrip_blocks
 template = env.get_template("portfolio_review.html")
 
 html = template.render(

--- a/uv.lock
+++ b/uv.lock
@@ -365,6 +365,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/30/96cf7d324e75cd2c349e2911ae2334d987fb8525d551495a2ef6758c26f3/boto3-1.43.83.tar.gz", hash = "sha256:6413d6e99f716af5d333a732db140e4b3359cac005a1271b11777b6d9ca82194", size = 112686, upload-time = "2026-08-28T19:35:52.273Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/4b/843f30dc77324778efa90c4169d503963668760b8d8abdf26a61bd090141/boto3-1.43.83-py3-none-any.whl", hash = "sha256:73a3564f737d4516625964eee709a498fa98ccee6aca929febad2b0b5fbeae1e", size = 140025, upload-time = "2026-08-28T19:35:49.228Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/6f/cf16418004c832e6eb9abc6905fa323a3bf96a76ca7f2e97858801a4103e/botocore-1.43.83.tar.gz", hash = "sha256:d9389b3b74400c34219965a2fb858c1d48744718865ee0496fd03bd5b21b943f", size = 16010078, upload-time = "2026-08-28T19:35:46.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/50/332d6713fa09b05ff0882f5d194569fa70d1c8735aca9829b1286fef32ba/botocore-1.43.83-py3-none-any.whl", hash = "sha256:bf75a6cf587c22d968e43e79fe122c39f82deafbe9c3422bc5d3e80b6210fc98", size = 15704489, upload-time = "2026-08-28T19:35:40.603Z" },
+]
+
+[[package]]
 name = "bottleneck"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -412,16 +440,16 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.5.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/b7/1db48a9ce2984842c8c886432ec8a2719613322e868a966ba82a28862f25/build-1.6.0.tar.gz", hash = "sha256:bd2c8afc603e7a2e0ce70e2ea85f0a6d02043bafbd307f5bada0f98669eca5af", size = 113825, upload-time = "2026-08-27T21:01:16.458Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/e5/aa1e81b21aea0ce0ba435311837a37d4cb936e7461f9fecac08580073ba9/build-1.6.0-py3-none-any.whl", hash = "sha256:f7aaf1ebbb79178a02ba248bb524f2176b256017e17e8e4bd4289c7b38cc2bad", size = 31187, upload-time = "2026-08-27T21:01:14.957Z" },
 ]
 
 [[package]]
@@ -525,24 +553,48 @@ wheels = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.9"
+version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
-    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
-    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
-    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://files.pythonhosted.org/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
 ]
 
 [[package]]
@@ -607,14 +659,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.2"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -628,31 +677,31 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.15.4"
+version = "7.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/c3/4f2195f512fb172aa425a8803a874b2baa9ba7f80ff7b6080998761fc701/coverage-7.15.4.tar.gz", hash = "sha256:0548198fff07ccf4faf469520bce1c2eceb1ce3e62891921138dec10907f9d00", size = 936952, upload-time = "2026-08-06T13:50:24.442Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/f5/deb1a27aa20746c0278ac998c4179e272004699b2d33959ce020c5ac1615/coverage-7.16.0.tar.gz", hash = "sha256:077f0964087883176ff6ab9b074694cae29f8c708273b13ca62c183c6ed716cd", size = 945620, upload-time = "2026-08-28T21:54:37.74Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/84/651a9310859673aaa3b3203f1aa1641ca60fcf2494683e1c9474c7172780/coverage-7.15.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c705b28feb2775dc82a25f1d473a370bc37ff93f5177f4e29ce2425f560f6921", size = 222565, upload-time = "2026-08-06T13:48:00.796Z" },
-    { url = "https://files.pythonhosted.org/packages/82/f9/4dcf700137e8af550670f4d74d1b63828ce93e1e2b05e5f10710eb2ea987/coverage-7.15.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3ff205ab5e3ecc670f6a4dd19d9cbf12ede53dd41cfc1e15716ec961ea6d314e", size = 222936, upload-time = "2026-08-06T13:48:02.391Z" },
-    { url = "https://files.pythonhosted.org/packages/07/4a/612ff1e780b3fbfd637486f542f84adc5503873d8b5d279dec1ffeef9414/coverage-7.15.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5172326e861a38b48b48befca15e0f477a26b283337a33a739c8fed229934e36", size = 253926, upload-time = "2026-08-06T13:48:04.382Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/04/d1cff1c2ead4708a6a79c01d3736b6a25bd38a36678398f72a8dd33dfad9/coverage-7.15.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:12b59c90084e3234fb11184886bf4a40f4f16a8c8f867be2e087b81f8e8868d4", size = 256523, upload-time = "2026-08-06T13:48:05.996Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/80/d34e13fb4b293cbdb9665838cf5522077b8ad14ef947550631a4bced36a5/coverage-7.15.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349062d66f00b40fa2c1c222438bad25fabf755631b5d82937fe985c8008615c", size = 257759, upload-time = "2026-08-06T13:48:08.036Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e7/2c5fe7636fdb0732fe0f09f308a5b066864078b7fc61f6678e8478554f2e/coverage-7.15.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4256ced708e598e05209bc1a8ab4074e04a51dba4c62fb45926a229af675ace7", size = 259890, upload-time = "2026-08-06T13:48:09.834Z" },
-    { url = "https://files.pythonhosted.org/packages/92/28/9689f0858dfff59c2ea688938ab9fa2925631235df67126a42b6c5c70ae1/coverage-7.15.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d80f974b20782d9612c8b4c9beeca867074c7cf4079d1419843fa25a26428b25", size = 254121, upload-time = "2026-08-06T13:48:11.459Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/e2/785077c230c157243eb5aa9a26c3be260ecd02001bead54a3cada3df8e03/coverage-7.15.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e179f19bfe1d31f8eeeaa12990194d761c4f62f0759661000bca6cd8729f40b", size = 255891, upload-time = "2026-08-06T13:48:13.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/90/e20371b17b40f912f21305c2db2f30efa3de306f7320fc916804872c85a4/coverage-7.15.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8bc16bb47b7679670eceff71d78bfb7d6e5b143f6c2cd117487ec7c75e0d4b78", size = 253859, upload-time = "2026-08-06T13:48:14.736Z" },
-    { url = "https://files.pythonhosted.org/packages/05/49/25371987ee459a5f67c0427fb75c74f9358e65f2c71fe75bf41c1b6c5fcb/coverage-7.15.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd685005cd2c4200adfc14cf39a603b9320efab3f18a8f7f156d20c9cc3345f", size = 258011, upload-time = "2026-08-06T13:48:16.464Z" },
-    { url = "https://files.pythonhosted.org/packages/30/6e/32e67467f6154bf4f1c4f63b05acc5097cba4237d45bbeeea446b52e8ac1/coverage-7.15.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:337399ad2c93b3acd2a937627dae8b3e86b66707cd3d3e856347999aadf1ef8d", size = 253676, upload-time = "2026-08-06T13:48:18.493Z" },
-    { url = "https://files.pythonhosted.org/packages/03/c1/8b24192e89286399765155251f99ee9f070a9d637109018ac23d99b99f6f/coverage-7.15.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:96e257121228ec5cd2bb919276e94ac11074471bc37d68dbae0e8308cce15fff", size = 255453, upload-time = "2026-08-06T13:48:20.057Z" },
-    { url = "https://files.pythonhosted.org/packages/16/6f/8b41ebdf67c87854e17c035336a90f1cfbad0c14c2a584301be6ff148718/coverage-7.15.4-cp313-cp313-win32.whl", hash = "sha256:c65a9e0dfc6143491879da4e13b5e30f8be192055de508d737fb14601edbd22c", size = 224605, upload-time = "2026-08-06T13:48:21.655Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/e2/2946c7f0b42b152ecb21ff1bdad72e3d301e790c0c487e4a86e8c9f69347/coverage-7.15.4-cp313-cp313-win_amd64.whl", hash = "sha256:2ff8f5e9b8f7a94f0c11c45631eee103dbcb7d63274edd12c56efe1be690b3b4", size = 225148, upload-time = "2026-08-06T13:48:23.376Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/83/3f4a69957f48ae7a0aba76c34743f88963d607b19e03f3f8e66f91cae0f9/coverage-7.15.4-cp313-cp313-win_arm64.whl", hash = "sha256:6e0a8a5083b096487d6cfced94cdd514d8f5db6f113610fb36c0620edb1028cf", size = 224536, upload-time = "2026-08-06T13:48:25.117Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/d9/e70c286c979378f061d8266e279b686ab0b0b688e1fe0af864684f23a77d/coverage-7.15.4-py3-none-any.whl", hash = "sha256:964730a1e9de9c0cf11be6a1a3c79ce419c34882842abd256086ba4698705e84", size = 214332, upload-time = "2026-08-06T13:50:22.192Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c5/e62c87f4799d1e3647d5b2ae16ea1d12205d72fde1ea8529e13fe050f678/coverage-7.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1545c52ce756b8a97007f439a220297f1cd72a2cbbcdffccdf1c1f70e74f9a42", size = 223215, upload-time = "2026-08-28T21:51:55.628Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e9/5e62fda9397175fb206f75368b6e85da06d831c181b6d0f67ca073cd2f89/coverage-7.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0598aadae641f30a0796b75b45c0b9c5de8619bd5cfb251bb0cc254e86e6dd13", size = 223585, upload-time = "2026-08-28T21:51:57.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/40/bede08621b1ba67e88c4d3336c22b52cb7911ff1fa4ef055344b6670e58a/coverage-7.16.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4080ad6bad9f14690e6b2104f5e8d137ccc65a4b5427a36662090637d4bd16d5", size = 254575, upload-time = "2026-08-28T21:51:59.233Z" },
+    { url = "https://files.pythonhosted.org/packages/12/d8/ab0bdaa45dfd6b8cbf1a3ec548fdf827684b1997f9724375c5b3e89144fb/coverage-7.16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e9883a2f8206ce3af59117dc278e5d043fea06912bca3f199816129e5e2de354", size = 257172, upload-time = "2026-08-28T21:52:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/bb/135de81784bbd7dfedcab2b92b03d71d75b09b0815b42d6dabb052def5a6/coverage-7.16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:984e5430fc6f858385009e92549955157d79335b1f3e13e1031e0f89d1284261", size = 258410, upload-time = "2026-08-28T21:52:02.76Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/72/ce44ecc062fb2e43d9447bb76154d091c2139232f20c125297c4b58f4c6a/coverage-7.16.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b1374099dd1ad0d31fbb6c95d00a56a3c5e85fb3343dca14fc12f78323a2b42a", size = 260539, upload-time = "2026-08-28T21:52:04.821Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/9389c36a41e59406ca2bba493807c2294d2e5186a7e9ebcc2e63a0f2a711/coverage-7.16.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34d8686bce035c8465b318a8c2890e69ba14a00801a27f4eb6bdc97c23944d87", size = 254756, upload-time = "2026-08-28T21:52:06.68Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0f/7762447b15e01fb84263608540123c4d9941f06303265ee74d801ccbec0e/coverage-7.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:857fceba6ff4b507ee0ad98798a33d544a8473df0c542bf04251ee4ed5ee6292", size = 256540, upload-time = "2026-08-28T21:52:08.529Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/fa/c60dc75a8346c1dbebebc7279b19971c88f70dd575f0bc10bc0cb16f92d5/coverage-7.16.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bbf08d951abaa1ce89e28c998361d56b952413846b459cd017f116ad4c9adbfa", size = 254508, upload-time = "2026-08-28T21:52:10.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/4e0834f3a1fccaa8bf625a2a1d73bde0fa32577dc3249853c0dd0e7f2b20/coverage-7.16.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1a03e78f53e4d2ab13adac19958a89322d1829913e5623d642627bf60b35da21", size = 258659, upload-time = "2026-08-28T21:52:12.124Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ec/fe712d3a11fd6e874565a5fa5497c48b8ece561d9611da040b44cdcf8386/coverage-7.16.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:dcd3dafcdd78305d27c59a1006b53a4990acb89e68d8fbe0992f4f83503c827f", size = 254326, upload-time = "2026-08-28T21:52:14.181Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/78/093e12072e01034c65ff380f76c74b79dd83e44fa92b689a2154389be734/coverage-7.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c1bcfe470a796fbea6234accd81d258a31574dc0b7bf569e16be757572c4de17", size = 256102, upload-time = "2026-08-28T21:52:16.003Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c0/265176117ca5d06e3f65575842884cdda96cf213350a31e9d41c80d65854/coverage-7.16.0-cp313-cp313-win32.whl", hash = "sha256:1420370276f1694b663207b8245c3628aafb9624fe3cebf313a13d860e55ee67", size = 225250, upload-time = "2026-08-28T21:52:17.82Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/8a87f2c04fde322430b45d16d8f543693e9894c5b2d2ca238a287c00beca/coverage-7.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:496277c8d7beed695e02c7be53516a0152e4caef8738a0feab6a638546cce449", size = 225790, upload-time = "2026-08-28T21:52:19.641Z" },
+    { url = "https://files.pythonhosted.org/packages/23/40/c21feacd9edfe7063195bf9cc84d650e9938fc6a23063e4f027199b160e1/coverage-7.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:181c2906b9b3759955c1c33c51fbb91c754fbd0b82ea49e2c81061f5a052082c", size = 225180, upload-time = "2026-08-28T21:52:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5a/234e8fadf85c3cc48cb31c247b9e8e0c7f06ece80f5b29f9b8c241f9da4c/coverage-7.16.0-py3-none-any.whl", hash = "sha256:245f7de6d023a5bba375dbec9f2e0869bfa26ac0cc639bbb7b4c814884000b73", size = 214977, upload-time = "2026-08-28T21:54:35.189Z" },
 ]
 
 [[package]]
 name = "crewai"
-version = "1.15.16"
+version = "1.15.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -687,14 +736,14 @@ dependencies = [
     { name = "tomli" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/80/616fbc703f3e682dd7009c247d70b2e185a139f86e48c0b5a66be8f63adf/crewai-1.15.16.tar.gz", hash = "sha256:38f75f499a5e6a5dc78369a3f5384452b791bc4852a1ff38c342aca4e04e8264", size = 7885470, upload-time = "2026-08-14T00:08:52.217Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/07/3a6d94fbb3bd465c653208a28d3e59d539d00cb5bef55626188a46ed7457/crewai-1.15.20.tar.gz", hash = "sha256:c4a4d02c27eca7502479ce8cf3fcdd1658fcc9948aa86962ad19e581530032b4", size = 7965515, upload-time = "2026-09-04T12:42:59.848Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/55/29fc1a03ae190c0bc2f921dcf9226c0afa22483558a18bb8c6f0cbd1679d/crewai-1.15.16-py3-none-any.whl", hash = "sha256:a93ae2c78b42dacdb932c2e4bbba2efb108ac610c23cf5453d8d59000858665b", size = 1114637, upload-time = "2026-08-14T00:08:49.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cd/fa00e87bf061e8bb02546cd00f58c4d85694b0fe027afae5eb1f578c610c/crewai-1.15.20-py3-none-any.whl", hash = "sha256:8bf272a687ad3320b681f23a183a6ac445f2fa7fc78b52943b835acc2eb158d6", size = 1141815, upload-time = "2026-09-04T12:42:58.166Z" },
 ]
 
 [[package]]
 name = "crewai-cli"
-version = "1.15.16"
+version = "1.15.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appdirs" },
@@ -714,14 +763,14 @@ dependencies = [
     { name = "tomli-w" },
     { name = "uv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/e4/eb56bf3c36485b6f6c51489d747d4f92750d3cadc19ecdb03c23dd026a74/crewai_cli-1.15.16.tar.gz", hash = "sha256:6d8f0c03bb05e88114b1a60e93aced09db2cc0a83f6811ec83f2e902fda14426", size = 227940, upload-time = "2026-08-14T00:08:56.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/30/8521f26795a71179b684c5b2d8135e78f8b4fcabe79acae93e0b3d9a42e2/crewai_cli-1.15.20.tar.gz", hash = "sha256:21f1735ee7e6818f658f46d59844d6f04700af5398c632a3e0fd42c8e6180c93", size = 233643, upload-time = "2026-09-04T12:43:02.502Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/b2/bbc5da7b20e15a5e67b92aed90a729a8e3175918adc626a763735d893d6a/crewai_cli-1.15.16-py3-none-any.whl", hash = "sha256:b98848f2cffe03fcefe69eeeb64e8dca8ec0fcc7f00437c419ad1972dd4a8c2c", size = 195493, upload-time = "2026-08-14T00:08:54.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/a04ae71e6226c10ae921911a8b8216cef6ae5d1db98c5b36f941058728c3/crewai_cli-1.15.20-py3-none-any.whl", hash = "sha256:2d692143cb4a46ef97f927fc1a2f6035790d2ee2fe4d1bb50fad9f884576ce6a", size = 198183, upload-time = "2026-09-04T12:43:01.266Z" },
 ]
 
 [[package]]
 name = "crewai-core"
-version = "1.15.16"
+version = "1.15.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appdirs" },
@@ -737,9 +786,9 @@ dependencies = [
     { name = "rich" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/86/4d8273b80f41d7c7637ae0ada4d8ba78b540acf94735bdd0bf624ccb776d/crewai_core-1.15.16.tar.gz", hash = "sha256:c8d5548e223f32262243e91ee83b6976002616a26fc10951b3d5f1c05f10697f", size = 35445, upload-time = "2026-08-14T00:08:58.569Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/7f/75b9f75f90f6639edb68e1591bc6fd54ef1381cbdd4f10f41f62ef12b985/crewai_core-1.15.20.tar.gz", hash = "sha256:5a3ad81107172f24b6ee14a24aff87f93e3b56da7220a0e5584992d9b9476939", size = 39207, upload-time = "2026-09-04T12:43:04.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/88/e954a1928421fd923b92c33cf22951d5e0dd2dc0c3fb129dd48dfeaa6b57/crewai_core-1.15.16-py3-none-any.whl", hash = "sha256:7a74e6ddbecd9df042dd459fd5e19a308b576958469bfa134ceb12dc6814106b", size = 40428, upload-time = "2026-08-14T00:08:57.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6a/f5e1f1114a6900275e240feffae6580ddccc6f5e4716372b3ec97511e3ab/crewai_core-1.15.20-py3-none-any.whl", hash = "sha256:09a96fbd08e2f849e4a521ecfdab88b62fcb3b94292f4e7039c0bc3b9de67d40", size = 42481, upload-time = "2026-09-04T12:43:03.421Z" },
 ]
 
 [[package]]
@@ -769,63 +818,63 @@ dependencies = [
 
 [[package]]
 name = "cryptography"
-version = "50.0.0"
+version = "50.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
-    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
-    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
-    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
-    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
-    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
-    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
-    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
-    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
-    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
-    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
-    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
-    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
-    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
 ]
 
 [[package]]
 name = "curl-cffi"
-version = "0.16.0"
+version = "0.16.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "cffi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/23/d32e113b16dbfb458bea408871ed98dd12f306a366a04215e84537e0af7e/curl_cffi-0.16.0.tar.gz", hash = "sha256:b00b423da8028eb6221e3b63bcd63d681150c07cee8b16000d1f7ea292731895", size = 238344, upload-time = "2026-08-01T13:45:12.372Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/f6/347067dfacb19e44a4166d7bdb183e3a2629680beceb5e52f7cb2cc1a3b4/curl_cffi-0.16.2.tar.gz", hash = "sha256:2986a86cdcf514ab73632c2de62a01db3cc97f7ecf17798a1be16180f4474198", size = 238986, upload-time = "2026-08-25T11:51:11.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/fe/0c330de78421af13e6384ab948e3adbcd4c638b06b53b7fff108bf1db121/curl_cffi-0.16.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6128021320f74999ec1216c1817b2c3adcb0f334d204add1ccf18e248bf7efcb", size = 3023503, upload-time = "2026-08-01T13:44:33.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/49/3b502d0d09e427b1bdec4f7339bb115c971c9b3fdaf355d02ca06e97ad61/curl_cffi-0.16.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:edd5f6e8f122157f4d2351b0b5e48e6a1c0677a2064da71451bb30ef57af19ba", size = 2780341, upload-time = "2026-08-01T13:44:35.131Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b5/b341f96f9fa12b28d1150913a1f9007a09a36757c81b4100373c5bdbf78b/curl_cffi-0.16.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:93615d44f23e56c1256700c2e78de4b879310f39a5621828ea7e2a5ecc04bdda", size = 12824596, upload-time = "2026-08-01T13:44:36.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/3b/d600b20bff0c55b80b156dc9be0de7c3b3ee2d29977d0a839ea703fab978/curl_cffi-0.16.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3c31e71bf68a9c02a279a184ec9c0ea7c80ce1ef4f1d35073fae3124eb3a7868", size = 12647842, upload-time = "2026-08-01T13:44:38.814Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/45/9208864ec429558efac168088e50f8a91b947f742ee128cff55b88c7b635/curl_cffi-0.16.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:182416f07d71a342240554fa62c22e591999b78c225b21d3fe27d9f807420dd6", size = 13472637, upload-time = "2026-08-01T13:44:40.893Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/c8/1639a1d9c8b64d0323330b219b7207a54b14fc54982c30cb08c8cc95aa16/curl_cffi-0.16.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d95c0deccc2184eeee7c2aa18d07de261184b418210995aabd0d29f98717a05c", size = 12828918, upload-time = "2026-08-01T13:44:43.049Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/02/bcdf03ea583a445280568c9b163c10668037ee09ece62e78c15846a62df0/curl_cffi-0.16.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ce1f823bc5ce675291a7cf14781496775dfae9298638c25059f2565f6a58a704", size = 12604731, upload-time = "2026-08-01T13:44:45.239Z" },
-    { url = "https://files.pythonhosted.org/packages/17/8b/4ddae52044c537ace13ad7e46dded8e9340a64e0704e320455c5151108a8/curl_cffi-0.16.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e52586a9dc4ed5e75faa39be0f30353b10cdc7410bad276beb013085e974bb44", size = 12576433, upload-time = "2026-08-01T13:44:47.626Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f5/38ee2f039db7832f07ce91f6a3d22d87ebfcfaa541130371ac1faa5caea9/curl_cffi-0.16.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ce87f301b31147711c3aebc86fb7e16d8dc48f7e5df272c1bea760c687e28eef", size = 13240699, upload-time = "2026-08-01T13:44:49.727Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/03/b9df2973f1119f9d11d8fb3bf2682e5ffe5c52ef3ab89f720473c60fe97e/curl_cffi-0.16.0-cp310-abi3-win_amd64.whl", hash = "sha256:e22a8212d830108e977ff394237f637238e265f5f65037d6c1ee71ea8cc03bcb", size = 1976497, upload-time = "2026-08-01T13:44:51.839Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8b/092beeb5fbe3b7370666708eb5618a9e593ffc80ecb2c97c3395158d270b/curl_cffi-0.16.0-cp310-abi3-win_arm64.whl", hash = "sha256:095fc36e4988736f31521d6fe0aa1f243dba22656b4818fc2fb3b7a547e7a9ba", size = 1711122, upload-time = "2026-08-01T13:44:53.242Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ea/81cf3858b256494b31a554cf76bbd345def3ea7e7a1a592cc515633b4e28/curl_cffi-0.16.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:06b1c7e07af8ff7c4c5ce4086ea89cc582ebff9adff4a37cfffa5f5de5d5b943", size = 8603463, upload-time = "2026-08-01T13:44:55.003Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ac/3772115da1b6b9b6064e8c128dfeb6c9e708dd4603a17eb52f658558c5e1/curl_cffi-0.16.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:afe05fc1022039c2853177ef13f67b7a9915bff62e35eb4fa1a295166bc55a34", size = 3024444, upload-time = "2026-08-25T11:50:32.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/21/57a757acb1b43ef944735835b50cfdf00150113164d755a99f8d21d875f3/curl_cffi-0.16.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e6f238ddfef41a5d074bcc2f6b8fc21e653a1e7d4d9a2163839030d9de24b2ca", size = 2781420, upload-time = "2026-08-25T11:50:33.851Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8c/755116d4f57fbad64947f47141ccc342a30bf5998ca6a33a2bcc33f34ab9/curl_cffi-0.16.2-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5382ca2a67a459dd6f64203555fd248b71abe4ca6cd40669902916dc5f558a33", size = 12827642, upload-time = "2026-08-25T11:50:35.388Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/31/aedc88071ee74b9b7848e48f11ddff1c242ab52f914f47309e0d15c4982f/curl_cffi-0.16.2-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1b0deed58ca724ffdb80e1f4029208325b2a4999f0a438f55037c591232e6c18", size = 12651309, upload-time = "2026-08-25T11:50:37.272Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b0/b3dd929480f419f8aa921860afb44e15d2a22fd0be5c545296b9db865aa3/curl_cffi-0.16.2-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b2a59707f5345491a08a3d45f6895b1c9dc192d403a1ebc42c1d1ef43a58453e", size = 13474592, upload-time = "2026-08-25T11:50:39.344Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/14/fbed6244544be92659de5cad4cca8d0ef79a05c17518d1b3fd2ca84d80cc/curl_cffi-0.16.2-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3645b13dc1d7dd727e90e847a767b6a2fb5a16a0cbc86a1fb8e77714775f498", size = 12833348, upload-time = "2026-08-25T11:50:41.395Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/8d/ee9b29ad9e2788cce9be333caac445be3950780e2eb1bdc47b53bb1f06c6/curl_cffi-0.16.2-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b07b19225a979ff85f30868712d8a274e69f013489c5b40102ec0167cd0a756a", size = 12604773, upload-time = "2026-08-25T11:50:43.476Z" },
+    { url = "https://files.pythonhosted.org/packages/60/b5/373754bf9bbdac84ec0d668d9f75487ed9ca236802c3c1edb9bb34cb045f/curl_cffi-0.16.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8b6877cf7a1470e357441d5fbd4a338d2372d49c352f0b8a57e565910f932f4d", size = 12580793, upload-time = "2026-08-25T11:50:45.681Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/61/7f659fe76575494268af7ac622250f3841b2a43eac8207d1758e61e96d05/curl_cffi-0.16.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:23f490b0b11d87beb94d5d26c4661c26f0439396f839af322a1847c268971913", size = 13240951, upload-time = "2026-08-25T11:50:48.388Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ac/21e1241211aa53102417c6952bb2929b1d7fee7806c9f1745b2d9f93ccdf/curl_cffi-0.16.2-cp310-abi3-win_amd64.whl", hash = "sha256:3614728ce7f15507b1e72761639c0524a434c3c8b141eb1aae7e8e037dcb292b", size = 1977254, upload-time = "2026-08-25T11:50:50.452Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d8/178f229cd6169df842e52aa54b9b523b9642f7e09ca4f7a646a9b096a3ec/curl_cffi-0.16.2-cp310-abi3-win_arm64.whl", hash = "sha256:cbf7d2d14057bc62ae1da9e03f18f08ca18dbb43c7fca1eaa827f5d703b32f5c", size = 1711623, upload-time = "2026-08-25T11:50:52.034Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0b/97ef41ea98548f48dff99feddea318cfc9266f15c891664bcc88fd5d6b7c/curl_cffi-0.16.2-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:58598186eccd24d2b2e126f945d8a5bdca0066a2789052023d3d8370ebadca30", size = 8605929, upload-time = "2026-08-25T11:50:53.748Z" },
 ]
 
 [[package]]
@@ -869,7 +918,7 @@ wheels = [
 
 [[package]]
 name = "cyclonedx-python-lib"
-version = "11.11.0"
+version = "11.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "license-expression" },
@@ -877,9 +926,9 @@ dependencies = [
     { name = "py-serializable" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/40/6509e6cfd7f2f3255501690f46375fdd224949e21fd1e96f4f4c8a9041b1/cyclonedx_python_lib-11.12.0.tar.gz", hash = "sha256:16767c4039de90c04e9f03348f8f0ed4b8ff842eaa7eefcad3a95685f970dacf", size = 1445378, upload-time = "2026-08-13T07:52:18.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/f3/56ccb2884aaa3db5622368e5191a3384b15f35392aa93df8b2f508c660d2/cyclonedx_python_lib-11.11.0-py3-none-any.whl", hash = "sha256:3049fc83e06a059b5c5907a527625a8ed5073caab10607ed4c9e5503b590fd44", size = 528689, upload-time = "2026-06-17T11:57:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f0/b2cb999244f2f4194df63ecff6939228178fa63a33be809c412684ca8db7/cyclonedx_python_lib-11.12.0-py3-none-any.whl", hash = "sha256:0e807521a921a5c3cb8ce1153f8a61d29eedfe76a46aac2796b7c6b573391a54", size = 529453, upload-time = "2026-08-13T07:52:16.836Z" },
 ]
 
 [package.optional-dependencies]
@@ -957,11 +1006,11 @@ wheels = [
 
 [[package]]
 name = "durationpy"
-version = "0.10"
+version = "0.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/5d/5f8571bd5dedc80863191621ac4be001f3f3dd8315d2ec078705dab7dec1/durationpy-0.11.tar.gz", hash = "sha256:181898e1ae282e288f0a2291829656bf1b6b3aadf30a97993b85db4943642905", size = 3582, upload-time = "2026-08-26T13:56:00.991Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/c4/ebdf7837bc4ef6fd98cfb013c28855bb358467bf86c1af011bbc21e21df0/durationpy-0.11-py3-none-any.whl", hash = "sha256:a739fe2b8972c250ff72f8e2c488d18cf25f7b852f49ee76048775d5171df30c", size = 4133, upload-time = "2026-08-26T13:55:59.456Z" },
 ]
 
 [[package]]
@@ -1009,14 +1058,14 @@ wheels = [
 
 [[package]]
 name = "faker"
-version = "40.36.0"
+version = "40.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/d2/026af1e002bbc6df534d1f8262b18ec79a974f928e9290bfbfdfe7c7b2af/faker-40.36.0.tar.gz", hash = "sha256:754048c76c03afa7de83eee8f4bcee3cf668cbb7d995f54a4e9678db7f110308", size = 2025903, upload-time = "2026-07-24T21:11:33.088Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/fb/35acc76128d5ee8983d940da871cc8eba876e7b0e9e6bd402ecd7104dcdc/faker-40.37.0.tar.gz", hash = "sha256:a92dff7f310e61fb544c61720e15edb2e7448bc33d15a321a99e9ab7b94abf54", size = 2025920, upload-time = "2026-08-21T16:33:16.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/9a/b947ed175ce9a0dcb070ccf3607f0ce8720cfb5ed1a36166a150b2acd5af/faker-40.36.0-py3-none-any.whl", hash = "sha256:82b9497d9cfe017048075bcf969298a74b1b6e39f5e4dad1211085d1133f7b62", size = 2062829, upload-time = "2026-07-24T21:11:31.37Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/22/bf589b6b2c7527047f55450358fbe5961aeaadf168d6b51a1a1c67da497f/faker-40.37.0-py3-none-any.whl", hash = "sha256:ddbafa55c94d5b69c08ced3a7f202614204a02e07ba6548c729b8d18acc0b490", size = 2062853, upload-time = "2026-08-21T16:33:14.516Z" },
 ]
 
 [[package]]
@@ -1074,11 +1123,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.32.2"
+version = "3.32.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/30/03b03951873a1a0ffc7e8ca0e10c15597b59e8d0e39260704cd2ea087bc4/filelock-3.32.4.tar.gz", hash = "sha256:2bde2e4cf732e0153406d8a7bc80620ecf5e621fe0d25e41143c4e3b4733ff30", size = 222126, upload-time = "2026-08-23T17:37:55.363Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a4/9b63d595d748e3aff8812b65eacc1a2c4bd90b7c2012e08e72373b4835eb/filelock-3.32.4-py3-none-any.whl", hash = "sha256:22e58ca3b1ae3b98993b762d7338367ae64fe50252bf78d59da3bfebcdf1cedd", size = 99864, upload-time = "2026-08-23T17:37:53.913Z" },
 ]
 
 [[package]]
@@ -1171,18 +1220,18 @@ requires-dist = [
     { name = "crewai-custom-tools", git = "https://github.com/fjacquet/crewai-custom-tools.git?rev=v0.6.0" },
     { name = "empyrical-reloaded", specifier = ">=0.5.12" },
     { name = "fear-and-greed", specifier = ">=0.4" },
-    { name = "feedparser", specifier = ">=6.0.12" },
+    { name = "feedparser", specifier = ">=6.0.14" },
     { name = "finnhub-python", specifier = ">=2.4.20" },
     { name = "fredapi", specifier = ">=0.5.2" },
     { name = "gnews", specifier = ">=0.8.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
-    { name = "langchain-core", specifier = ">=1.5.4" },
-    { name = "litellm", specifier = ">=1.96.2" },
+    { name = "langchain-core", specifier = ">=1.6.0" },
+    { name = "litellm", specifier = ">=1.97.0" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
-    { name = "numpy", specifier = ">=2.5.1" },
+    { name = "numpy", specifier = ">=2.5.2" },
     { name = "pandas", specifier = ">=3.0.5" },
-    { name = "plotly", specifier = ">=6.8.0" },
+    { name = "plotly", specifier = ">=7.0.0" },
     { name = "psutil", specifier = ">=7.2.2" },
     { name = "pyportfolioopt", specifier = ">=1.6.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
@@ -1192,7 +1241,7 @@ requires-dist = [
     { name = "ta-lib", specifier = ">=0.7.1" },
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "vadersentiment", specifier = ">=3.3.2" },
-    { name = "yfinance", specifier = ">=0.2.62" },
+    { name = "yfinance", specifier = ">=1.6.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1204,12 +1253,12 @@ dev = [
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "pandas-stubs", specifier = ">=3.0.5.260730" },
     { name = "pip-audit", specifier = ">=2.9.0" },
-    { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "pre-commit", specifier = ">=4.6.2" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
-    { name = "pytest-socket", specifier = ">=0.8.0" },
+    { name = "pytest-socket", specifier = ">=0.8.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.16.2,<1.0.0" },
@@ -1221,10 +1270,10 @@ dev = [
 docs = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-awesome-pages-plugin", specifier = ">=2.10.1" },
-    { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.5.3" },
-    { name = "mkdocs-material", specifier = ">=9.7.6" },
+    { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.5.4" },
+    { name = "mkdocs-material", specifier = ">=9.7.7" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3" },
-    { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "pre-commit", specifier = ">=4.6.2" },
     { name = "pymdown-extensions", specifier = ">=11.0.1" },
 ]
 
@@ -1333,14 +1382,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.59"
+version = "3.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/61/3285044215fb596bf093e39ccb96ece0a1076a8ca57a61e069a6a33cdb1b/gitpython-3.1.61.tar.gz", hash = "sha256:f51c24d8c0f733a195447385f5774a5dfe8767f5acfd7994a33755644c6ecc95", size = 231680, upload-time = "2026-08-28T11:01:13.761Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/49cc172da4d0578644ba37cec5cb365b1fefc603b26edea9bcac1c7f830a/gitpython-3.1.61-py3-none-any.whl", hash = "sha256:8ab28c9da863cdd9e7d7694ec46cf3e6c9a12d8a30a1acd3447aec11975d530c", size = 222118, upload-time = "2026-08-28T11:01:12.262Z" },
 ]
 
 [[package]]
@@ -1379,35 +1428,35 @@ wheels = [
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.75.1"
+version = "1.75.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/73/74bcab964c9a7a61f2bb71e8179b0f13e6fa98f7ce00fd168aab291e4a2e/googleapis_common_protos-1.75.1.tar.gz", hash = "sha256:d3042c6c5a2d4e67113104d6b6818b59b6bd92a197f2a91508e801fe815cf071", size = 150967, upload-time = "2026-08-06T06:24:51.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/90/fb8f1c84537fbf210c1f53a53ae473a805f6599c5a40b93c1bbadd211f7a/googleapis_common_protos-1.75.2.tar.gz", hash = "sha256:8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2", size = 154083, upload-time = "2026-08-25T19:19:13.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/51/186c02b8549b69ccda44429cf6ff5081e4b61a602ddfe6a8020d1be31d1b/googleapis_common_protos-1.75.1-py3-none-any.whl", hash = "sha256:28a1934bcd33b9c9da66ac301a0a4227e3367f095a17d0375cb98f0a09d93b79", size = 300626, upload-time = "2026-08-06T06:23:46.696Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl", hash = "sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e", size = 307002, upload-time = "2026-08-25T19:18:08.927Z" },
 ]
 
 [[package]]
 name = "grpcio"
-version = "1.83.0"
+version = "1.83.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/b1/46539f5050d7c316a13396d185451f95084a74ddc68b12d818595bef0377/grpcio-1.83.1.tar.gz", hash = "sha256:9cee6fcbf2eb57c4b49451787bfa87be8efc1ca02a0b327dd4b54d44502e362b", size = 13445033, upload-time = "2026-08-28T07:09:11.464Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/eb/135daaa713f32d33b8f99b4153b3f8dc3b2a124996ac15581bf9ebdad3c3/grpcio-1.83.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:6662f3b1e07cc7493d437351860dc867bddc6a93c83ecf33bbfdaf0c217ab2d0", size = 6304480, upload-time = "2026-07-23T15:19:53.962Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a1/121806ce69f23138dabe06aa595b0e5f1ae051a37e4c1954eed7d692c800/grpcio-1.83.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:74fe6f9e8a35c7dbf32255ee154d15e3e5338a81ed39173d079d594d2e544cd1", size = 12154419, upload-time = "2026-07-23T15:19:56.3Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/e8/d0389e09cd6b4c4d3089b92967ae4e3ffd64795bd349bf2f85cd6656d3da/grpcio-1.83.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10b3fa0475eb572c9a81a6fe37fa16a9c500c0c91cfc148cac15692b7e3c2867", size = 6873200, upload-time = "2026-07-23T15:19:58.701Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/51/f464c1d211fa50d5adbabe1b2e519948d99c13757052bfc9ea7afa28e284/grpcio-1.83.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5f20a988480b0f28207f057f7f7ae1313393c3cef0adcfeae8248f9947eaf881", size = 7618811, upload-time = "2026-07-23T15:20:00.733Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/c0/539fe0832f2dd6500a28f5263071623fb34e8d4867aec632ccf81bd21156/grpcio-1.83.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bd82671b39065ba18cd536e9cd45b27ff649053f81ddd2c6a966d595067080f", size = 7042310, upload-time = "2026-07-23T15:20:02.675Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ca/ccf617d37ffa72567fa8e005ec7090c99da922799be2fb9847c8b21ca18c/grpcio-1.83.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc60215b5cb9fc8ca72942c498b551ac2305bd08f6ef8d4e3f0d21b64fbecd61", size = 7575412, upload-time = "2026-07-23T15:20:04.712Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b9/fd8d5245f823a8e0fd35d90e20ea3aa4acd47f8d5318fa8df307df52dec6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f1c3e5689d4b90987b1d72022bcfe866a9a3dc66197484cf856d96b6150e7f45", size = 8604248, upload-time = "2026-07-23T15:20:06.77Z" },
-    { url = "https://files.pythonhosted.org/packages/14/1e/f37632fc11db72dfa4bba86c3a43e54358e53030df111ecae5e91a733ad6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a21cb4eeeba124443f399be2e8b624943cde864dcbe588cb42e5c483a52a906c", size = 7977458, upload-time = "2026-07-23T15:20:09.109Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b6/d70b69ae5c0cfc341b9ba474980e4ed99cbf05c0e4a14e9eee8cb73db0a5/grpcio-1.83.0-cp313-cp313-win32.whl", hash = "sha256:8fe04f1050a59f875601eb55d42b4f66946fe89817f967e34db1462ccd07dadf", size = 4393993, upload-time = "2026-07-23T15:20:11.017Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/13/45d4cccb555cf4c476226979bf3d2fd0b0254216f7564c3a053e35117efc/grpcio-1.83.0-cp313-cp313-win_amd64.whl", hash = "sha256:6e01ecd9d8ef280abe1365138a4dc318f9a5287f4cb1b41d07816f796653f735", size = 5159650, upload-time = "2026-07-23T15:20:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fd/d1fc58933bf88c9209f89dc570c810f1aa57cb04b3459cf2b26f61e32112/grpcio-1.83.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:8d228e253b77865efcbdd7b5894ca882c9e0ea98c02b7d20582e61ded8dfd4b5", size = 6305628, upload-time = "2026-08-28T07:08:27.872Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/49/0b40bae059c619505c9b751cee6caa208e4904e290aaefa1728c4c2c67a5/grpcio-1.83.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:0468b627f2987c9a77f7580030207cbd85457ffe52998beff4f0b5c38c58a72c", size = 12156839, upload-time = "2026-08-28T07:08:30.191Z" },
+    { url = "https://files.pythonhosted.org/packages/61/4b/e8c0d635da0ee5ddd9950c8d540f5dcdd0ef1854a382cc55496a487a8d31/grpcio-1.83.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a6a282e81530cead60bbd752cc04950a57f224379e9821495d6a35bd5ce9b1f4", size = 6877036, upload-time = "2026-08-28T07:08:32.285Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d4/760a33f339a7dd3d5f4b3e0e9bec5472d95592a80f887b2e9dab4e41cfbc/grpcio-1.83.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:947d945f52e8ecf3cafd2bb7113502a16ccfda3e12c854443094de32d83ad432", size = 7624404, upload-time = "2026-08-28T07:08:34.194Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ec/bd798654b06fb42a92b57d1dc1b530084fa89ed442806fcd0a833a36f9b3/grpcio-1.83.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:55656318d5dd387077396dffb929171ca3966e24bfead9a6c5dba9f889062cb4", size = 7042942, upload-time = "2026-08-28T07:08:36.208Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b0/c00f86614566dd0961825cf0f43d4f96a74371d9d95f952bcbc4b86d9a27/grpcio-1.83.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9daf5acf4fc9d5f5627229969c2580a91e511779d76e4ccdeb9f4770f05d8bc2", size = 7576937, upload-time = "2026-08-28T07:08:38.041Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/38/85eff43a5c89dc666a252b5c9f8e9ab03f89e11c95b6263d2933f08fdbe7/grpcio-1.83.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7b94174cbca93316888f805efbeb08f1c020f7b7493d2d50cc4f6b64ebb7e8bd", size = 8608391, upload-time = "2026-08-28T07:08:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4e/82835483e2f812494be865e7965c0d626cb9e71ab0d83a420d75aea4ad67/grpcio-1.83.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:65c5a7210911ffe0f67b1cdc5308f9854b6d1f1b345e3e49ab7cac1ba50fa346", size = 7980060, upload-time = "2026-08-28T07:08:42.434Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b7/68a98bef733fef704fbcfb3957c8dba67e3e38ca7a7fea851195bc97c648/grpcio-1.83.1-cp313-cp313-win32.whl", hash = "sha256:179368d9361854616ce6f397d4716e07480129652752fcbcfc5a7260455ad6f2", size = 4395226, upload-time = "2026-08-28T07:08:44.463Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a0/df4de3b51d37ac8fb0320bb9668381ce2bd3b7aa990880bfc56a8a26f665/grpcio-1.83.1-cp313-cp313-win_amd64.whl", hash = "sha256:2e57af456385491a76e13c4aada8c8f43a8e47051e06ea97a9dbe2a49654e6db", size = 5160273, upload-time = "2026-08-28T07:08:46.216Z" },
 ]
 
 [[package]]
@@ -1524,7 +1573,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.27.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1537,40 +1586,59 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/9b/ddf3d02a8681f1b9ce52fda03d755dad6b74c4f8172304c4c8d2975450f9/huggingface_hub-1.27.0.tar.gz", hash = "sha256:c1fed40ea82a6b41b477f5243546549b792ae0a93abcea608cff66089bf8f8df", size = 942668, upload-time = "2026-08-07T12:48:05.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/35/42316e8f6908b6d21bc8df017cc6efba94fb5edbf99b64e28dd142325e20/huggingface_hub-1.29.0.tar.gz", hash = "sha256:6ebb385a581435325cf6d5c5b233d5d4bc91175834d99fd65dae14379b36e9ad", size = 963121, upload-time = "2026-08-27T12:18:37.432Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/d8/95b735e183957c1f26d94c52977f09d466d55119cbbc1558ea4975e4c216/huggingface_hub-1.27.0-py3-none-any.whl", hash = "sha256:7df6827c2f956c60fbaa64646e979e566db76f619dd0a9729dfb8c5a3eb4f68d", size = 784926, upload-time = "2026-08-07T12:48:02.905Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a5/47c2ea9b228ccbcba8467e9a64823146e8ebbad29855e591d8f5eedcc9c7/huggingface_hub-1.29.0-py3-none-any.whl", hash = "sha256:b00f7782afc14db4bc6572763810a635bdfbab8623d957bfb553bd18e03852cd", size = 795768, upload-time = "2026-08-27T12:18:35.431Z" },
 ]
 
 [[package]]
 name = "hypothesis"
-version = "6.165.2"
+version = "6.165.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/73/fc3743243603dc49911a1ec073a3a524ea8e1c7d48218d3c2a3faa9a8709/hypothesis-6.165.2.tar.gz", hash = "sha256:680a1adf523ac792b46064f425b112ce6c08a7a8f50e65d08e029de6aa11df95", size = 502277, upload-time = "2026-08-05T21:32:43.713Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e2/0fad246d2b6330e1f78479bfc566b5c22be82aee8a865cde9a08f648487d/hypothesis-6.165.10.tar.gz", hash = "sha256:68b45e09834cd80523cb1eb274463073c7a9af4e4ef7cff34d9615f355572d32", size = 503703, upload-time = "2026-08-16T22:56:15.404Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/63/46c9908fe7bd5ffa5002fa88fe289dfe6d3cea3fad1ab8942fe11f1c8a2b/hypothesis-6.165.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:33a7303566e660664f3f02ea1df85f7b966cd6723165c696996cfd8630913b3a", size = 781704, upload-time = "2026-08-05T21:32:03.548Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/7f/fdce62542a514f6b33c4fc0a760e6d17bb57602b28cb079b78e55b8ea32d/hypothesis-6.165.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:06d8fe4c82a935f67e610c99848360f5caeb04f547c7d7a830a5c74fb96f053a", size = 777243, upload-time = "2026-08-05T21:32:17.546Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/c8/39cd922bf3e1ec84977b768d4e8be31ae051e3a6b400b4fdd7ebcddb1eed/hypothesis-6.165.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de2e3f6a6f75c876be481138c6c0802ebe10deef9f13ce1cdd6e0ed21d8e1e28", size = 1106492, upload-time = "2026-08-05T21:31:47.844Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/91/7bb502379a8dcc43f2538530c05cf16fd4e386afa587d65cc289484425cf/hypothesis-6.165.2-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:21668cb5a8a694d45ff4c43f20a8fc577a47467b5102c680a43638b027136368", size = 1135105, upload-time = "2026-08-05T21:31:49.453Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/04/4ce8ae1bf78d09d7543ab7037a3beedc7f3d963c7aa04e82842415284689/hypothesis-6.165.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea4ab5cfdd6c6a23a60777559ea06c34868234fff6542ff6125c0250429348e", size = 1156034, upload-time = "2026-08-05T21:31:44.687Z" },
-    { url = "https://files.pythonhosted.org/packages/49/de/b074d899f4a04fa8b99a5bbd66f209c1c02bc21f9f87404539b28b99aff0/hypothesis-6.165.2-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:0a6add02d9b3b73b59f4d69f5b15abbc07113cd335cc140815cec2877e6b496c", size = 1111344, upload-time = "2026-08-05T21:32:27.211Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/38/5a8514683a181f82a8ad9f6d084b704fea7a97c9814033939fc493b55fca/hypothesis-6.165.2-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:11013896b6a2ed497079558cb9f89e8b3b564f8859782b38f72cfc1dbeca66ad", size = 1148115, upload-time = "2026-08-05T21:31:01.009Z" },
-    { url = "https://files.pythonhosted.org/packages/88/c7/08cf7930d8bec7f1df971c948af2ccb5a402d5b8b19b306af655a603b180/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4ceabc69a95e761f381663c6452537fde12a2a6e0275e095b6822c0e0f3b1364", size = 1280321, upload-time = "2026-08-05T21:31:14.843Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/91/c9ebb7da3b6e06c47aecceb959cf7df6af75025663af543373c5692f97ac/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:11e1ce261765ffa6acbaf540358426519ca4a5e46b825cf39b429c77c1895689", size = 1408134, upload-time = "2026-08-05T21:31:27.383Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/24/13c2fd9f253ba3a92d4aaa61ae45a8b130df57ab5bd6fc481e2aae520e36/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b0250099b2e55d72872319918aacc501110a182938a3d56bcae4a999bee5db08", size = 1280884, upload-time = "2026-08-05T21:32:00.188Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/fa/2820bdbe0660394544b9e120b03ea7020702d7fa5c76236166de6ababc9d/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:96d02928d1a0b7d59e39fd8ada75f0b7d0377ff29f91c94109f92fc2dab9af74", size = 1322998, upload-time = "2026-08-05T21:31:24.373Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/24/38752794eb821f5c77da08523602003c344f3498fce09f20741cd5b5e29c/hypothesis-6.165.2-cp310-abi3-win32.whl", hash = "sha256:0f2044093c8244d73893e755a7fa53154b7eca57b37e1427d9b0d9948f6c2b3e", size = 667506, upload-time = "2026-08-05T21:32:10.547Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/71/b28f714a127017750e450d152aa4fbff51bd144c6840090d28b529b408d3/hypothesis-6.165.2-cp310-abi3-win_amd64.whl", hash = "sha256:2aa30716066e5ee7750e56b8f90cefaf4ed28c12b4b1d66cef40014fd3f95196", size = 673650, upload-time = "2026-08-05T21:31:25.726Z" },
-    { url = "https://files.pythonhosted.org/packages/22/01/add18f19d5e5f084a59709f0dcebf3cb1edeca475ce8a31573dc33891e66/hypothesis-6.165.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e2bf15d05264ec9da8d55c3843902f906ced5e84fb3da924eafe165697ab4638", size = 783183, upload-time = "2026-08-05T21:31:55.305Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/4b/df2e4c24d208518a6a3dab7acabad7f5ec6c5bb0f4d0bf1701d2fb7206ce/hypothesis-6.165.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3748153d4f64d347f8c988dd41fbef3513b66819e73e9209b1c501bf0d716a13", size = 774829, upload-time = "2026-08-05T21:32:01.891Z" },
-    { url = "https://files.pythonhosted.org/packages/72/a0/b75a001efbde704ff2188924a4d4bb3cdf7a22924dc51c155115af64858c/hypothesis-6.165.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f689976e0eb578afbe8ce37669cb637f00f7c545ad303412947ee4abe2f29ce6", size = 1105224, upload-time = "2026-08-05T21:32:35.189Z" },
-    { url = "https://files.pythonhosted.org/packages/71/f2/4942f510c6441b5d60dc7f0d8d2af74fe444b62d3af565bdf42d9b6b803d/hypothesis-6.165.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7c68a5684b2e2ad3c33500198a6073b3d04493fd7b1ef34937645ad092b797d", size = 1155166, upload-time = "2026-08-05T21:31:46.408Z" },
-    { url = "https://files.pythonhosted.org/packages/48/11/405ebff50c6949518d34f487017412d5b8f8ee9239e50ecdfdd99a745f4b/hypothesis-6.165.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b40db922ccb53fb77c68d944748a3eb5b945402967b64093d9ba970d028cf1af", size = 1278170, upload-time = "2026-08-05T21:31:43.116Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ff/93ad0f4b55100876604d2c316a8c6e0ee037cb0da925caaa478709e504b0/hypothesis-6.165.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d2fd48ec969b2dbe1c8e25dc86d199c6820b9222846469449b997f5546383378", size = 1322061, upload-time = "2026-08-05T21:32:07.217Z" },
-    { url = "https://files.pythonhosted.org/packages/14/37/14b655c664a957e44c7f59d9498e53d79b55f1b752a1bb38fee9da403e9c/hypothesis-6.165.2-cp313-cp313-win_amd64.whl", hash = "sha256:9cf13225121280036ea5a8ff8babb82ec27a4736aea669bbe0bc9839d254575f", size = 670824, upload-time = "2026-08-05T21:32:21.25Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c1/9a9538e6d185baf5cc7f15bc3b76e08efbb3de4b3c782f234356449c0dd7/hypothesis-6.165.10-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f839d29d0cc12048cf073d88ca4fdf94d420bc2b8afd69641ff6d496422ccd4f", size = 783243, upload-time = "2026-08-16T22:55:44.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/30/b70d9d79e871a75cbdeccd9067f20ecdb9eb2a1dfa03c630be3ad13b8b30/hypothesis-6.165.10-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e10858f57ed0e74baa04393845f469fe8ad502c16ece4499bef7700c575611bd", size = 778815, upload-time = "2026-08-16T22:55:46.948Z" },
+    { url = "https://files.pythonhosted.org/packages/db/52/6f0a9b7aab24b0635e2238f3fbddea5b54b17879ac813df42a3cc3384c5c/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76a7be86d986223b9f1bdb7e7cbcdb048649901fdb956c598ef73bdab1786cd5", size = 1108009, upload-time = "2026-08-16T22:54:53.082Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/06/8d0d4e11ff02350d09ec9f9e90af354158e59e16a8907ba5199a4ff2d7e8/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:717aea574e0e5edba2868aa66b1caae335d8f1ad3fb29f01dd6502953fa823a1", size = 1136596, upload-time = "2026-08-16T22:54:54.443Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/01a1e440f2e38dc1ccf5d597af5b8a0bee5f21b674c99c123b5554de9690/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4334058033e0214475f019e15492a50f3854fe8728cf51fe25c6191a2c3f8e52", size = 1135234, upload-time = "2026-08-16T22:55:08.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/18/8a26c24d3d9db20265f39df341ab265858c094e209571e3179cf237935f4/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2abb50cf1cf77d721de0a24c3f99d9c4ffdeb2cbd1e12aebb5a7a93e2b6b6d1f", size = 1157528, upload-time = "2026-08-16T22:56:02.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/8e/ce3c829b1937402d7944420ca26a05a0c8563e894dcff03d34ffa279d306/hypothesis-6.165.10-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:3de69aa8b924b400291a3cc42aaf78e6ab65c905a3e7e1a5dc39d95ef1b428cb", size = 1112870, upload-time = "2026-08-16T22:54:55.919Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1b/4c4926d6c9a2b5d7cc090cc1e91219d6796102aa2a2c4b8f961c939e60b5/hypothesis-6.165.10-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5841331c504e02d7c334591681cb8587cdd59dee7e149db6d3db8e3f9e9f02eb", size = 1149683, upload-time = "2026-08-16T22:55:30.567Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f9/df24eb28412f82465e2b7707f0ff1ec274d580bce389d4d9156617dc7bba/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2d0e0f8263d34dd8fa3b39eaa9a50bba56a8470b3dd9ebf6672d10840abe063e", size = 1283402, upload-time = "2026-08-16T22:54:18.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/07/c2b2a761300cf60b90ccebba4328175331e67d34f4fbd39429a7ddcdce49/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0c4e6869817c3cfdf5a2b4d348497b95159bdecb3365be732c9b8570e36a4eef", size = 1409948, upload-time = "2026-08-16T22:54:22.343Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ec/1c2bf1acdd0e273d81f833f85caf0ae5423db68a783554992fca36e6c541/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:9f07ae36c3b093e13687a894e79fe69e98a94c0b67fef656c575247682218143", size = 1265023, upload-time = "2026-08-16T22:54:41.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a8/7f984908b7391160c7801b84e51ca8e4ba88c89e8d8811aa1aa7c03de73c/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:aff1f584c9538e8979cd180b1d70bf99bc16be19d4666414f49e5942b21a4f2c", size = 1282698, upload-time = "2026-08-16T22:56:06.998Z" },
+    { url = "https://files.pythonhosted.org/packages/48/78/3a5d91c2d0250521736c42dfa2402b75049bc5fe2fb716c10bc84bb91ed1/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1f2c4db25fb8ec1a16a8dba580666337b8ffb1887c4cf1750cc954313897cef7", size = 1324816, upload-time = "2026-08-16T22:54:46.675Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/99/27450763853a034bca1574d3e0a315164b33ff49c3862df6872dda45e25e/hypothesis-6.165.10-cp310-abi3-win32.whl", hash = "sha256:b33dc30170a7402e03c180f2c5ef69dc077152f35b91621e9cebcde9c7d71746", size = 669039, upload-time = "2026-08-16T22:55:11.962Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fc/ff2988b72b5705ad9ca500444bf3f43e3c2f41edfa034bbfeb23b215791a/hypothesis-6.165.10-cp310-abi3-win_amd64.whl", hash = "sha256:e9f924aa610c0618445e1e8738c822c3190ce2a2699a0cb48ec3a351a96761f2", size = 675213, upload-time = "2026-08-16T22:55:01.697Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/821810d36f78d9d9421cd2c5d9d36983b45bb3575c3086276cc5c76f9f73/hypothesis-6.165.10-cp310-abi3-win_arm64.whl", hash = "sha256:1d305448e9bd8e2f4f3cea0eafd809efdaab4e998a0019bc615650c8463e42f1", size = 673537, upload-time = "2026-08-16T22:54:47.898Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fb/c82c5bd92864ffcf319772fedc8c9bf2dbe4ca14baa0fee6e49e67b5ba1c/hypothesis-6.165.10-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9d77c3be7b429875036ad0f0597c6e5cc6bb17894a4da005e3807de64d2673ad", size = 784726, upload-time = "2026-08-16T22:54:32.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b9/3d7acd08506da85557e65147b7f3fca8c47684e33be90bee0acb523920db/hypothesis-6.165.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:490c56b830772b0eca3b4b2cecb3741a1ed26b1d7206a279e1525dbf0aa95ee4", size = 776375, upload-time = "2026-08-16T22:55:13.303Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6b/922e8b3f9a706dd89d440b9545d2c6231c65e74da1c1fee3ff36c251b9c4/hypothesis-6.165.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed68e27b8a61e57a3ccdc7c5a14499e00b54dfe223087204d5d40b3b5ef58b6d", size = 1106763, upload-time = "2026-08-16T22:55:06.129Z" },
+    { url = "https://files.pythonhosted.org/packages/01/39/f5b9a5d390d4edd1ad472334493ac442963ebeb4daaa74ff4bdac6ef292f/hypothesis-6.165.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6caadcd1afb62630ff5c5ff353626eaa616553a5971295ad6dc2b19ca8a39620", size = 1156778, upload-time = "2026-08-16T22:54:33.824Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5f/5fbe1be4326337fd6acefe2d18ed44007ee1dc1f98fe5b3c0eb22942364d/hypothesis-6.165.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9145fe43ebb22e66672967c3fab411793b226ed776e4fe282271bca6ad3c0bb", size = 1280756, upload-time = "2026-08-16T22:55:54.834Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c0/cf6f9e1ef632a1a75694eed0db3a02e6fc75c367a363e94acee52f043c64/hypothesis-6.165.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:79900a9920a0b1d3a626c03a90ac6bf7042e78d46906a565b86a0dbe926f1d96", size = 1323889, upload-time = "2026-08-16T22:55:56.567Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cc/662b94880f260b0a88de1fdcf60fc9984f6e2a796da549542adc10a7bc83/hypothesis-6.165.10-cp313-cp313-win_amd64.whl", hash = "sha256:c01dd04044c472e47193b54f68e84e08d6ebf4f29551885aa959b015f7cd9747", size = 672346, upload-time = "2026-08-16T22:56:03.792Z" },
+    { url = "https://files.pythonhosted.org/packages/47/fd/985aa564d6ffd06483d45a62b40d319df0a703cd8bc1d041de17d102fbaa/hypothesis-6.165.10-cp315-abi3.abi3t-macosx_10_12_x86_64.whl", hash = "sha256:eeab73050ea58c13dd56e329f594c1dfe32ebd7bb169bbdf4f8ceefbc31ec6b5", size = 782882, upload-time = "2026-08-16T22:55:37.93Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2c/6cc11151e450f72353a490940cd0db704680d07b78dc75dcc9f480e0d0e1/hypothesis-6.165.10-cp315-abi3.abi3t-macosx_11_0_arm64.whl", hash = "sha256:4c68e983d0007d014bb01ad4bcbba78bc432c73a1755ff36d5102ceefa18299a", size = 774584, upload-time = "2026-08-16T22:55:51.822Z" },
+    { url = "https://files.pythonhosted.org/packages/10/39/ef26fa79c1738dfe9cdb1a3584fb6717d26429ca6c9d011cc4fdf08130c2/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7730d8197086f65d8969a991d6728a1d420a51b19fea06535c896cb43a1e05d0", size = 1104876, upload-time = "2026-08-16T22:54:58.937Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f4/3fcc84e7637f42bf00d987093b9418083ac8db81b87392608a60f4b7c5fd/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7a7980a898a3e6ebe4de1896a0507e3d519edb53fb9b4bda478c9fbeb6514558", size = 1133353, upload-time = "2026-08-16T22:54:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/35/59/21c5c14179c38f8d0de3560e7f1825c083311b3013b63f817d7dc78dfcbd/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b5820d009aedb7ae9cfd32f98b1ab0c0bbd6268379c4fab042218b6b655c63f8", size = 1132300, upload-time = "2026-08-16T22:56:08.539Z" },
+    { url = "https://files.pythonhosted.org/packages/14/af/fbb56059961e416b2de7b9dc5352db2e8572bd5ea46892957e4c1e5548ab/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37a7ac3d34220800e1107871cc391bca1b00439875925d7d821878b8b791f245", size = 1155175, upload-time = "2026-08-16T22:55:19.824Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/53/77fb0c2dad445858555429c4e06cf94a59ae8d2407dd6426b5af97c84828/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_31_riscv64.whl", hash = "sha256:dafa7c9dbe3d802f9bcdf261b29c8a70700fb22839947f06e471f62c46b6257f", size = 1109881, upload-time = "2026-08-16T22:55:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/7b/d187f673ff30e6ada640953636f978ffe64a6332f756b64163c2277f8d0c/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:90915635b9648071129b0f72c0673cf8eac9eb84cfd445c5bedef30c714b1ec2", size = 1144963, upload-time = "2026-08-16T22:56:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/60/31d504e364134d60af23e5f6365db0da3cf4a51b3ed3d4836e5a2cff12cf/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_aarch64.whl", hash = "sha256:e1bbeb7c506b07ee0422cf9b2f7212fefa4240957f03526d38d27bc6743a0a48", size = 1278684, upload-time = "2026-08-16T22:55:22.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e6/89d26834a08c02f8da149e541dd40d7a96f68d9722f43146e69a77436ed7/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_armv7l.whl", hash = "sha256:2b36aaffc88625a44f91074c5bbedfdefb9b376c38d1b3c342edcd2e4c8ed16c", size = 1407202, upload-time = "2026-08-16T22:55:14.949Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/20d1e72246867ea195440092e8bb422c7ddc2f271b87b5b65679d5532719/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_ppc64le.whl", hash = "sha256:18a3ea838ddea183388f8788750afa8494d79abb5358823be9782585f34445d3", size = 1261395, upload-time = "2026-08-16T22:56:05.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9b/ebab6c3c2b90a16abb4119198178652d12aff83cc8ec2cfde5276c69fb1e/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_riscv64.whl", hash = "sha256:2a2567b3a03a4a5a7c575c191cfcce321a967df3727803817e75bffbbeaecabe", size = 1279213, upload-time = "2026-08-16T22:55:35.066Z" },
+    { url = "https://files.pythonhosted.org/packages/23/78/69b219b524231d36eb20c792e1f01e7cb037e02bd0af1c29f77ed9a969c0/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_x86_64.whl", hash = "sha256:8001925fa3dde51cb574e4c9de4c7efe77c4e4d64bd2fd2ef61d5651f9d04f3d", size = 1322367, upload-time = "2026-08-16T22:54:21.279Z" },
+    { url = "https://files.pythonhosted.org/packages/55/63/ad5cc153dcc72ae5e7905fb9b3585f3e48ce892a2d6366f90163e867a69d/hypothesis-6.165.10-cp315-abi3.abi3t-win32.whl", hash = "sha256:c6559380469295c4009215fe1cab561301591a3bee2e2fb3f4f96d2273a3affc", size = 666038, upload-time = "2026-08-16T22:56:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/80/32/b62307b73fbc99f0a4381d6f9456df76fbcbb7a27ef7256e26f0376f48ea/hypothesis-6.165.10-cp315-abi3.abi3t-win_amd64.whl", hash = "sha256:30797f20ca45e57f526d2df872f63ba453cb4e1091ad542184a7a951af8da79d", size = 671941, upload-time = "2026-08-16T22:55:00.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/dd/e0f98add0548ef73ea7afac45da1fb8efc854d7f9931db568754d0f963f3/hypothesis-6.165.10-cp315-abi3.abi3t-win_arm64.whl", hash = "sha256:c53e9b1c36350df9965ec44d6c0d4e0bbbb38f720dd2b0e1256dc6524d411015", size = 669931, upload-time = "2026-08-16T22:55:50.205Z" },
 ]
 
 [[package]]
@@ -1584,11 +1652,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.18"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -1623,7 +1691,7 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.15.4"
+version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1633,14 +1701,15 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "pydantic-core" },
+    { name = "regex" },
     { name = "requests" },
     { name = "rich" },
     { name = "tenacity" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/24/f6b28e83b3194c6223ed7c6eed5724687f6ecd378ec2ff24044f0cbf1f09/instructor-1.15.4.tar.gz", hash = "sha256:ea2280c3678d0f6891c4d826104f95624b680e69877113a6345b1d7c9027ba0f", size = 70049678, upload-time = "2026-06-28T07:36:43.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/e3/b3487414c03c59ef2f2b9adb4630ada8948cf4b263413a6cd37d91407988/instructor-1.16.0.tar.gz", hash = "sha256:5176def4060e17650e70851e1461fe649e0470de80ce782f245ae444d53b6429", size = 70198815, upload-time = "2026-08-27T15:34:05.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/8d/f668a30fff4d25b36533355e23aeb0b5724df4628eb974124ed64b7bcf8d/instructor-1.15.4-py3-none-any.whl", hash = "sha256:00e0ecda80fd9746fb6d082d3f9641e193adb1d8849f0775f91519a82aeff968", size = 252522, upload-time = "2026-06-28T07:36:36.863Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/83/5d836d8239d1b9ea5d5d5bfa1558a765e4304f5504de19ae076db1c2b99f/instructor-1.16.0-py3-none-any.whl", hash = "sha256:313ac2ef4f13a4828889a24d65ad3ed63d794506759bd3412c4b71eda197db33", size = 260086, upload-time = "2026-08-27T15:33:58.515Z" },
 ]
 
 [[package]]
@@ -1835,19 +1904,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.9.0"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/81/4cf8d0412e1f37b2bfa70d0aeb9c7ae4ab73607534e44d60b55efb485306/lance_namespace-0.9.0.tar.gz", hash = "sha256:f738b641cc615b17323baa4eb47900f184688739ee3d2ea9fe39396b9588e53d", size = 11637, upload-time = "2026-07-01T07:42:41.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/93/da5f7fcac690db9b282a3439ed9e34960c147619a0d6e1f4eb8cd240e7a5/lance_namespace-0.11.1.tar.gz", hash = "sha256:f67cfbbe0647b7cb42f23b673e7edf8a75b7d8a047265a916492f8d247ee1bc2", size = 11631, upload-time = "2026-08-18T17:40:06.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/fe/f38747c9610ade83dd9a99a0470b9432b6f21ce4e2bb5524edbe66f626fd/lance_namespace-0.9.0-py3-none-any.whl", hash = "sha256:f785ff10927e4ce0db69986576670fedd37f8a33521e8a4630c6be22db8061b2", size = 13501, upload-time = "2026-07-01T07:42:39.372Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/bc/601f2b3cc4cfa0070d858a33223bc823fffdd7981a25c45984a5216ca952/lance_namespace-0.11.1-py3-none-any.whl", hash = "sha256:07643fce9a42ad4d58cc8bf91e3f592bc7f4cbd8d0ad5233223506debf67551c", size = 13507, upload-time = "2026-08-18T17:40:03.561Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.9.0"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1855,9 +1924,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/32d0e2618549ace857c80a457e5915ef3e1145661baff876c8a5ec27be5b/lance_namespace_urllib3_client-0.9.0.tar.gz", hash = "sha256:cf796fa5307fa4dde91fe4bec2af28b90ba79191852d4394e8fe44276538e40f", size = 235805, upload-time = "2026-07-01T07:42:42.563Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/c5/2bdd0ff98b469894c8a73be809d26ffdad5402517b0e5f9e758026cba29e/lance_namespace_urllib3_client-0.11.1.tar.gz", hash = "sha256:145a9e9424d7597487249b5b95ee274423bf2910e1a9160b6a07b676b61ea46a", size = 237345, upload-time = "2026-08-18T17:40:07.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/ab/c8754da0a1efc817f8480100cfe12b7e04034df834759de8ecf02beff3cc/lance_namespace_urllib3_client-0.9.0-py3-none-any.whl", hash = "sha256:be819c8cffb1e460a3a504dbf52d1ca009560a48e7202b8c4279998e4adf9fe4", size = 405586, upload-time = "2026-07-01T07:42:40.503Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/2a/eaaefd55d1190291207049fedc6b3eb22b506e57d6de91bae46bbaaa9c60/lance_namespace_urllib3_client-0.11.1-py3-none-any.whl", hash = "sha256:36537f529294da6d884ba0fe783704483f0a75463497c7705fd083a4d0257990", size = 406311, upload-time = "2026-08-18T17:40:04.842Z" },
 ]
 
 [[package]]
@@ -1884,7 +1953,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.5.5"
+version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1898,26 +1967,26 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/c1/c226367fdf92a173c8b520d0b3583a0aaf4c3fe4952010f680e49d88589d/langchain_core-1.5.5.tar.gz", hash = "sha256:c08d78176113867e9a76acc1007d641cd68fa5682e9e0018980d062b4ae0777e", size = 983166, upload-time = "2026-08-14T18:56:24.364Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/7b/406b4a8dd43dd01f69e04aafdee206809a2097134b2f944e12802eae7948/langchain_core-1.6.2.tar.gz", hash = "sha256:1ec6d3a98f7c8cdbb5bb0deff86e7ca37e16bf4f8f49f022d10723656c62352d", size = 1004390, upload-time = "2026-09-04T21:29:22.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/09/9f29e62e99118865d092acda6143a1ba6ce1893e3dcb72388a75b798e37d/langchain_core-1.5.5-py3-none-any.whl", hash = "sha256:537037fd44ead7c1ffb9621011029ad2e347e051519d17f112d7bf7be12f4365", size = 565884, upload-time = "2026-08-14T18:56:23.051Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/62/d3fb7c215cb2f237c3fe84880bf347a38deafef6033b6d5f1339ba8ca401/langchain_core-1.6.2-py3-none-any.whl", hash = "sha256:21e6c7cf097c68b777fd69ea00864f09bd9ca76ac73e3e3fa14e1ee366eb4711", size = 571690, upload-time = "2026-09-04T21:29:21.175Z" },
 ]
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.18"
+version = "0.0.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/56/913599f2f9cec8524868929f12d72b2ede377a6056ca8a40a32bdadfa535/langchain_protocol-0.0.19.tar.gz", hash = "sha256:79d90a1425122ac87e8052e2ec054fbd09c3edbf341bdfb6397112a495c7bf8c", size = 6265, upload-time = "2026-08-26T21:12:00.703Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c9/f6cbf357d48ccbd18bb394433b1fd7ad9be004eed9377ad08bb85777e5e6/langchain_protocol-0.0.19-py3-none-any.whl", hash = "sha256:4cdf879a492a35980fd859ae792d3c65458ccaae504e183c9a10d7eac1f0720f", size = 7327, upload-time = "2026-08-26T21:11:59.781Z" },
 ]
 
 [[package]]
 name = "langsmith"
-version = "0.10.17"
+version = "0.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1935,9 +2004,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/56/73674bd922fe57509c38075d089017d65e02f50d687fd70ee6c0b153d729/langsmith-0.10.17.tar.gz", hash = "sha256:2bf0e69246ef77282ea93e78eb22dad1ec8d8a002d31cbd607d0d6448f9c6458", size = 4798702, upload-time = "2026-08-07T17:23:04.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/0a/1acb2a3ffbccbe8f8dc358778967c9d2979e8a59b67ceba6eb54474324ab/langsmith-0.11.2.tar.gz", hash = "sha256:927694c939c9fb44187e0126cf718413c45ffce2324d480438e70eb0526e1380", size = 4841592, upload-time = "2026-08-27T22:31:34.004Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/e6/e264e87ce79467aa0cc6c5e945e74050d7880394da325b3559cfdb41a186/langsmith-0.10.17-py3-none-any.whl", hash = "sha256:2a1242a0500147ed846ecbd5fe2f41c21b1652f6833b1af0f209231006f67e5e", size = 734484, upload-time = "2026-08-07T17:23:02.598Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d9/cec0c1d24dda8c67a23ad204d0167e50aee202460e9388488661d94513f5/langsmith-0.11.2-py3-none-any.whl", hash = "sha256:75258142d27dffcc5df331479704b23fc3fd812cfca0469119bb9055a842882f", size = 753928, upload-time = "2026-08-27T22:31:31.644Z" },
 ]
 
 [[package]]
@@ -1987,22 +2056,23 @@ wheels = [
 
 [[package]]
 name = "linkify-it-py"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uc-micro-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/3e/79f35b8c31a1881893b7e62be80b2573f06e38db47c33065749293ee1b97/linkify_it_py-2.1.1.tar.gz", hash = "sha256:a78f40fee177eb912e9d2375074108378523c38d3fde5d3ee804f465b6cfbfee", size = 30889, upload-time = "2026-08-24T17:16:57.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3d/e34b19cd144071c583317268c4feb2c59c03ac57eef69753410c7abb11c0/linkify_it_py-2.1.1-py3-none-any.whl", hash = "sha256:8539a6b470efce90ba9b69e39b848e5b15b7ad89f7f98ca17d3532c243f987dc", size = 20532, upload-time = "2026-08-24T17:16:55.965Z" },
 ]
 
 [[package]]
 name = "litellm"
-version = "1.97.0"
+version = "1.99.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "boto3" },
     { name = "click" },
     { name = "fastuuid" },
     { name = "httpx" },
@@ -2016,41 +2086,41 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/08/db78a9f53e5688ad0f9e50d5c3bfe616e445aac120eafcca907f04634e48/litellm-1.97.0.tar.gz", hash = "sha256:6f7ce326a2e5385ef850e0b0768d41f502ec79278860090a838511cea067b067", size = 17762282, upload-time = "2026-08-16T00:05:44.724Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1a/76b5f28ba9e07fa0cb807bbdefdf318c554f60623bff699e7b601d0d7b3a/litellm-1.99.0.tar.gz", hash = "sha256:594bf4b6ff6b79c6aa3c3b78c0e939d4afd12687e076ba3fb608d38a5aa7f9c6", size = 16786386, upload-time = "2026-09-01T00:43:07.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/d4/a04f8bda468fb25a0a8a392a6922c9ecf6c122ad9bf9e2f69ebd173e1cac/litellm-1.97.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ff401dd5d66f54b9b474f0652c419fb7bf883fbf5ca64c0bc363acdc98b758b5", size = 24235645, upload-time = "2026-08-16T00:05:20.055Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/51/a055bf5df38112f07970937d95416b22379ee84664b739bfe87a8292e098/litellm-1.97.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:2983b40ed5d8b1bcbbfbc0d66fefa21b04db91b87c05dd680ae77cba74e561ef", size = 23893493, upload-time = "2026-08-16T00:05:23.79Z" },
-    { url = "https://files.pythonhosted.org/packages/14/28/b1cf429493aec5260ac2737dd82f6200c729fd26b336dc21cf001cfbcd8a/litellm-1.97.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e3a1f70d693716b4e8a8108f0a464b0e2c555e274ddbb8ef89c4c59c80be14ed", size = 24031743, upload-time = "2026-08-16T00:05:27.138Z" },
-    { url = "https://files.pythonhosted.org/packages/08/4a/22c49e8bd068bfdab0daba235cc2d2752d76d855ccb8f6dafe7dabf01ca4/litellm-1.97.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5b56dce7df44a6a9e6caf5379de2578a8cb82831ceabd3d71cc99b370a1015e7", size = 24397362, upload-time = "2026-08-16T00:05:30.89Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/22/f60558230969ac7d860bd93aff6bf6a69bcd8a3ef4f35eea211174ef4e81/litellm-1.97.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6b360ddc3162c2ed39b64d3f9957a7af70cd9c60cf71f7a4dfa355a0bf05bebc", size = 24107078, upload-time = "2026-08-16T00:05:34.463Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/e4/6c74ff4b188d9399a036d41e86c4c616d95ce5fd9d9b3c42646bd02f270e/litellm-1.97.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3c4f1dd45e14127f2303769a7ae79482697823e329ae503513d014ceea4dd704", size = 24493640, upload-time = "2026-08-16T00:05:37.85Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d1/1475c4ecdf43221ab8ee8d0fcc6b469c26d0d80913d0773e18de81cf18f1/litellm-1.97.0-cp310-abi3-win_amd64.whl", hash = "sha256:dce3377207234fc5c5b275a5e234ba056a5051fd178ae8e9a6aeb5d056f12095", size = 24289278, upload-time = "2026-08-16T00:05:41.441Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ef/4ef1afe95d3a7c52d63b5f2bb32ec5264a4cea198a7dddb8ceff9633f2da/litellm-1.99.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a43e8716da8beed04480e91b4233ff2f1ab1fedd84cad332dbc526b54a9229ca", size = 23350560, upload-time = "2026-09-01T00:42:41.449Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/f329cf74fc1f929a93210b16523bbcebd679694090df741bb8bee726a473/litellm-1.99.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e2b383070656fdbec4bc44602edaaed2a21e99ceee4ea0a4650c8cb381e67b59", size = 22999186, upload-time = "2026-09-01T00:42:44.978Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4f/0e73fc3f0740249b676d0714bd58c4141f1fc733b88a85b6001f9f2e5e62/litellm-1.99.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e461b7ce53af990e5287cf7ae30d82c956b56dcce886f63ef39a76e678f82a3b", size = 23145753, upload-time = "2026-09-01T00:42:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c4/8e92a6277e28096784616cfda16b2cd839c7bdaabce692ae950e2f0cf72e/litellm-1.99.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1c45097e426fed2ae7fbd38b5404c3addeb203d0e1148c0a59848aabd5fe83c6", size = 23518654, upload-time = "2026-09-01T00:42:51.582Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/aa/11c9bd6297e4a9001426ff825bc8bb119d3a9a3de4e5ee9fed22997e6e28/litellm-1.99.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e42f94731665b68e263481efd79f7629e9b97eed7e10c57dc37a890eca058227", size = 23218889, upload-time = "2026-09-01T00:42:54.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/a9/1fc21c6fb21897867d9c753d651b24903e63955dadffeb2a73517f35003a/litellm-1.99.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71109c323164b4b6776ff259876523e6e883a465aa1413dd51a1bda8e92efc5f", size = 23617457, upload-time = "2026-09-01T00:42:59.173Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4f/df449e0cfa1f40025e91f3a47b03109e16de44d43149e97fbcbd1ae8c5e2/litellm-1.99.0-cp310-abi3-win_amd64.whl", hash = "sha256:5617804e838499bce8fecb41ad9bc984b7977361e557666fed0fef0c4623ce62", size = 23432066, upload-time = "2026-09-01T00:43:03.177Z" },
 ]
 
 [[package]]
 name = "lxml"
-version = "6.1.1"
+version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/a9/970b8fa0ecc4fbf1dfaed0d89bbc1fc1421b25ec26a2038c91e872dc6c8e/lxml-6.1.2.tar.gz", hash = "sha256:1055241852f2b02068af4a625a5d32c087db193c12251928af2562ecd2239f18", size = 4210626, upload-time = "2026-08-19T04:58:15.341Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
-    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
-    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
-    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/61/2a/e9651f47a31a60b5cae031abc23391ed9aa30c8fc07571d1a38f58d6d770/lxml-6.1.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:351318f5c0eb7fcab5b4fdb507c6f88fb2c4b5e67784c7e5911448c91fffb5d4", size = 8590165, upload-time = "2026-08-19T04:58:40.489Z" },
+    { url = "https://files.pythonhosted.org/packages/61/87/a8098abaf35118767d1703b84c98940a5d833064e0eca39a00ecfe9840ab/lxml-6.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0edde95e4b4278dcc0175eda06dc8aa2631ad9f83ae5dbdbc4f0925e200b0b0", size = 4632474, upload-time = "2026-08-19T04:58:47.465Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cc/fe74d1def7f4fb967c4a825608a074d4dbdbb871b0d6bd59c6ed07d67868/lxml-6.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8326e24ae6c3a6bfb03fa8b4793f9a5d804c125228aa067f652b0428e31b87c", size = 4936196, upload-time = "2026-08-19T04:59:03.477Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ad/b96e6ca926e26726a99aa643602aac7411ecc1731ddb1b25af8cc57edfcd/lxml-6.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7c534ed898413f439b048130011e99a4245ee13d62d431f6b4f7f2484d02a93a", size = 5093290, upload-time = "2026-08-19T04:59:17.498Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/84/616f5d3b7cd086fcfba3e5add6fccda67f976c1c753ae9ed7bbd317cb9be/lxml-6.1.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e37fe49fe2d5aa40a2cb1cc8176673ad7de0d124e6f4a509d9318f5979c7871", size = 4998767, upload-time = "2026-08-19T04:59:28.385Z" },
+    { url = "https://files.pythonhosted.org/packages/80/88/d5b453a8d083483c9442ad7f5ac5c560796022eb5c80d60b65d75e449236/lxml-6.1.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9b52ea73a37fc64aa3357ff8607801d46dd170506d3cf8253a91a1d91639d4f9", size = 5626717, upload-time = "2026-08-19T04:59:40.045Z" },
+    { url = "https://files.pythonhosted.org/packages/71/45/31e5aa4d4bae024908ba1d03480c7425cf027a28b7e5c88d1b7202bd80cc/lxml-6.1.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8b9a92652e75e7731309ea51db5dee892eef414ce70a6ec3441e5d36bf5189f", size = 5232330, upload-time = "2026-08-19T04:59:46.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5a/2627912420df8b2d31ba3014da5539f15ec85add01d42048864ffefda516/lxml-6.1.2-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:9088da25ecd609965f838d89fda0465a905b48f4dd90331db9845518f2177372", size = 5347054, upload-time = "2026-08-19T04:59:52.762Z" },
+    { url = "https://files.pythonhosted.org/packages/16/86/54ac0f529b22a8f12313726dd49e12961bb46471d9028cc28d2a29408f0b/lxml-6.1.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:0349321a0537d4fdbebb2af06dd1b64676132c72e2ae250de8cdb58f8c43019c", size = 4707275, upload-time = "2026-08-19T05:00:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/42/ffcdc6e4519be90df907cdae7e88409efb25d823ae4de8846f737dae1884/lxml-6.1.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b20440e578d269c5e8a722ab602ddd0f0cedb8b080006b3f936da9991a593d3b", size = 5240071, upload-time = "2026-08-19T05:00:19.604Z" },
+    { url = "https://files.pythonhosted.org/packages/68/49/5b1d7ab35f013f1127ec48f3108319f58b65b00d5cb26f215adbe86eadfb/lxml-6.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7766e525282dd38fd89567311323e441996eb958e8e816d16b38f782e3aecd2a", size = 5050356, upload-time = "2026-08-19T05:00:27.968Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/57/1cf049d054189b55c8fe8012269234f6602256949b69cd3ba80608a88219/lxml-6.1.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9221442682c27417f10fe11184ea4cce174b25ab52465570b1f3ee3f85f320fa", size = 4780394, upload-time = "2026-08-19T05:00:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ad/064488a8fa60e639fd773e421a18bf17541d02a95fbf36238ad7c65f69d4/lxml-6.1.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:75530642d8471327e691ab9b0513a5f9c77f38871014ceda40f51bb51765c0a1", size = 5645854, upload-time = "2026-08-19T05:03:42.697Z" },
+    { url = "https://files.pythonhosted.org/packages/85/bb/120e56f3cf1c149bb3b014278fb86d0a6dd552403981081f0ee0a0a57be7/lxml-6.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:678e35f1cbca98f55107511ee21a60568535c950f3c2371819bd64504c980d20", size = 5231132, upload-time = "2026-08-19T05:03:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/7d49aab893c128671a3276580074cce4c002896145b8dd2893da79633bca/lxml-6.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c2bae42b3a09f977330a08f4a8fe72aec58c4bdb89069d3fe7272a71d885881", size = 5256076, upload-time = "2026-08-19T05:03:48.092Z" },
+    { url = "https://files.pythonhosted.org/packages/72/28/ddea3aa1fa9acfd384fe34d4a2a93eecc07541dd2d922fa9b140c60d8014/lxml-6.1.2-cp313-cp313-win32.whl", hash = "sha256:5848f3de6a8de8a93cff9f068134393ff5fa69ac2a04399f7d49cd67c61c348c", size = 3602177, upload-time = "2026-08-19T05:03:50.571Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/7a/96bac167538748cae2544335855f812fa33e49a9a67bc8b8520dcbd592bd/lxml-6.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:6cb0c87421946030b92b558be416852780a912454e3dcba0998e4497c9c588d5", size = 4004117, upload-time = "2026-08-19T05:03:53.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/24/9498fa3c84135956e5ef55ea4d8bd11e999e381f7f210fb6f8c6a980ef03/lxml-6.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:648861c19b775b89ebefa14586f85090b10163367476d77f242c4131c835ce73", size = 3665412, upload-time = "2026-08-19T05:03:55.621Z" },
 ]
 
 [[package]]
@@ -2218,7 +2288,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-git-revision-date-localized-plugin"
-version = "1.5.3"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -2226,9 +2296,9 @@ dependencies = [
     { name = "mkdocs" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/99/8067eb7d1652767ee8e5474010647dd5a8e464e0ca8c783b5cac135a2043/mkdocs_git_revision_date_localized_plugin-1.5.3.tar.gz", hash = "sha256:873444b54cab4d47c69bd6e85da05ef5fbe81fee27e64508114c46a0e4f81e37", size = 451961, upload-time = "2026-06-01T08:32:09.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/43/7c2f67a2ab0f9d2627d52a5a0a12b4206e4468a109ae7a091eeeb45f6825/mkdocs_git_revision_date_localized_plugin-1.5.4.tar.gz", hash = "sha256:07a785522008e881ff4c307e3259ad3ce00931b2d2147a22cdfbb532ff25e4ab", size = 452896, upload-time = "2026-08-21T06:54:47.302Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/d0/cbe85158dc091219fd5134bf6d724d30b1f2005ee1d0dabaaa41416bee78/mkdocs_git_revision_date_localized_plugin-1.5.3-py3-none-any.whl", hash = "sha256:cd96e432de6a7e59b31c7041574b22f84179c8636835419ff458877ecfaaaf05", size = 26156, upload-time = "2026-06-01T08:32:07.765Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7c/a19cdb6e1c6f033cd35df847688f99c4f9b80b626fad87483f2069a6dc5a/mkdocs_git_revision_date_localized_plugin-1.5.4-py3-none-any.whl", hash = "sha256:b5e6b4b9e7d169750b6eb078fd91151bc855e65c019a065accce537ec6e69e05", size = 26155, upload-time = "2026-08-21T06:54:45.673Z" },
 ]
 
 [[package]]
@@ -2281,50 +2351,50 @@ wheels = [
 
 [[package]]
 name = "mmh3"
-version = "5.2.1"
+version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/69/d00269fee7a3102fcc0f04f0a312e41c6b237762bdcad4c19426f18e697c/mmh3-5.3.0.tar.gz", hash = "sha256:95832419b87b882bec9dcd7d041d74887ba7745b3659c14be1ae1db5cfa35cad", size = 33607, upload-time = "2026-08-26T04:58:20.042Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/a5/9daa0508a1569a54130f6198d5462a92deda870043624aa3ea72721aa765/mmh3-5.2.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:723b2681ed4cc07d3401bbea9c201ad4f2a4ca6ba8cddaff6789f715dd2b391e", size = 40832, upload-time = "2026-03-05T15:54:43.212Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/6b/3230c6d80c1f4b766dedf280a92c2241e99f87c1504ff74205ec8cebe451/mmh3-5.2.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:3619473a0e0d329fd4aec8075628f8f616be2da41605300696206d6f36920c3d", size = 41964, upload-time = "2026-03-05T15:54:44.204Z" },
-    { url = "https://files.pythonhosted.org/packages/62/fb/648bfddb74a872004b6ee751551bfdda783fe6d70d2e9723bad84dbe5311/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:e48d4dbe0f88e53081da605ae68644e5182752803bbc2beb228cca7f1c4454d6", size = 39114, upload-time = "2026-03-05T15:54:45.205Z" },
-    { url = "https://files.pythonhosted.org/packages/95/c2/ab7901f87af438468b496728d11264cb397b3574d41506e71b92128e0373/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a482ac121de6973897c92c2f31defc6bafb11c83825109275cffce54bb64933f", size = 39819, upload-time = "2026-03-05T15:54:46.509Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/ed/6f88dda0df67de1612f2e130ffea34cf84aaee5bff5b0aff4dbff2babe34/mmh3-5.2.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:17fbb47f0885ace8327ce1235d0416dc86a211dcd8cc1e703f41523be32cfec8", size = 40330, upload-time = "2026-03-05T15:54:47.864Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/66/7516d23f53cdf90f43fce24ab80c28f45e6851d78b46bef8c02084edf583/mmh3-5.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d51fde50a77f81330523562e3c2734ffdca9c4c9e9d355478117905e1cfe16c6", size = 56078, upload-time = "2026-03-05T15:54:48.9Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/34/4d152fdf4a91a132cb226b671f11c6b796eada9ab78080fb5ce1e95adaab/mmh3-5.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19bbd3b841174ae6ed588536ab5e1b1fe83d046e668602c20266547298d939a9", size = 40498, upload-time = "2026-03-05T15:54:49.942Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/4c/8e3af1b6d85a299767ec97bd923f12b06267089c1472c27c1696870d1175/mmh3-5.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be77c402d5e882b6fbacfd90823f13da8e0a69658405a39a569c6b58fdb17b03", size = 40033, upload-time = "2026-03-05T15:54:50.994Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f2/966ea560e32578d453c9e9db53d602cbb1d0da27317e232afa7c38ceba11/mmh3-5.2.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fd96476f04db5ceba1cfa0f21228f67c1f7402296f0e73fee3513aa680ad237b", size = 97320, upload-time = "2026-03-05T15:54:52.072Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/0d/2c5f9893b38aeb6b034d1a44ecd55a010148054f6a516abe53b5e4057297/mmh3-5.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:707151644085dd0f20fe4f4b573d28e5130c4aaa5f587e95b60989c5926653b5", size = 103299, upload-time = "2026-03-05T15:54:53.569Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/fc/2ebaef4a4d4376f89761274dc274035ffd96006ab496b4ee5af9b08f21a9/mmh3-5.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3737303ca9ea0f7cb83028781148fcda4f1dac7821db0c47672971dabcf63593", size = 106222, upload-time = "2026-03-05T15:54:55.092Z" },
-    { url = "https://files.pythonhosted.org/packages/57/09/ea7ffe126d0ba0406622602a2d05e1e1a6841cc92fc322eb576c95b27fad/mmh3-5.2.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2778fed822d7db23ac5008b181441af0c869455b2e7d001f4019636ac31b6fe4", size = 113048, upload-time = "2026-03-05T15:54:56.305Z" },
-    { url = "https://files.pythonhosted.org/packages/85/57/9447032edf93a64aa9bef4d9aa596400b1756f40411890f77a284f6293ca/mmh3-5.2.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d57dea657357230cc780e13920d7fa7db059d58fe721c80020f94476da4ca0a1", size = 120742, upload-time = "2026-03-05T15:54:57.453Z" },
-    { url = "https://files.pythonhosted.org/packages/53/82/a86cc87cc88c92e9e1a598fee509f0409435b57879a6129bf3b3e40513c7/mmh3-5.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:169e0d178cb59314456ab30772429a802b25d13227088085b0d49b9fe1533104", size = 99132, upload-time = "2026-03-05T15:54:58.583Z" },
-    { url = "https://files.pythonhosted.org/packages/54/f7/6b16eb1b40ee89bb740698735574536bc20d6cdafc65ae702ea235578e05/mmh3-5.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7e4e1f580033335c6f76d1e0d6b56baf009d1a64d6a4816347e4271ba951f46d", size = 98686, upload-time = "2026-03-05T15:55:00.078Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/88/a601e9f32ad1410f438a6d0544298ea621f989bd34a0731a7190f7dec799/mmh3-5.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2bd9f19f7f1fcebd74e830f4af0f28adad4975d40d80620be19ffb2b2af56c9f", size = 106479, upload-time = "2026-03-05T15:55:01.532Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/5c/ce29ae3dfc4feec4007a437a1b7435fb9507532a25147602cd5b52be86db/mmh3-5.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c88653877aeb514c089d1b3d473451677b8b9a6d1497dbddf1ae7934518b06d2", size = 110030, upload-time = "2026-03-05T15:55:02.934Z" },
-    { url = "https://files.pythonhosted.org/packages/13/30/ae444ef2ff87c805d525da4fa63d27cda4fe8a48e77003a036b8461cfd5c/mmh3-5.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fceef7fe67c81e1585198215e42ad3fdba3a25644beda8fbdaf85f4d7b93175a", size = 97536, upload-time = "2026-03-05T15:55:04.135Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/f9/dc3787ee5c813cc27fe79f45ad4500d9b5437f23a7402435cc34e07c7718/mmh3-5.2.1-cp313-cp313-win32.whl", hash = "sha256:54b64fb2433bc71488e7a449603bf8bd31fbcf9cb56fbe1eb6d459e90b86c37b", size = 40769, upload-time = "2026-03-05T15:55:05.277Z" },
-    { url = "https://files.pythonhosted.org/packages/43/67/850e0b5a1e97799822ebfc4ca0e8c6ece3ed8baf7dcdf64de817dfdda2ca/mmh3-5.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:cae6383181f1e345317742d2ddd88f9e7d2682fa4c9432e3a74e47d92dce0229", size = 41563, upload-time = "2026-03-05T15:55:06.283Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/cc/98c90b28e1da5458e19fbfaf4adb5289208d3bfccd45dd14eab216a2f0bb/mmh3-5.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d", size = 39310, upload-time = "2026-03-05T15:55:07.323Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/fa/e07f6b9e2fba550fe539b6c66ee7fc28e44f5bd445a7203ae4c169d4aa72/mmh3-5.3.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:6576400e7a748ec5c7ea72f38d626939876dd1756f4a0ccf552b8646dcf6f3e9", size = 41040, upload-time = "2026-08-26T04:56:29.766Z" },
+    { url = "https://files.pythonhosted.org/packages/62/9c/cb0f23e71bddcc519331c9787ec029e0d2fef64ed1bc490ad84b00a43950/mmh3-5.3.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:2b4cd2fcf1b517872530d9ef1a2de2ef9b86e5a0f8927539ea0b68337618244e", size = 42153, upload-time = "2026-08-26T04:56:30.954Z" },
+    { url = "https://files.pythonhosted.org/packages/27/1c/99f2ff480922046a496c2e53728a13a467b68f01a0f48370577c0825a763/mmh3-5.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:f401a82d80c53d88605b82a80623edd95d922732d2c513c1c5f8e4b5e10c2913", size = 38796, upload-time = "2026-08-26T04:56:32.207Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/05/e137452583b33a56d053ad48643a7c56e4cf466efc8a145da6a736913ae3/mmh3-5.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:86238bb78ff65c9fc1e6b371b78f271e23c5d61898222c201122209dc8eadc76", size = 39474, upload-time = "2026-08-26T04:56:33.196Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e8/a9031fe6ed0eb06ab1c98eb76182eb01dc484dc46873a8e5ef3097d9bdf4/mmh3-5.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:222ea0a485e23bdcb29e28d15b8b01ebe34e8720bad4b5f92b645ed86e3fc715", size = 39983, upload-time = "2026-08-26T04:56:34.195Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ae/11459b39af5341de2a048998a717f57b3a1c4e6a9edf8fe09e314b2c263c/mmh3-5.3.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d95ee6696aa5b7283f4a27b67eb7db1c4fb5bb7a9117205d29ebaaa7f6294d7b", size = 55464, upload-time = "2026-08-26T04:56:35.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/841b580415a614a3ad836db1cb8d57c425bbeb717c80263a9d979b1a4eac/mmh3-5.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e2f439ffd4fd7d64b77f6a287d4605700bad26fe12bb1b63b4ee45211344e2fc", size = 40084, upload-time = "2026-08-26T04:56:36.44Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f6/f5cb0e2f7bb7df876847dab63ee984c3f6173569d5b892edc04bc797c1b7/mmh3-5.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7f9cb34c661454f73432112a81ac522ebe69500feeb8d77f744f6bd3e8b2f2ba", size = 39693, upload-time = "2026-08-26T04:56:37.428Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/61/9506d0b30d7388846cc3b884ec63b8d67f3ad2d521e61775315111e70ec3/mmh3-5.3.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b6b7397804e9299bd0c01ea426245fa3d730d3e9c31f583f51aa87bed399c481", size = 97247, upload-time = "2026-08-26T04:56:38.439Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6f/c6a4acf4715fede1e0acb17d6080ebe9b88290d113bbf9513a8728c65b4d/mmh3-5.3.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4a19b00097fcc8e3008bb006cd6bfaf0544e9fa2abc4cc77fbad57971a37dcc0", size = 103256, upload-time = "2026-08-26T04:56:39.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2a/f4fe4ebf2e44f49953ed1ee6b90d329d6843ebb949e60e881dbfde84e17d/mmh3-5.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83d93abf6a68d54b4e2c4c041ffcffeb94b1c9ab3171443fda3f5f19024be517", size = 106172, upload-time = "2026-08-26T04:56:40.67Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/61/23168dc6fa92e1d9b57905b89c694a521a00570f0fe325bc3f6422fe6119/mmh3-5.3.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:598350a6adefb5799c800fd00bbeacbc115ee560e2fd7b35f703608c1037a2ed", size = 113020, upload-time = "2026-08-26T04:56:42.035Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f6/68dbb5461727bb14fbca2342a7bba4521400d679d64e00dd98a992eb0be4/mmh3-5.3.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5c0772d6bba19a5601d24b3c6ce6627484fd5a3fd1d402913e1578b1447d51a0", size = 120648, upload-time = "2026-08-26T04:56:43.339Z" },
+    { url = "https://files.pythonhosted.org/packages/92/18/a879ce4c26e8c1741b575e6c854b2323fd7e116000965c8904428e66fba6/mmh3-5.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00105934e7d52f80b4364282918c37e2cc3cf9868ef4052016cbc39d8711c3f4", size = 99034, upload-time = "2026-08-26T04:56:44.771Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/28/b0548d78133f8e79bb16d6487f2df504ff4e16ea1330954f26be83b645ca/mmh3-5.3.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:99a5b0a908beb01b0e134b7b085d0ea6bfb7ed28ba3ed0737365aa2ce9bda0e4", size = 98587, upload-time = "2026-08-26T04:56:46.089Z" },
+    { url = "https://files.pythonhosted.org/packages/97/10/abfa952c6a443d07efb286b53b439d4418f7cfbac49fca8974cd78c17427/mmh3-5.3.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:da4ad7a0d4c589069c46101dcb55ee304616293bcf614f4c445b3ecc961fa836", size = 106407, upload-time = "2026-08-26T04:56:47.16Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/61/3b974a1cfe683c6cb01d2d3f2d5eddfca7e0a175d976d2307269143f4e0e/mmh3-5.3.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:8962a67c314f1da82957aee5b940698aaffff13e41b3298baa59d30cbddb23e2", size = 109922, upload-time = "2026-08-26T04:56:48.451Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/d2/ac7e18d6fcee3b26e06b3d33ecab4459b7aa6aff9859b13eb13e353a69ab/mmh3-5.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f61f2850b318c043961662f6cdd08e69b05f1d25d0e321782a3995d39f811548", size = 97456, upload-time = "2026-08-26T04:56:49.559Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/80/7911629b930d46ef8cb3165bce44f021d31361a2d7c56e35efe7b0d90493/mmh3-5.3.0-cp313-cp313-win32.whl", hash = "sha256:d7eec1b09bde3a9b6e2102717a587b9c9a96c360a1ef478b5668414619cac606", size = 40458, upload-time = "2026-08-26T04:56:50.785Z" },
+    { url = "https://files.pythonhosted.org/packages/45/c7/138d77c740f9d33ceffa968786fe23abe24ce442c210772b5b7cb6e0c198/mmh3-5.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:b1829bfe98d1f6e7bd79646b78e73dcef92c5aa32aaa622b9e07bf39df98c9b5", size = 41879, upload-time = "2026-08-26T04:56:51.785Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/e1/4312e5c18c8ef4060c9b50f1a645c9af7c3b79fad012c18fbe64a1b17103/mmh3-5.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:3fb0d4918b7d827ac804069849fde03d516628cbbf7bffe0b957ba6f1440cca6", size = 39203, upload-time = "2026-08-26T04:56:52.746Z" },
 ]
 
 [[package]]
 name = "msgpack"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/ea2100ec54d30c46ee9dba10a3bfb79b655e96c6df237238a3234c75869b/msgpack-1.2.2.tar.gz", hash = "sha256:9eb0b0e602064527a045ea28c4f174ed69383587e29cebe28947e3b84106eb2a", size = 187025, upload-time = "2026-08-27T10:03:47.793Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
-    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
-    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
-    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/eb/42f31c5a48811787ff59a9869721f70a49654d65ab6c455f4463c39b044e/msgpack-1.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8b2a281b556f120a43e591ea39915741b7ad54d4727b9c4350a0a11692252533", size = 83911, upload-time = "2026-08-27T10:02:24.06Z" },
+    { url = "https://files.pythonhosted.org/packages/33/54/10c6c16ddba8a5112e3680176b838e3694e4aad7284f9daa6d6d70d98817/msgpack-1.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e8cdd1f3e7cc52c751092a9bf740e81e6919ab109cd376ae2d965dad0bbae34", size = 83734, upload-time = "2026-08-27T10:02:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/75/35823e4419df8792191b2a17ae3fe71b41d02c162b2c491c94d1a87f0caa/msgpack-1.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1814f92306ae7862908e9ece7cfd90e0dc87ded3e89b6ae7ffdd1175d6376fdc", size = 405635, upload-time = "2026-08-27T10:02:27.012Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d3/6592e4064619b04f2dd0054c5fa13e37e3d55eb26044483d871fadb2f46b/msgpack-1.2.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d24b38a825bcca41bb956de50eb98451ef291304a8607fad99e619043d3e79b9", size = 417332, upload-time = "2026-08-27T10:02:28.776Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a1/b21c6818a545e9a4a976ac954a5c250eecde9a02e0ec82f415473dab1324/msgpack-1.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34e83e345194a2a51d8bd447dea9de2104f91e75b247f4735f14f04529f0746b", size = 374378, upload-time = "2026-08-27T10:02:30.678Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8b/7ada15c7b64151d6dbb562d1b091520efb2c37acf2403b1d4ae13797b27d/msgpack-1.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:682804bf31e43d46e51a9a33bd575b51e839d715ce6bd5612c055f7b28ad637b", size = 395809, upload-time = "2026-08-27T10:02:32.322Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f7/96283e50f7020df4dfeacc55612b7a210c8cdf0dda48bc262f1f9b3e4c49/msgpack-1.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9b659d77f8726fa5e7038967dda6b68d53cf34472c094cfa5b845454713b90d5", size = 373495, upload-time = "2026-08-27T10:02:33.832Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fe/1548dede9d9ca482f2d424a2e110a9705d4e02627a16b8bc8d10ce0208a2/msgpack-1.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d9a562aec0a92fe536da2e533d313b3d2a6b929157b1dec7ff623446dc0a8ab", size = 414360, upload-time = "2026-08-27T10:02:35.396Z" },
+    { url = "https://files.pythonhosted.org/packages/77/9d/4419b8f86c219174b1fb8bbd7faaf84a548935f7b1916d028401b9433417/msgpack-1.2.2-cp313-cp313-win32.whl", hash = "sha256:a4161eee7799863aee237c35c90427861f7b994416dd81ae829f560b0a81bdcd", size = 65196, upload-time = "2026-08-27T10:02:37.007Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f8/593f5caf0dacab41cde1564c5f0419e61af55ec9628006205e8fd5eb5e03/msgpack-1.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:b07c03f0da7e5279170df7745ddc732d526c8a198208936ec1a95c11ed2b2d5f", size = 72203, upload-time = "2026-08-27T10:02:38.28Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/c6ef92046b4a2bbb9d3aa0cb581cbf4a4051afccf6e5fb301a1bd3086f39/msgpack-1.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:d13d07efbf655f9ae7a2352b630c52727b359005b21ba08a507585c9ac8c0896", size = 65435, upload-time = "2026-08-27T10:02:39.534Z" },
 ]
 
 [[package]]
@@ -2383,7 +2453,7 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "2.3.0"
+version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ast-serialize" },
@@ -2392,16 +2462,15 @@ dependencies = [
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/6a/878cc1097d4035f82bd516658d0c528d2a9955bc7b363afcbd0b07fea11b/mypy-2.3.1.tar.gz", hash = "sha256:47c1b1207258513a9d93495f69c8be9de73916186f0e52703e8c461b7a623419", size = 3992554, upload-time = "2026-08-15T03:03:38.549Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/ae/f7d056eb0294586a572d0d0d89580ec633c064db520f11d37d5a2fb833bd/mypy-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:91ad22a52ae2c7e621c2f67c94d5a17f66b3209a4cff5cf8a573579835c69e97", size = 14947298, upload-time = "2026-07-13T11:27:47.734Z" },
-    { url = "https://files.pythonhosted.org/packages/32/d5/db3e7af01e7844d21662c6ddc1f7825ec7cb4053f0391ac02faf3638396f/mypy-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99ac767cc5d3b64c8d0ae226ead10c96694f94e4e7da1668642225dcd4e75aac", size = 13950768, upload-time = "2026-07-13T11:27:57.726Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/fb/43c031f0190513d1ec248ed037eceb742ddd2a4d74bbf406658a28173837/mypy-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de6d2c484742a4d7b0ed6d07b143375624d3b899c5749c7b3c947f56261f48a6", size = 14151586, upload-time = "2026-07-13T11:29:18.615Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c3/f8b2ffc60883084da91be51af58e88a7ffd4ff9795acb7d902ff88d31eb1/mypy-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7da939dd335cfd2ad788bdfd081c9f4e47634ab995e5a45eb15fd1e5bc052f8b", size = 15227411, upload-time = "2026-07-13T11:30:29.904Z" },
-    { url = "https://files.pythonhosted.org/packages/83/2e/16b917fc7adcf03f1aadddfc93aab804ffb234b1ab09c0ffd6d92a5d34a2/mypy-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7247eb2824f996722a949530183394921ca71deb9680052a338cf53cff7925c2", size = 15478790, upload-time = "2026-07-13T11:33:14.686Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/88/aaa65a93c73d0cdae7e42f8adb302bf6885bb281302084f99d0290a35347/mypy-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:75b0984bb3cbd76bb5c9291a8671f7ae66ca3b51c7584c358fc2e923259f0757", size = 11234919, upload-time = "2026-07-13T11:33:39.28Z" },
-    { url = "https://files.pythonhosted.org/packages/35/19/b40de63f1a80e63bc2d40f0679a6a8dbd34e95176c8122119bdf406aa552/mypy-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:d78fcf900b59cb7e82cb7e3a235e31b462d9333d92285bd1e4952d355b8ffba1", size = 10201510, upload-time = "2026-07-13T11:31:52.619Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cf/862010ee800ca9c2bd0c4c0dacf0f092e5411824a09b8f97ad4be8fe250e/mypy-2.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:114dff494000f18bd10d5d95d84b8567b26da60279ecbe838131841df20e635d", size = 13964542, upload-time = "2026-08-15T03:02:21.43Z" },
+    { url = "https://files.pythonhosted.org/packages/75/5a/3f3a2107b41e3e92e617e25daaee121413b91e9784bea733131ed4fecc5d/mypy-2.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8637731bb5eee3671eb2c3200827aa3564ed8a9309ecee4d1afe77e6d031bdb", size = 14168922, upload-time = "2026-08-15T03:03:00.351Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/41/04dc4fe7e63d7820fa4eff272e95157d30cbea921388f3ab3fe77794cd0b/mypy-2.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c80fbc405ed8020f5ff3802dc18cf060197bcdd3fbdd6a26ef2fd34dfdd5226", size = 15244791, upload-time = "2026-08-15T03:02:31.089Z" },
+    { url = "https://files.pythonhosted.org/packages/96/fc/c3053b26b9054949285aa868cb6af8c10e7591541cacd79c5dcc06a1fcf9/mypy-2.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:84081f538ce27375045c02e3d7f81bd11d853400621ae245d87ce7b6c420ec74", size = 15501627, upload-time = "2026-08-15T03:03:34.128Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4e/d77daab008bbc4e5001374d7928f4a260d28f0e6747af444fc4763f7a310/mypy-2.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:e9144ac16fde007096f9563eb2041b4433c2d705c4218edeb79e7e9d01035ee6", size = 11243961, upload-time = "2026-08-15T03:02:11.952Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f8/7eb68c136e4abd30569fe31ef2bfcb7eceae9952cab80017c04cd09f5d0c/mypy-2.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:77ad9529e67dca28e511f5cd5671436584ce91f6d3bac159a353158187b986ac", size = 10213219, upload-time = "2026-08-15T03:02:26.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/41/9675c7a1e78edecfba0b79e587a52594c56e189368261dc7b3a7fffb9527/mypy-2.3.1-py3-none-any.whl", hash = "sha256:6ed5c7e3419083268e5c9258bd1c1ef91af44a9e89374dbcaf37b775716e72eb", size = 2754338, upload-time = "2026-08-15T03:02:53.4Z" },
 ]
 
 [[package]]
@@ -2415,11 +2484,11 @@ wheels = [
 
 [[package]]
 name = "narwhals"
-version = "2.24.0"
+version = "2.25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7b/6248dada39781db1ab3ebf08943080df0796098515a87f6f8696d14ec744/narwhals-2.25.0.tar.gz", hash = "sha256:62c036c810662bf7820b7737077176313bc59350eeeefb808510f388c743e4b2", size = 677076, upload-time = "2026-08-20T18:10:15.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl", hash = "sha256:1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f", size = 467373, upload-time = "2026-08-20T18:10:13.834Z" },
 ]
 
 [[package]]
@@ -2491,7 +2560,7 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.28.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flatbuffers" },
@@ -2500,18 +2569,18 @@ dependencies = [
     { name = "protobuf" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/12/3807e2b17d9eb71d3cb78ed2ba76869b05c637c9b9d6112e636098b0c97a/onnxruntime-1.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:31410f544674f534c2f27348af52ef81682ca9c8719154bf4d48f0ef23823b1e", size = 19141759, upload-time = "2026-07-25T01:21:53.765Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/23/b46045c3bf67a9cf54c12f5df0f018a422c65fbb9d6072b10071bebfaae2/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f649dd6f6452d12a8059888aa489fe519e062e18793dac72b9efa0f9fdb64135", size = 17049339, upload-time = "2026-07-25T01:21:43.005Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b6/8c5396e7894e77c5a7d1e026f3acb9dd39c4b5644e412e37a0055eaa3bc5/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fa221d669282bd8f582708ce4c96010a7e9fb0661f9006b37fe2fedafb73fe", size = 19214329, upload-time = "2026-07-25T01:22:04.133Z" },
-    { url = "https://files.pythonhosted.org/packages/56/f1/51225c202edba4dfc94e1ea03f3d78f1aaf307da75fd792c0ce1946b2514/onnxruntime-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:1a1a19175464665c9b8d50bc916f216cc0b569110045b7bbca8f9f290b186f58", size = 13755033, upload-time = "2026-07-25T01:22:29.302Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/db/f59f715edfdd96a051f32b5ef0e680a20a8755d4ecd75f63090e960e347a/onnxruntime-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:cfab507abe09d6ffeb817eee07944d452fdc0b00fdcef34cab4db10a45e378c7", size = 13454175, upload-time = "2026-07-25T01:22:19.912Z" },
-    { url = "https://files.pythonhosted.org/packages/47/28/810314fa88647af9f4cdaf438a30ad1cfebebb53ded55499232d7a0094e6/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac301f53b1930402fc46c368e268acfed02f3207272aaff05070d7e09f96f031", size = 17057307, upload-time = "2026-07-25T01:21:45.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/cc/9e9f193cc0f29f263a8f09ec08487aed6c96ee856d5fd77da32a425c1949/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7f022a1103cae591c75fc4565589a515f2ddd14a6ac8e8a05812dfeda142e28", size = 19222954, upload-time = "2026-07-25T01:22:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/d375facf60edaf41f5732f9f689c98a800fcc52df5cf6ddfb406703eb5a1/onnxruntime-1.29.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:be0f8ed688cfb1d4d5765a137193b7bfab0c8ea214eed99260b380bb525a3a7f", size = 21429708, upload-time = "2026-08-17T22:54:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/b9ad04051a8c4f504852ce0e8e10f9a6b2f1a331eedcdcc503df776dd0ea/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d67673c5367727860922c5262d724472f1b5539fb7ccf4c81a638f9b71719803", size = 20816263, upload-time = "2026-08-17T22:54:04.088Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2c/d8eb945d2a372149df9705a8d5c8d7c6c46c987c5446dbcea9e1ea7f6556/onnxruntime-1.29.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e2128f31f449e922c62dbe5d8b6b7b079f0bcaf2d56a102fa203cb6e5bb5ab19", size = 23136817, upload-time = "2026-08-17T22:54:06.714Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3b/66b424c63fa92dfaa48d1719efaae66fc8c256b9426a832eda51d8dfe1e9/onnxruntime-1.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:2945e1f82f81f27e88decea88c7861f45baea23818950d467bf3909aa303119e", size = 14001310, upload-time = "2026-08-17T22:54:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/83/22/d6a700e3a6322fa3d56fbe7cee9ffc53f35e77ffcd6b7e97f4b7722a27ab/onnxruntime-1.29.0-cp313-cp313-win_arm64.whl", hash = "sha256:4b940b0d777590c7e20bf298f5c16af1ea6ad1b400a1c822a6be192f64f4d954", size = 13747112, upload-time = "2026-08-17T22:54:11.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/89/c4af146de3d60a32c89fea48d5d34bfd044faaf8957270043a03bd1b462b/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:533f8370ce124304e5cb08ab961836cf755631e3dd77adc5f3bbdab70c2b7d99", size = 20826136, upload-time = "2026-08-17T22:54:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f2/e6bbacd11dfe8d070613261a758795ea128b9fc9bea391a2a7da2e4c7a08/onnxruntime-1.29.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c1ad3f437153fe77f9d01a08fbaac0beb030e09b8a80ace1603bcf69b6c95481", size = 23138951, upload-time = "2026-08-17T22:54:17.154Z" },
 ]
 
 [[package]]
 name = "openai"
-version = "2.53.0"
+version = "2.54.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2523,9 +2592,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/cf/36e3e7235fdf6d125c052acc0970924611b17a20a4fe580596faf4566a65/openai-2.53.0.tar.gz", hash = "sha256:baf5802ad08980e1d9d561e1b996e800c8bcd14af5847c6d0e7a5cc59e4d4116", size = 1099435, upload-time = "2026-08-03T21:42:01.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/9a/8c75e8c8a5b407a0586faeb2afac91674ff955c191ecc1d6d3b6669f6788/openai-2.54.0.tar.gz", hash = "sha256:e3e6f8bc1ba30ddf381ace1a14340eed381cb984a1a59bd0f34b5be3b5d49cfa", size = 1100285, upload-time = "2026-08-11T18:46:59.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl", hash = "sha256:c694ffc747a3c4d1663ef2b07b811315a476164ee5efa3a993967349ebca7618", size = 1659829, upload-time = "2026-08-03T21:41:59.581Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a8/bb76c7356de8ad57f59d5ff993d434df0607f07f08bcc9c9a5c275e399c0/openai-2.54.0-py3-none-any.whl", hash = "sha256:89089789197ccdb87f173a03145ed1598d00795220c93e96cf712b1cbf5e5f2b", size = 1660351, upload-time = "2026-08-11T18:46:56.684Z" },
 ]
 
 [[package]]
@@ -2656,25 +2725,21 @@ numpy = [
 
 [[package]]
 name = "orjson"
-version = "3.11.9"
+version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/742fb1f62b825f2c010697eaf4e828004bc2a81e7e806666989c132c7c42/orjson-3.12.0.tar.gz", hash = "sha256:d14203fb1aae2ad9b3d52f8a0e82aeb10197ef1c9bc61da7f358bd70b00123d5", size = 4142915, upload-time = "2026-08-14T16:13:30.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/33/93fcc25907235c344ae73122f8a4e01d2d393ef062b4af7d2e2487a32c37/orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021", size = 228458, upload-time = "2026-05-06T15:10:20.079Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/27/b1e6dadb3c080313c03fdd8067b85e6a0460c7d8d6a1c3984ef77b904e4d/orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c", size = 128368, upload-time = "2026-05-06T15:10:21.549Z" },
-    { url = "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81", size = 132070, upload-time = "2026-05-06T15:10:23.371Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/26/d398e28048dc18205bbe812f2c88cb9b40313db2470778e25964796458fe/orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a", size = 127892, upload-time = "2026-05-06T15:10:24.714Z" },
-    { url = "https://files.pythonhosted.org/packages/66/60/52b0054c4c700d5aa7fc5b7ca96917400d8f061307778578e67a10e25852/orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10", size = 135217, upload-time = "2026-05-06T15:10:26.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/97/1e3dc2b2a28b7b2528f403d2fc1d79ec5f39af3bc143ab65d3ec26426385/orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362", size = 145980, upload-time = "2026-05-06T15:10:28.062Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/39/31fbfe7850f2de32dee7e7e5c09f26d403ab01e440ac96001c6b01ad3c99/orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97", size = 132738, upload-time = "2026-05-06T15:10:29.727Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
-    { url = "https://files.pythonhosted.org/packages/11/d4/5bdb0626801230139987385554c5d4c42255218ac906525bf4347f22cd95/orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9", size = 141492, upload-time = "2026-05-06T15:10:32.641Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/88/a21fb53b3ede6703aede6dce4710ed4111e5b201cfa6bbff5e544f9d47d7/orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677", size = 415087, upload-time = "2026-05-06T15:10:34.438Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/57/1b30daf70f0d8180e9a73cefbfbdd99e4bf19eb020466502b01fba7e0e50/orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4", size = 148031, upload-time = "2026-05-06T15:10:36.358Z" },
-    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/cc/2d10025f9056d376e4127ec05a5808b218d46f035fdc08178a5411b34250/orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32", size = 131613, upload-time = "2026-05-06T15:10:39.569Z" },
-    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
-    { url = "https://files.pythonhosted.org/packages/91/2b/d26799e580939e32a7da9a39531bc9e58e15ca32ffaa6a8cb3e9bb0d22cd/orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254", size = 126696, upload-time = "2026-05-06T15:10:42.651Z" },
+    { url = "https://files.pythonhosted.org/packages/54/cb/d7b78218a987eb8a8ce4eeae0286b1bb679333eb631ea0eeaf6371680bfc/orjson-3.12.0-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9a36ec60f1796f9a3f13e3b98390295e17a1c7c10155b448d264098bf9ee5900", size = 223397, upload-time = "2026-08-14T16:12:44.003Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4a/bc87c45e7ec639d35ebefd62618e01939531ac8e171426606a01bda05914/orjson-3.12.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:ad0422b92d5195443a39f80c3bcf731cc2e00f153bd32063a47b73b057bd0f03", size = 123662, upload-time = "2026-08-14T16:12:45.433Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ee/c9a4ff3f2dbedbbe9e635d0fa72c8866adede09b6335ef9644f53752f0d8/orjson-3.12.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:5a0fdbc216388f653d3752ff310e710f59253bd4ed6a2bfb3f4f06b84714bbd8", size = 113374, upload-time = "2026-08-14T16:12:46.755Z" },
+    { url = "https://files.pythonhosted.org/packages/75/09/3f330a026a796c8b4c97a6f429652a5e912e7065039bf96ed25e42aa7b25/orjson-3.12.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2eb5c56e534127b2b8fa38d2363c8b1b8190367ee0d1d16c041517d880843b94", size = 130029, upload-time = "2026-08-14T16:12:48.06Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/40/094cc53126a3d22f76cdf83b6ea67338bed01d774037621a785aa8e6e5ea/orjson-3.12.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:784106539f4b9d4b930e0b4eb8d45168507dae001945e71b4675a367f1e5e806", size = 130528, upload-time = "2026-08-14T16:12:49.362Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/74/89bb236deb9565f99434b13052bb40ddfcce4adf3afbfa3132ee7e421468/orjson-3.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c680706fc8396d95e7c4c1f9482563f552137aef91b57237a3ad5aaf64629df", size = 131075, upload-time = "2026-08-14T16:12:50.692Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ac/1176360d762c01b5bd34acd56fc098e936c491363d8b6b397ad4aa475547/orjson-3.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:83445adc40cba26d6d621185a45128ce455b766af368cad2ab64b970603a7978", size = 135321, upload-time = "2026-08-14T16:12:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/02/bbd881c8b9276d50b998de38b4e97de8ace1aac940b0ee545aedbf65ed00/orjson-3.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:644d005bc82f917337a95ce270c9f6f92f9834c2bed7b1477572f8db00784222", size = 127472, upload-time = "2026-08-14T16:12:53.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/02/a0934d7503e6dcbedd6afac3e7f3f8597fd09389949ad94d0f7540e9dbca/orjson-3.12.0-cp313-cp313-win32.whl", hash = "sha256:d8e78d3d93705e3d27cc17cdb209e44d7a8ea203010cac6ce9c7ffc1ae1996f1", size = 128000, upload-time = "2026-08-14T16:12:55.14Z" },
+    { url = "https://files.pythonhosted.org/packages/52/87/69f98f8d40faff103a965a5fbb83f08241b01beaf92badb5413fbc9358cc/orjson-3.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b85931be5b6763c31283805c9bdaae1ca03ad9f6f12a15f1cbf6745b907932c2", size = 121841, upload-time = "2026-08-14T16:12:56.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/07/b83046a4e3cadcc0987d0f160696107c4af706a619b56e4ad01940cadadf/orjson-3.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:6a31348d7dfa64cd9c78bd1f510ff44c48fe64d71094e6b90e364dba3b55949e", size = 126765, upload-time = "2026-08-14T16:12:57.806Z" },
 ]
 
 [[package]]
@@ -2919,24 +2984,24 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.1"
+version = "4.11.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/0a/062135c9a98dac804265073cc3afdbec5ae1aa37980bb354f461bafe81b4/platformdirs-4.11.1.tar.gz", hash = "sha256:bb1af68078f25e2f3e111e2d43b8d536df41b73c8a684b40bb018223b66fae27", size = 32396, upload-time = "2026-08-07T23:06:48.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/06/cf1564dcc2e2261c8c8c6c05628dc8b418943bdae2a4e58640ceb2f770fa/platformdirs-4.11.5.tar.gz", hash = "sha256:e8b31f4f8bcbbedef91a6b57a706255e4f148d2a4e01648382a0a47342539173", size = 34823, upload-time = "2026-08-27T21:36:37.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/85/9b31b44296cfa3bb56cddb35e6a0f6578bab0b490c0806c0245e32c6110c/platformdirs-4.11.1-py3-none-any.whl", hash = "sha256:2efd27d363e8dd2e661639ffb398865a5e0a46442a11d266bf375a0e0c10e386", size = 23261, upload-time = "2026-08-07T23:06:47.219Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl", hash = "sha256:89f8d42695853b89c7170bd49bc3dc593f98a71e695ede88e06a3b247bc4563b", size = 23900, upload-time = "2026-08-27T21:36:36.227Z" },
 ]
 
 [[package]]
 name = "plotly"
-version = "6.9.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "narwhals" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/07/795c79dbce40c39bece88e69d049babbd23ffa95b5d117f248db8ea03abb/plotly-6.9.0.tar.gz", hash = "sha256:967ad33e8c704fed051800d11d985eb206a9c795c14206b30a6f463ed9c67d0d", size = 6919903, upload-time = "2026-07-09T14:55:59.982Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/9e/8894e8eae20a5b2a44aa568b1d2d80291e8eea6ce7bc75cdc7a152aef0ac/plotly-7.0.0.tar.gz", hash = "sha256:08b21f1244a97e7a1a699833c4bb2678475aa108b3f1989886ed0b038ebfd849", size = 6218668, upload-time = "2026-08-25T17:47:29.088Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/18/d8544811ab076f876c4892b3714f5b0dad335e1dc33aef826df431b8325d/plotly-6.9.0-py3-none-any.whl", hash = "sha256:36bebe2f1bb13884774fe61689c329071446f6ce4a8927fb1f0d6fb24f581236", size = 9909646, upload-time = "2026-07-09T14:55:55.421Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/2f/6f492108d9955bac97979d9949c1b35eab30fc630b1f22bbdd2c7cacbab4/plotly-7.0.0-py3-none-any.whl", hash = "sha256:78cbf7bd06d1b05bb3b8ec1b709864695229b55151b6f7530fbf55517ead6fdd", size = 9052859, upload-time = "2026-08-25T17:47:24.689Z" },
 ]
 
 [[package]]
@@ -2978,7 +3043,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.6.1"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -2987,9 +3052,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz", hash = "sha256:8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441", size = 198670, upload-time = "2026-08-10T22:07:18.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl", hash = "sha256:e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e", size = 226202, upload-time = "2026-08-10T22:07:16.942Z" },
 ]
 
 [[package]]
@@ -3086,17 +3151,17 @@ wheels = [
 
 [[package]]
 name = "pyarrow"
-version = "25.0.0"
+version = "25.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/e3/27f57f80141379d60defe6703eb50a707325706f07fedfd1312c7a751995/pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a", size = 1201653, upload-time = "2026-08-10T12:40:53.904Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/c8/098ce17d778fd9d29e40bb8c5f19a40cc90c3f0b46c9057b0d7993f42f54/pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc", size = 35844549, upload-time = "2026-07-10T08:27:37.956Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/66/24c28877219abf6263d909b1592c97ff82c59f13a59acbed11fc87c0654f/pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e", size = 37610397, upload-time = "2026-07-10T08:27:43.803Z" },
-    { url = "https://files.pythonhosted.org/packages/53/55/6d1d5f5aff317ec5de9421594679ed51ed828fe7e2ce209327f819d801e4/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be", size = 46841701, upload-time = "2026-07-10T08:27:49.741Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/5d/f790fb6965ab54c9da0dda7856abc75fd0d7648d865f8d603c111d203a64/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9", size = 50090118, upload-time = "2026-07-10T08:27:56.051Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/8c/faf025357ebf31bc96777f234277aa31e2aeca6dd4ecaa391f29085473c2/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d", size = 49945559, upload-time = "2026-07-10T08:28:01.927Z" },
-    { url = "https://files.pythonhosted.org/packages/07/a1/bd051871708ea99a5e0fc711926c26c6f2c6d0130c7aaac8093e34998af6/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1", size = 53114238, upload-time = "2026-07-10T08:28:08.594Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/31/737f0c3cffcd6af647849477d1dd68045deac2e3963c3f9f211bedc48540/pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18", size = 27861162, upload-time = "2026-07-10T08:28:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8d/8f271a7a034c834910ec925d56fa4b29733b1380f5289419f5aaa3b02777/pyarrow-25.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:c7c534ec03c358a76ea3e505e74c1b6aef290af90c444dfd092dbfe23e755b85", size = 35855328, upload-time = "2026-08-10T12:38:45.489Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cd/5bac242f4e841b9971d5eb94fdfe2577e2b70be983e27401e72055786037/pyarrow-25.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:dda9470024204d7bbf2042b47c6e8a0e47a3eeb8e34405882dfaea6577e0c153", size = 37622415, upload-time = "2026-08-10T12:38:51.107Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1f/96d03b4e1506524f7087adb0fd6b2f69f0c9c7aaff1ec36d8030082e15a5/pyarrow-25.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:44a9120ce5bd81936b8ab9a88076e3fd47c2c6838e0e43630fed83626aca81d9", size = 46813813, upload-time = "2026-08-10T12:38:57.773Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d6/33a411115b61dbfc16ad6ad73e71730f6fea654ee3667673bc53ab0e2fe7/pyarrow-25.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0befcf816e45a1af33ac775a9970b749e4868a230c7372f0ae5e932bee27039f", size = 50104452, upload-time = "2026-08-10T12:39:04.579Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ae/b1b97c9ca87f9f9ddbb5230c798df94eccce61bd79b9b45458c69a478588/pyarrow-25.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3f89685964f46e4216103c75483aac0c0692a5f72212d7ca835adba5ede56ce3", size = 49951343, upload-time = "2026-08-10T12:39:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9e/a112df5cfd5a68cb1d9fc31cfe38c28d5aec9f10865ce37ecef2e4450873/pyarrow-25.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6943e2fe7954d29d84de45d29d34c8dc36ce96570e67d89aa9976e650a4a9138", size = 53144784, upload-time = "2026-08-10T12:39:20.503Z" },
+    { url = "https://files.pythonhosted.org/packages/31/24/97e8bd98f1e3b07e2ba08bcdff690674fbe16d69a7d2712cc3884665e615/pyarrow-25.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:31e49a7888fcdf3a835da33ae777f6bb9a866334e5a789282fc26dcf426f7f15", size = 27870159, upload-time = "2026-08-10T12:39:26.161Z" },
 ]
 
 [[package]]
@@ -3197,7 +3262,7 @@ wheels = [
 
 [[package]]
 name = "pygithub"
-version = "2.9.1"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
@@ -3206,18 +3271,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/9b/195603d5371861005a3467c5e4afd02fd0698795a2aa36dc41498b9d879d/pygithub-2.10.0.tar.gz", hash = "sha256:90ff24ef1cd1bd57124c2a3869cafee9d7b066909129ecdaba2c2d1903bc118d", size = 2750952, upload-time = "2026-08-20T10:05:08.327Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
+    { url = "https://files.pythonhosted.org/packages/91/71/f314841697a1d52af3e1ea7c5e1c3f09685b64ae4c58ff16b605a866255d/pygithub-2.10.0-py3-none-any.whl", hash = "sha256:192ada2a76e4afc7d6b37e500c9bfeba1731e6506697445a5ba1c4af8bf0b924", size = 455554, upload-time = "2026-08-20T10:05:06.991Z" },
 ]
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
 ]
 
 [[package]]
@@ -3236,15 +3301,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0.1"
+version = "11.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/17/2db4b414de89659144488e0d9c6c0bf0c8395841dc12d81d0532cc6ef310/pymdown_extensions-11.0.2.tar.gz", hash = "sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d", size = 855419, upload-time = "2026-08-22T19:28:47.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/43/9f45ec4d14e596efc32c925a78104934790438b0c0628b70d741016734ad/pymdown_extensions-11.0.2-py3-none-any.whl", hash = "sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5", size = 269929, upload-time = "2026-08-22T19:28:45.389Z" },
 ]
 
 [[package]]
@@ -3281,31 +3346,31 @@ wheels = [
 
 [[package]]
 name = "pypdfium2"
-version = "5.12.1"
+version = "5.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/42/0b51bdf50ccf13f3deb3209ca996179a49761dc191748469cf0de55b0055/pypdfium2-5.12.1.tar.gz", hash = "sha256:d0e0648fb2e28f50efcd1ec0a5a18ced9f4d66b2c227fae9b603f0a883b2d13f", size = 274428, upload-time = "2026-07-17T10:01:22.713Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/78/a52cb80611339ec95f35c7a10d7bfe7a6f97f3b50a35a9f94283d062512e/pypdfium2-5.13.0.tar.gz", hash = "sha256:7ca2d8e31bd8d0d40c496416b7d8bea423388669ffd494929f50e8c3a82326b8", size = 273639, upload-time = "2026-08-13T10:58:15.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/7e/bd8df53b1131c582f6646372047b49162032bd01628d49b9a60cd94d2181/pypdfium2-5.12.1-py3-none-android_23_arm64_v8a.whl", hash = "sha256:05bab9b1ba2de7fc299ae2af25cb9c8a0543bc8bb893e879fe8c9ba8310e9ce4", size = 3392276, upload-time = "2026-07-17T10:00:47.376Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/13/a2b71e17b0439d2af78c817a381e3557371c6c56098581da8485aef65ea6/pypdfium2-5.12.1-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:d4ee061e566a6422b660cdddaaa799a2d1cbf2f016921bcaf24d61426d01d942", size = 2848776, upload-time = "2026-07-17T10:00:49.09Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/a8/d7a61700db3022792b28bce5264be90a7d2e7104998362af6b93766f50b2/pypdfium2-5.12.1-py3-none-macosx_13_0_arm64.whl", hash = "sha256:66a9ed40d70a5d728cd42148fecb9d7a0917c6161d6bb67c844093a4ed1df089", size = 3480243, upload-time = "2026-07-17T10:00:50.674Z" },
-    { url = "https://files.pythonhosted.org/packages/01/2c/d7a38fad74b6da0947cf8763aee0f8e6c9d3c12fc8e137aa615f7f8ae76c/pypdfium2-5.12.1-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:847378a5ab41332998b2621b21bab2e96dc8c3eff36a08bce26695b964163983", size = 3643490, upload-time = "2026-07-17T10:00:52.236Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/29/aca739676323558595fcf8cdc8d7939d2b25aaaa6f538e829f1fee938cdd/pypdfium2-5.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eabf028ad8e7bc7811c9acf3a72718c180569b624b844d2c6cc974609784275", size = 3649734, upload-time = "2026-07-17T10:00:53.776Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/e0/e4ecc05f4f1a11d11c8d684a24b2fc8be8207f341be985dac301caa4f6aa/pypdfium2-5.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7857cfa6642ec5a09db12ff8f5cf6b6494585b5e3a605399fddc4fb862837b63", size = 3380828, upload-time = "2026-07-17T10:00:55.377Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1b/c94c9d486791276e736350917a11fe2cf3acba2c6c7f03f9ac0d51f8952a/pypdfium2-5.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05bfa20a08a96584253bbe38b60e13f81a037eac31c5579e607ec1480ad25dbf", size = 3777202, upload-time = "2026-07-17T10:00:57.212Z" },
-    { url = "https://files.pythonhosted.org/packages/14/aa/7f81f0c035fc32850dfab9daf78530814f215be226dad7491e3caa0a3e8c/pypdfium2-5.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f059f7bdbdf4352eb83691071096940d769d6ae5930b8734237fdb1bd78fbc2", size = 4186083, upload-time = "2026-07-17T10:00:59.022Z" },
-    { url = "https://files.pythonhosted.org/packages/23/16/21420a6f2bc5f981299c336817dd5d72709dad5fda30ac38cbd5f0f7b372/pypdfium2-5.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e10cbf41b21233ec5e20adfc170cf60edd77abead86a97dc708fff55a8a886c7", size = 3701734, upload-time = "2026-07-17T10:01:00.952Z" },
-    { url = "https://files.pythonhosted.org/packages/36/a1/bb89f49e2b3ea3e945b67859d2ec6e73e722a83c006099c675692641e51d/pypdfium2-5.12.1-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07eeebb2784f4cd38d386b924235df43217a397442796673296bb6efbdaad1d0", size = 4030403, upload-time = "2026-07-17T10:01:02.568Z" },
-    { url = "https://files.pythonhosted.org/packages/80/a7/cea5eb0c39e9c6fdf9853a3008bf021d08f962228073af90354b60c5ccdc/pypdfium2-5.12.1-py3-none-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5c3e6cbe43581af79526184643920ab03a9401a0c79f2226bea9d4d1e3d34008", size = 3994411, upload-time = "2026-07-17T10:01:04.25Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/43/5e470213b27c13b0d94d03d97fc3740507edadea1d1e2ce2049bfbec4aa0/pypdfium2-5.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4648f0905441bcb141687ca2263bbf38a1aa056b943eef06019f91cff3e1da4a", size = 4993687, upload-time = "2026-07-17T10:01:05.811Z" },
-    { url = "https://files.pythonhosted.org/packages/db/da/af7972ca72f24ed720db6501333fd67bc66aa6aa5a5ec698551bd30ae62e/pypdfium2-5.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:bdff622181fab64f32328591c9c8287cdc745c9a1f2afc26ca3feba39e3e6645", size = 4534560, upload-time = "2026-07-17T10:01:07.291Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/63/06a7f2cd691f7e336cbc53fd65453fee516042c8ddb016bc50d1cd2bed45/pypdfium2-5.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:236dbdc88aa54f14b27937ccb2ebe3dcf08c10dbb8652f432ea982dc9af39732", size = 5237681, upload-time = "2026-07-17T10:01:08.997Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f5/937b080671758ab0b3d3d69b2657006682e4c6a0134b36774be4ed1afcfb/pypdfium2-5.12.1-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:9c8856ce7dd77a7827476c7d75afe1197d6cd505f5cb4167b6aacf661f3f8ea5", size = 5143027, upload-time = "2026-07-17T10:01:10.69Z" },
-    { url = "https://files.pythonhosted.org/packages/32/02/094632700c24728fa443dc89d9d1c6e4fc05bb00778b22e8482fdb133da0/pypdfium2-5.12.1-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:5f257bb40fa44ce9ba18d2c919777dbd3f16bf22548b1d68fd56c7c92f1de530", size = 4647048, upload-time = "2026-07-17T10:01:12.559Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/d0/12d84bf55a4fcf2c0ed242afc94168933194f672067e1d162aa60a8e4426/pypdfium2-5.12.1-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:974082344172da76a5c3c0782eaedfe6069dbe88db77d8c671ef36b61e9b14e2", size = 5088747, upload-time = "2026-07-17T10:01:14.42Z" },
-    { url = "https://files.pythonhosted.org/packages/92/9c/92a460bac1f6cfd6f96251802b3098a804fb251dfe0b5eb004ede958ae0e/pypdfium2-5.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:715ae16b34ea1d64884d58800155179ba700e9ea65a2f583b020666acd2bfb12", size = 5049695, upload-time = "2026-07-17T10:01:15.961Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/67/53c61d366222550220b42a9212131407f49d3dbcf050178c620bf80fa899/pypdfium2-5.12.1-py3-none-win32.whl", hash = "sha256:e5358d2ce4ebc5c899aab1df9ca5d215357244e9168aa443225d3c1e649c7eac", size = 3725466, upload-time = "2026-07-17T10:01:17.773Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c3/08b62718faf2f6b6aa49207626e3113ff3ec1b3cd076c0ef8fd852f0e57c/pypdfium2-5.12.1-py3-none-win_amd64.whl", hash = "sha256:9609be73a6701a68f29dffe0335f7a2e4b3ba581542ed65d35d49f761a4600ca", size = 3859845, upload-time = "2026-07-17T10:01:19.417Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/d5/ad551e55790134c8bc87ea16e0866a3721def0620fbfa19112c8ad4a25a6/pypdfium2-5.12.1-py3-none-win_arm64.whl", hash = "sha256:afc0b7e0c975a429abc75875209ce17b66d749f6ac5cbe8ba72470e83901e304", size = 3674605, upload-time = "2026-07-17T10:01:21.008Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9c/a49050af85055054299c7fab658ac63f8fddde575774aecbf8f71c7a9e5f/pypdfium2-5.13.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:882f4bbd4b17a335b43603169a14cde9341de12b238acd5c39e690cbca7c4293", size = 3417299, upload-time = "2026-08-13T10:57:40.522Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ad/f23027328843ee2bdd05afe16bb101f5906befd0c70de35fa8c53f60a5ff/pypdfium2-5.13.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:d96929bde3bd64c771ab3558ca1ffd7704cc4d872ab92cd9f8f8b8a20f7f36b8", size = 2864708, upload-time = "2026-08-13T10:57:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/08/99/1fe58428b69d2722dcbcfaa08ce71834a332c5b518fd58874bcef936b823/pypdfium2-5.13.0-py3-none-macosx_13_0_arm64.whl", hash = "sha256:da5c7b74eebf40b5c1fbe1de01aa1edc8827a79fb1efd999616bc20dcaf77ba4", size = 3507415, upload-time = "2026-08-13T10:57:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/06e26da88a4f5b4ed289325868717a186020661b7b221aa6df622711d31b/pypdfium2-5.13.0-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:2abedfb5c70992b19c780ed58d7f7b929e8ce8ee52c9140158f44317c90ec6c7", size = 3670979, upload-time = "2026-08-13T10:57:45.607Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/31/f8210d53775f142be934336665b1d60e800c3f176f28c29b4908d945c518/pypdfium2-5.13.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ee8c2bb2e68b396ab4a763215ac100dacb6b96d0da5bebeb239a021aecc3a7e", size = 3676486, upload-time = "2026-08-13T10:57:47.267Z" },
+    { url = "https://files.pythonhosted.org/packages/94/50/d339fa09fbe592564b100bfc76833170a1104a764a458ac2abfffcb632f2/pypdfium2-5.13.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07f58e91b8c45ca144a1ff3008faf3c73ef8a5e9fb32988831788363288228cd", size = 3400883, upload-time = "2026-08-13T10:57:49.189Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e0/b10cf41b5e9f0212d014c40635659c6ab95bb4fcc6fc47f5d3c571f8d57f/pypdfium2-5.13.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:46b2f5be9e7ae941ee4216e3d20b66f9dc3d81944a3d57756272de5275204709", size = 3803912, upload-time = "2026-08-13T10:57:50.865Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/25ba4ce9a9059ece82f4514df0658fde0aa9bbeafe135e76017c052bf56f/pypdfium2-5.13.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d96beb7f379e6c76d874ca93fcd182ac3168dd499056407070f9927fb1061b8e", size = 4218231, upload-time = "2026-08-13T10:57:52.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7c/74a2fb48e5b0d2402d9ca64b39074c722d67e9a8a2c58449a843a8c2329a/pypdfium2-5.13.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81df25c1ab4c13ff773102d3cbea1967511d079123b067fc077bd0c4d57d91d8", size = 3730077, upload-time = "2026-08-13T10:57:54.021Z" },
+    { url = "https://files.pythonhosted.org/packages/59/12/8c922f00518c26dc47d3676cc09c1d3c95e991c1977e31067d23cc2215cb/pypdfium2-5.13.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d66a32d89fa5b4a2715810171239eb194df4aba604727483ab760512f3c6a851", size = 4031512, upload-time = "2026-08-13T10:57:55.736Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/48/a171d034c2dac01adcc57d3dad3c97ba11f19d916f421176002c9e02c904/pypdfium2-5.13.0-py3-none-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b90b0a5ac310bb34db8eb848e58fcab4e201e124e3cf3cb1ccb7b85293e034af", size = 3995485, upload-time = "2026-08-13T10:57:57.39Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2e/dcb24776d409bb9e5b7fb26a0c62a87b98ab0e30dfcca645eaf31e35123b/pypdfium2-5.13.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ada81c36483cd61d07e32bc7814620ee96256b4f421b913f566861bf91800248", size = 5016636, upload-time = "2026-08-13T10:57:59.181Z" },
+    { url = "https://files.pythonhosted.org/packages/93/24/1fab8470fc6de6f4481f009c90757b1a1ee0a61d8e864ed273f72ffca855/pypdfium2-5.13.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:3826e521e895648983cb9ee6b934d4bf51552600043984f84e9c2b3b14b696f3", size = 4555251, upload-time = "2026-08-13T10:58:00.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ef/6e8dbea1eddcb55cf34172753ffccd39566333c803cc94d43c653f369f2f/pypdfium2-5.13.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5c029d7163a91f264eafab51fb442a84a33efd9fd83d5a06c0136a7857a3cc8d", size = 5263483, upload-time = "2026-08-13T10:58:02.48Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fe/2ff673730189a621c01f9193c74b0f6aa70d8740889fdf11949e1c541869/pypdfium2-5.13.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:be2dccbde0ce7efe334ecd8f348df4308db360756ede4f0821d82dfc9a58caa8", size = 5144135, upload-time = "2026-08-13T10:58:04.351Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0b/759b9037c007317fa5c990dd3f6eff2b99d3fbced251d1e2512be92f2e2e/pypdfium2-5.13.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:bcd81394fe101405e026eedb3e40bef84635c1e5d974dd6036420eb6937753c6", size = 4648156, upload-time = "2026-08-13T10:58:06.036Z" },
+    { url = "https://files.pythonhosted.org/packages/db/3b/ffe29679c52efe8eb02d77aa6656e6d6201395423329af018ebd5923a3d0/pypdfium2-5.13.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:2ed32ff685f8e05e637c990bedbf5fca66727bf27718d8bc33eeab21ce0630d1", size = 5089852, upload-time = "2026-08-13T10:58:07.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/b6/cebacc1601ddfdcd1e6a1dc321533d215ceccf9b825fa9b91b11c6dc39fb/pypdfium2-5.13.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9c777edba28d1d5fd15435ed3a78ee2fdb93dd069be37cb53b559bc122793770", size = 5074153, upload-time = "2026-08-13T10:58:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/54/40/cf14c4f534f817788966857afdedb90002198dca5ce4fe2c6ecb031955ae/pypdfium2-5.13.0-py3-none-win32.whl", hash = "sha256:d33ee7077db67478b75efe4b5ea9610fb96c5416a0bc4949227f0f59c34dfcd9", size = 3753164, upload-time = "2026-08-13T10:58:10.97Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/99/a37b6b902457569468ed5908c94e56cb6c4032541f02cf89f723d42a9148/pypdfium2-5.13.0-py3-none-win_amd64.whl", hash = "sha256:47dcca2a8d507b5fd24f94c3c9d48fb379430f097bc20f01beff6c963ffbcedb", size = 3885553, upload-time = "2026-08-13T10:58:12.709Z" },
+    { url = "https://files.pythonhosted.org/packages/50/7f/d39f6e64375c2ffd50ea100e3c73af79085c880c2791eb7203bc61d8913f/pypdfium2-5.13.0-py3-none-win_arm64.whl", hash = "sha256:554a0b23376460af1410e3c915906895e2dac67a086b9e6ccde0643a795d3b0d", size = 3700026, upload-time = "2026-08-13T10:58:14.206Z" },
 ]
 
 [[package]]
@@ -3399,14 +3464,14 @@ wheels = [
 
 [[package]]
 name = "pytest-socket"
-version = "0.8.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/3c/f9b58e57830e58980dbe8867d0e348f45701d3f3ea065672d448f4366da5/pytest_socket-0.8.0.tar.gz", hash = "sha256:af9bb5f487da72be63573a6194cfac033b6c7a1c1561e150521105970f9e99f2", size = 13912, upload-time = "2026-05-21T16:50:22.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/ce/4ef7b049852c95a8727b4a7e6496f762df1ac0b47bc0320d10293f5e95ec/pytest_socket-0.8.1.tar.gz", hash = "sha256:2f57787914ad2e1308d09ce141b95c3e55741fbb4fb7b7556593a6b063e0c9c7", size = 17313, upload-time = "2026-08-19T15:16:25.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/e8/4a8568580bae3dcd678599ed8e86a82d505a44df71c1ced4246c1aa14b4b/pytest_socket-0.8.0-py3-none-any.whl", hash = "sha256:81821ba59f07d7600fe2b551d8714f40b068bd46e8b6704c48664e9d60cdacb8", size = 8414, upload-time = "2026-05-21T16:50:21.022Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ef/ab507f117b3d19b54e3c9c632a99c28c3b284562ec6e02e274581d530d92/pytest_socket-0.8.1-py3-none-any.whl", hash = "sha256:f9846bed1dcd96eed459e5e14795bbaf96715cf4e827891fe70773817ecb8ed4", size = 8751, upload-time = "2026-08-19T15:16:24.426Z" },
 ]
 
 [[package]]
@@ -3448,23 +3513,23 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.5.1"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b7/1581a8103855c43567776aa34135e5ec3c597346c23bfd10c7eb5e0b10a4/python_discovery-1.5.1.tar.gz", hash = "sha256:e2ea8b884cd1701f386eda8cf327b87743f1dc21b7f784470799537d95635384", size = 77200, upload-time = "2026-07-31T22:06:02.48Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/96/0f93e27c9f60a650838f2118159aa115fd5732c0716247917b7ba7ede665/python_discovery-1.6.0.tar.gz", hash = "sha256:6393b4eae1be8b2182670635e7baff89ac21cb9f8e86fd1ff40c7b1144febb4c", size = 82849, upload-time = "2026-08-28T17:30:02.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/07/a89b539750a159d5101c4eb9fc84e2961f65cefbd5e0b7440b284471c0b0/python_discovery-1.5.1-py3-none-any.whl", hash = "sha256:ac07f44cade589d954e9d6a1e1468539fdddd2cf676beb51da73e0f156b7c932", size = 35752, upload-time = "2026-07-31T22:06:01.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5e/21abf578182fb15006a57faf3711a1e659e29d600d19b6e557eae908c81d/python_discovery-1.6.0-py3-none-any.whl", hash = "sha256:d4e244cf17b8b29819ed78003d55fbacf86eda23425b075454fff9271b79377a", size = 38451, upload-time = "2026-08-28T17:30:01.236Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.2"
+version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
 ]
 
 [[package]]
@@ -3759,27 +3824,39 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.2"
+version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
-    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
-    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
-    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
-    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
-    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
 ]
 
 [[package]]
@@ -3814,35 +3891,35 @@ wheels = [
 
 [[package]]
 name = "scipy"
-version = "1.18.0"
+version = "1.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
-    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
-    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/4540ee0f9c42a9ad7109d0d1a8cc70de54c3572b01c6693a2b1c70e90ceb/scipy-1.18.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:3ab3523da44749156e1f68b464dc56af11ae4cbc5c739a49d05f32b982eca9f3", size = 31089958, upload-time = "2026-08-21T23:24:35.8Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f5/769f36d14922b8071a43e95d24d18b6bdafad10d7f5cf647867e1ac052bc/scipy-1.18.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e6fb6a55cc0ba97b59a1f288fb86dc6fce8bdfc0fffcbfd015e3a954bf2a2d93", size = 28715106, upload-time = "2026-08-21T23:24:40.775Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/d7/21d890274f75ea37a8209d5519e72da3da90302e3b9fb8397a0918386a62/scipy-1.18.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ea324d9dd34c38bfb9bec8ca4d1b407db97dbb74029f566b8e322b1b6fe56fe6", size = 20456846, upload-time = "2026-08-21T23:24:45.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/01/798430ecea2e78ec7c02663d5f71c007bb6abeca931080debd40d7fa55ea/scipy-1.18.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:75b00eb8fb802090aa903f4ea1c7f5a584779f967361e68b7e98e531cc2d7174", size = 23087986, upload-time = "2026-08-21T23:24:49.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5f/4634e9d35c68496e4e34cb6946eafab044458e6cedab42b40b6588e475b6/scipy-1.18.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d416b16cccfd70fbf62400e84d0bb2f4e6af519a45557f1692c749b37f14b315", size = 33998146, upload-time = "2026-08-21T23:24:54.714Z" },
+    { url = "https://files.pythonhosted.org/packages/41/48/6450ed9243315322bbc19ac57b9b70d66a20bf1d38d124c96bc4bf6af9ea/scipy-1.18.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fdaf5ea890a6183d0565f51a61799d67081bd5b1cf03c5f4b3fd3732108625c9", size = 35312578, upload-time = "2026-08-21T23:25:00.44Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bd/bf5a4be6a3525676499f6dff307991739ff6fdcad1481b1aeb6745339f58/scipy-1.18.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c825cef2f49e46753726a7181a8e199804a912b29519ada542c6ebc654951899", size = 35612621, upload-time = "2026-08-21T23:25:06.144Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/4e/3c45c33e00a77996c4b1cb707929f833ba7b1d522ee29f882512c330676d/scipy-1.18.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3b417bf8c2c7c16e8f58ad91db17783ec911ac16e7b50eb6eab6e809b4f5b07", size = 37457323, upload-time = "2026-08-21T23:25:12.483Z" },
+    { url = "https://files.pythonhosted.org/packages/93/0e/e0348fbc0dbab65c114cf78957e7dfeb49f8e8b556b4d930cc12ff195e18/scipy-1.18.1-cp313-cp313-win_amd64.whl", hash = "sha256:559ed65f60c1af5a03f3912605a1b5114f522c7c32fb23c3376ae8f03219fe28", size = 36622841, upload-time = "2026-08-21T23:25:18.722Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/6a77f5f267c555108f0a864b6db714363dab567a8266422a79a385f9232b/scipy-1.18.1-cp313-cp313-win_arm64.whl", hash = "sha256:cd479fc04dd9401e3b4f49e76518768ef99c4f517a98c284eb091fd725719adf", size = 24399315, upload-time = "2026-08-21T23:25:23.458Z" },
 ]
 
 [[package]]
 name = "scipy-stubs"
-version = "1.18.0.1"
+version = "1.18.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "optype", extra = ["numpy"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/c6/c4c80bd13c0eec99121922c50cd1c72600672307b28e4ba67f636d6b298d/scipy_stubs-1.18.0.1.tar.gz", hash = "sha256:761cb35106200c90a37034d3c8120d3899d673de1e5879d3a2ac1d6816c62327", size = 410862, upload-time = "2026-07-12T21:09:29.993Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/99/02c608a58cf99774c577f22e457427f87c8e608652c5de95178daa003e1f/scipy_stubs-1.18.1.0.tar.gz", hash = "sha256:87bec0df883cd9cd6b7dc4c74a33362cf550e9cad679643a29a886ab2b438ddc", size = 448822, upload-time = "2026-08-22T09:22:52.944Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/0c/78404528783677077f072288724ff8ef8381bbc219b110e3147e60361b6d/scipy_stubs-1.18.0.1-py3-none-any.whl", hash = "sha256:704408c5f03a33924c9fed6dc9e25926dc331ed508d52f1beece0188525cebad", size = 616217, upload-time = "2026-07-12T21:09:28.45Z" },
+    { url = "https://files.pythonhosted.org/packages/12/11/263ced30149fbede00614a11f01de792842d3636b5a9e3abfee34e764a0e/scipy_stubs-1.18.1.0-py3-none-any.whl", hash = "sha256:fc1f00da3eb6bf1adf2138774b5e6a91dcf7c77039ff199577dc47929c10793e", size = 653731, upload-time = "2026-08-22T09:22:51.43Z" },
 ]
 
 [[package]]
@@ -3968,11 +4045,11 @@ wheels = [
 
 [[package]]
 name = "stevedore"
-version = "5.9.0"
+version = "5.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/dd/04d56c2a5232358df41f3d0f0e31833d378b6c8ed7803a6b1b7867b0eba6/stevedore-5.9.0.tar.gz", hash = "sha256:abbd0af7a38a8bbb1d6adea2e35b17609cf004eaac323e88a8d8963640dd2b3c", size = 514850, upload-time = "2026-07-02T11:38:08.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/a1/3b8ed9c1fc3aa6eebb57732d924ddaa0500ecc3b638d0454816320994383/stevedore-5.9.1.tar.gz", hash = "sha256:e97a2667923efda926e8713fde6a73616df68210a3cbc6f02b48967b676fd8bf", size = 518111, upload-time = "2026-08-20T15:25:14.754Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/8d/008761f6e1000600e5303db30d05724bdcf3d2d186cbb59fac79b52e39ed/stevedore-5.9.0-py3-none-any.whl", hash = "sha256:e520945d4c257700eddc1eb1d79df04b2ea578eef185e0e3fa5b442fc848d3f7", size = 54463, upload-time = "2026-07-02T11:38:07.43Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/97/bba6e7ec2f5498b9dcb7b1b6400086b80ae5a8ebaff4b25e8c8add75f439/stevedore-5.9.1-py3-none-any.whl", hash = "sha256:5c8ff3a9f336cc1a06ac0f597bc79d11a2f950bfd32e290ca56b5a301fafafbf", size = 54931, upload-time = "2026-08-20T15:25:13.602Z" },
 ]
 
 [[package]]
@@ -4042,28 +4119,21 @@ wheels = [
 
 [[package]]
 name = "tiktoken"
-version = "0.13.0"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "regex" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/62/167a842aa0429d45f5e797354fd4343a96f6043d67d0513c675c7b8d36e6/tiktoken-0.14.0.tar.gz", hash = "sha256:231dec90efcdccf1b565a1416107736f1e09b1a08fe736ef9d6363e626d03874", size = 38898, upload-time = "2026-08-17T19:49:49.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
-    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
-    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
-    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
-    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
-    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/50/53/ee1453623bf65f019328721ccb6587846d2c5b7b82f34e73ca09101f072e/tiktoken-0.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9c5fe393aab56469f04e432ff851216d3def3436cf5f07e442a240164bf500f", size = 1094198, upload-time = "2026-08-17T19:48:57.955Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5f/6448cfe278c3664ba9ec5b5ac08344341f7dc3d42888476e215a14eda2be/tiktoken-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cbe2cc3bba939bcdaf103e03df9d5039d33887080b315624be28ec69059e5f94", size = 1038820, upload-time = "2026-08-17T19:48:59.015Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3b/d67eac1bcce9dee3abe23aff5e3ded3116bbebaf67b80a0811c06d3806fc/tiktoken-0.14.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2157f52e4b4d7ac5ecc7457b3716834706e7ef9a46f5144029bfeb7cf71f4e06", size = 1186175, upload-time = "2026-08-17T19:49:00.068Z" },
+    { url = "https://files.pythonhosted.org/packages/37/62/cae690d9783146b0f81f564ada0f8f611de68178c0c9c7e1e969f0516b48/tiktoken-0.14.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:26e60f6a956ee171ab728b37b8439905d7ea1db435c30f9822f291e9861c861d", size = 1203884, upload-time = "2026-08-17T19:49:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/1e/633e30237b94e383cf814145499079f3bb9cdd4aeafc1bc42e01b0f810a6/tiktoken-0.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:380873f330b741c4435574f37edb20813d04603ace2d53e0a63560e1fec83010", size = 1250980, upload-time = "2026-08-17T19:49:02.274Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/56/4c12f07b812f84206f38d723eb1ebfdd34bad9309b5dbc0bee6bbcff4cbf/tiktoken-0.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3fd7c14b1cb45b486c39fc9b3443bb341f3e2fc7e6f31247f3435a5836651632", size = 1315434, upload-time = "2026-08-17T19:49:03.434Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e0/c65603f0c44811def666d3fbf611bf2af3b5e1ef613e06c19411419830b3/tiktoken-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:90a762670c7f968184723769a06ed51f5cf5ce5dcd1e30164f25c72d85c2d1f1", size = 940883, upload-time = "2026-08-17T19:49:04.583Z" },
 ]
 
 [[package]]
@@ -4163,7 +4233,7 @@ wheels = [
 
 [[package]]
 name = "trio"
-version = "0.33.0"
+version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -4173,14 +4243,14 @@ dependencies = [
     { name = "sniffio" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/b6/c744031c6f89b18b3f5f4f7338603ab381d740a7f45938c4607b2302481f/trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970", size = 605109, upload-time = "2026-02-14T18:40:55.386Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/dc/a2d25ed73ad49cfd79bf18d262577c3731c98e382284e28d522f49a0df35/trio-0.34.0.tar.gz", hash = "sha256:63b9485408bdfdde544fced107045a8c0086cdc4bd0ef2f797b9e0dd111b964b", size = 607457, upload-time = "2026-08-11T00:33:42.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/93/dab25dc87ac48da0fe0f6419e07d0bfd98799bed4e05e7b9e0f85a1a4b4b/trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b", size = 510294, upload-time = "2026-02-14T18:40:53.313Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1f/555f1364bed52a92a864181962b77f1b15adadeacf23b86105324363e461/trio-0.34.0-py3-none-any.whl", hash = "sha256:6c7c9f49917694dcdcd5f67abd168df5599eca480d61f29854d17a61a75c2f05", size = 511840, upload-time = "2026-08-11T00:33:40.552Z" },
 ]
 
 [[package]]
 name = "typer"
-version = "0.27.1"
+version = "0.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -4188,27 +4258,27 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
 ]
 
 [[package]]
 name = "types-psutil"
-version = "7.2.2.20260518"
+version = "7.2.2.20260827"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cb/f1/6901857281d4e8d792492e1495eef6f4f01318a3b6a066486d81000a4511/types_psutil-7.2.2.20260518.tar.gz", hash = "sha256:9f825f631463a5b4d26f19f63aebc9ec25f01140d655026f3ad8a67841f9b331", size = 26660, upload-time = "2026-05-18T06:05:09.389Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/ea/23a949b56d3a226a142b43c5c32404fae7044400296d18e8eda63d5d03a4/types_psutil-7.2.2.20260827.tar.gz", hash = "sha256:3c6067dba47c700495ca493f07b11e866ba13de223aabb26da555f9c86ae0b1f", size = 27294, upload-time = "2026-08-27T12:06:22.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/eb/f726339668879819599c74c2e1f0cab760912a4159046942bdae2ad37bd6/types_psutil-7.2.2.20260518-py3-none-any.whl", hash = "sha256:6a3d697665754a60d7b5a41d5a2cff12b53f5e0676d77810cd28ba5e14cb4049", size = 32820, upload-time = "2026-05-18T06:05:08.321Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/1b/7e0f5cfad4faa4a2e0845f69e9206eeefc6659dfa11d07da04e2fa47d08b/types_psutil-7.2.2.20260827-py3-none-any.whl", hash = "sha256:62364359cf85482aa698a62488e5420cae5c576e8acec450ce7fb3b91cdb3d96", size = 33365, upload-time = "2026-08-27T12:06:21.444Z" },
 ]
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260724"
+version = "6.0.12.20260815"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/72/b56089aeee6c496d969bac42376bedb6e3eeab4682e1018fa3137122f94b/types_pyyaml-6.0.12.20260815.tar.gz", hash = "sha256:28764110c9cf35846e733da32d8d734df7473c5dde9ef67c3b7332ec0e819858", size = 18545, upload-time = "2026-08-15T02:41:51.532Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
+    { url = "https://files.pythonhosted.org/packages/08/52/eefeba09be4ef2a1eb989eb92934561e8e502a6ee3c32654996e4be7e399/types_pyyaml-6.0.12.20260815-py3-none-any.whl", hash = "sha256:6f332212b7e191f3afd5016a713c510b6340593b7ebec573c7d5d20aa5386d3b", size = 21148, upload-time = "2026-08-15T02:41:50.555Z" },
 ]
 
 [[package]]
@@ -4234,14 +4304,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.2"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
 ]
 
 [[package]]
@@ -4343,15 +4413,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.1"
+version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/18/ccce41535dee1be77735592bd19965f3972c82e07ee703d324709496b716/uvicorn-0.52.1.tar.gz", hash = "sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd", size = 100571, upload-time = "2026-08-01T18:19:30.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/d5/68e6e9bca63c0badf67002890a46d3784c958de45b65e1275ec583ca1f06/uvicorn-0.52.1-py3-none-any.whl", hash = "sha256:e4403f9d93188cf9d1088e9f40e3acd12630e2df8675316704379a7fc20fff6a", size = 79859, upload-time = "2026-08-01T18:19:29.294Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]
 
 [package.optional-dependencies]
@@ -4392,7 +4462,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.7.3"
+version = "21.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -4400,9 +4470,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/10/8b7a5454efc032be50c1c5641467dbb5d31314500205212b2aa66d3c8af4/virtualenv-21.7.3.tar.gz", hash = "sha256:5e9e287f5c808070eea3b40403d3368248e64b24f1b60bd9a36e85ac841d2c3e", size = 5525482, upload-time = "2026-08-08T14:43:20.286Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/41/c3f34799487924f2a6f43b8a8b7acd345a6c61aac2211d4bced8621ca4f1/virtualenv-21.7.7.tar.gz", hash = "sha256:6874376f99ba6b8d4e3ee8bde67f9285412400c7d5b29ba41ee6daa5e0221bdc", size = 5347022, upload-time = "2026-08-28T18:59:50.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/2a/83d779d2dfb61f101d7b1c10073d18984e37262d8b4f171c99911a952430/virtualenv-21.7.3-py3-none-any.whl", hash = "sha256:26dfda3c34f29bf1a3ca167426a67658d59979b9954e705aef60a5f724ce1773", size = 5504590, upload-time = "2026-08-08T14:43:18.57Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/dcec8dc767b812193316c7debed1e2b53e586e59c267bfe517688ff90275/virtualenv-21.7.7-py3-none-any.whl", hash = "sha256:67a6a68fef3ad8ca16b8b89f33fd8f97996cc0bf0db31629d07ecf8dec539a2c", size = 5324620, upload-time = "2026-08-28T18:59:48.056Z" },
 ]
 
 [[package]]
@@ -4464,14 +4534,14 @@ wheels = [
 
 [[package]]
 name = "wcmatch"
-version = "11.0"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bracex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/25/1da725838132221e33568973da484ff43813662ccc06ebf7f6e3abddfcd5/wcmatch-11.0.tar.gz", hash = "sha256:55d95c2447789712774b198ceec72939e88b5618f1f8f0a9b605bf7740b63b96", size = 141360, upload-time = "2026-07-10T05:50:24.183Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/43/30e407989e313677dbb9d5f045f966549a7254834571e342eaa4b55cc67b/wcmatch-11.0.1.tar.gz", hash = "sha256:1ea2b4fa678b8ca268253798d5963935df39132d47c3e241c0a0732224005e7d", size = 144662, upload-time = "2026-08-14T15:20:40.477Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/12/f38b6fee116274d7221743caab07d765032e1370bb54cad8714f87aeb0e8/wcmatch-11.0-py3-none-any.whl", hash = "sha256:3a5977ace27e075eef67eb03d539563f1a19018b62881949a42932cf66926934", size = 42914, upload-time = "2026-07-10T05:50:22.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl", hash = "sha256:fd149ecddb9f0a88ea780017d6dde17c994e494e7f7303d4e3c9d6251f978f4b", size = 43449, upload-time = "2026-08-14T15:20:39.379Z" },
 ]
 
 [[package]]
@@ -4494,31 +4564,31 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "17.0.1"
+version = "17.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/96/e01084f83a64bcb3a27994bd0cb0db68ff29d9c6707fae37ec19b18ba990/websockets-17.0.1.tar.gz", hash = "sha256:5baa9bc0dfbae8c507e51c8cf1b6d4628086f7a87bbd3a9952bd5f035451f1cc", size = 183298, upload-time = "2026-07-31T11:31:27.665Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/72/fba934cb3dff7a85d811820efffcd141ddd52b5a2a01637f64551373ff4d/websockets-17.1.tar.gz", hash = "sha256:acfea4c20bf54384883ea33b1240fc1db4f52e190823a4e2b334bc3e8bfca96a", size = 187520, upload-time = "2026-08-26T17:25:33.063Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/a8/79c577bc2f874ee22f6f5ccdab97ba9ce6b96806be3fcc3a6d8490f88a21/websockets-17.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:55b12e47dcee83673a40d07686cfb6f9d6dfc285976ade9463f61d2bef3fad22", size = 212593, upload-time = "2026-07-31T11:29:56.518Z" },
-    { url = "https://files.pythonhosted.org/packages/db/99/e1cfaf419bb3b2fcfd6792a846f1d936293132b0b9a56530ced016c83c7b/websockets-17.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c1c118a6b0e25bfc9a6802075d748fa6321714ffbdf3c88d29d9a0e3c7386c75", size = 210280, upload-time = "2026-07-31T11:29:57.768Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/ef/cc994494bf7d97e41833f6ff55c24f535e4d527a10370b9631737e9c2f00/websockets-17.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:734d20364dc2cfe03674883cafcf580b6e431c5ce42b476312b9285310230cf9", size = 210538, upload-time = "2026-07-31T11:29:59.021Z" },
-    { url = "https://files.pythonhosted.org/packages/87/32/fbf2d132f63ba3e67f675bccf333469786a24e0418969ce1d8e6ff9e6f02/websockets-17.0.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9493314a99e599163c854fb5900ad7f7ea38c5cb9d9103aa30b3c6b8181c01fa", size = 219925, upload-time = "2026-07-31T11:30:00.298Z" },
-    { url = "https://files.pythonhosted.org/packages/16/50/64eee3d25a47fe744a9490e0627cc373dca096755db740f91c28bd61cd35/websockets-17.0.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:18ded646ce98cdd3c0235825b3252f1df55765ba49b616bb10282f758667b4d0", size = 220206, upload-time = "2026-07-31T11:30:01.52Z" },
-    { url = "https://files.pythonhosted.org/packages/15/56/10ed4bc4dd75f204e3c62bd4898e44a8742a27773c80b188cfa7888aad2d/websockets-17.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1bec5d6a19f5fbe87e4940739cfc65e7bb53d8b353e1029b8037a1653b321bc", size = 221445, upload-time = "2026-07-31T11:30:02.788Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/be/bb14328614c068ab09569962fbf218fc00413ce3febc6d2684c764b6f37e/websockets-17.0.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:872273e629ca7e3d35f16a2dc6ede84e1d5c831e616b8277de6e4f83114e7c58", size = 222887, upload-time = "2026-07-31T11:30:03.943Z" },
-    { url = "https://files.pythonhosted.org/packages/32/1b/4cb0eec2fee310007104687493175af190019f705940c864f9c523fe9f6f/websockets-17.0.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1df81d174c1561292de9e40b141cafc04f69077272f6c352afe1d743e20810df", size = 222072, upload-time = "2026-07-31T11:30:05.258Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/9c/14e6391de777ddb39c439c450deb551406d445e25a5877d6fa25c49d4544/websockets-17.0.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:759adeb5b0c5775b563254ec63b5b79089fc0045b479143a0b1b8c0ebaae1253", size = 220826, upload-time = "2026-07-31T11:30:06.53Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/57/96e94e384442247bbed5d3ab67381c7257355c2d66b62c3ad33a17f5d385/websockets-17.0.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1d99db29b5444e3982f1ce2ba8a833508ad44b2f1fbd0bd99e81d825c0b461", size = 218107, upload-time = "2026-07-31T11:30:07.766Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/8c/9c9dedd14c3919435df9b35cdee7111268c751252b87652f3a6a4f56e760/websockets-17.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:02ed63bf26dda9fa27df730a41f6664586c4ee05972c8fb667ce1725b3fd13d3", size = 220889, upload-time = "2026-07-31T11:30:09.035Z" },
-    { url = "https://files.pythonhosted.org/packages/94/4d/ca73c2ac82c00f50c529784bacb323e42da4816333211bc1543d90c9cf11/websockets-17.0.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:eab6de8a98b9a7772cf686d00b4de439fc7efb8ab05ae106ef227291d06f87c5", size = 219486, upload-time = "2026-07-31T11:30:10.289Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/da/fb37ac09dcd7c69dd73bac979ed393df35f78a3c232e293d1ff3bd586d24/websockets-17.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2a855b6dfe21c4d3420be265ae031829ba8ba0be0ea350d9f7c3ef30ae63ebe2", size = 220258, upload-time = "2026-07-31T11:30:11.605Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/04/9693f191d968a93f37326a17301a101d49580889c688f466699f89ecdee1/websockets-17.0.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7002d5f9e1c3ddd991cdfdbfee18cc8c8b196b2445022892badacd6cb338bbbc", size = 221358, upload-time = "2026-07-31T11:30:12.858Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/29/ad0d85c01db5dcf22898d51648bd2c25af0dd0a4a41c550b11acddeeeba7/websockets-17.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c395bda8e7d8f51a02e80261fb57127979e5c472675d9a96b2860619ad47da48", size = 218921, upload-time = "2026-07-31T11:30:14.064Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3b/bf8e855e495dcca63f2b8aa019cf2ada3160e1fa66d833c7417f3b1f7f38/websockets-17.0.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:aadc298969ad229d8e3029fc5cc751fdad286696230f9cf014e90ff9cd8e6ea0", size = 219871, upload-time = "2026-07-31T11:30:15.358Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/db/c7abd6639a93a40279cd1ddc57e09e1c4f8381c4cfccdb775aa5aac9770a/websockets-17.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f11a398d8170b7ac5000baf7f258dcda579ef3ea744e0cc6a165e0dfbc0d3198", size = 220154, upload-time = "2026-07-31T11:30:16.96Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/2a/25a9f8f2e5a6ef34e911d2f55d9f756bdeb92b4c28cfb77b8430bbc73cb1/websockets-17.0.1-cp313-cp313-win32.whl", hash = "sha256:846a4a8b0833e3cad57523d9e3bd50ec8ea05ab9d06c582f82a1340ba096af5f", size = 213038, upload-time = "2026-07-31T11:30:18.434Z" },
-    { url = "https://files.pythonhosted.org/packages/81/2f/ea1380f72bb11b64fc5bc7ae0d42de5bbf3e6dc13b965706b2a1d4e17cdf/websockets-17.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:409d93efcaa14f7a99592c5baaef5ec6ca94fba0f5aec1a86f693977c69c9c1c", size = 213348, upload-time = "2026-07-31T11:30:19.693Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/c7/b956ed9151c3c74530ebc62d716fbfdbde7507a6acc6423a64f9ecfb6b8a/websockets-17.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:90246fa9e6cb192a778ce6ce024057ec54317a894db7899c922dcdc1f4cbf6a5", size = 213282, upload-time = "2026-07-31T11:30:21.045Z" },
-    { url = "https://files.pythonhosted.org/packages/09/ce/3929538b2b9918f5eee623fbf3346893973191f6df93f19bbda097bd7bb7/websockets-17.0.1-py3-none-any.whl", hash = "sha256:c6be9cba65c65cc76dfa3d4619e359ff02a4476c74e179b215236c11a0b32345", size = 206718, upload-time = "2026-07-31T11:31:26.037Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/31/5f6450a7879f4f063ef08897cc385ea3ce3f1fe17f08b11e3fd959abdf27/websockets-17.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2a0162a6372110a5601cb5c9fd826635cedf69f3e110c545dd19774e040b970e", size = 217006, upload-time = "2026-08-26T14:56:10.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2a/c1b006fc861695d2aa4e35327b842015ce1d98cf8f99241829b3d6460bfc/websockets-17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:829dba1bc049779de9b332088c1a6a9858e96bd67e50b6b644a95e02b67836bc", size = 214690, upload-time = "2026-08-26T14:56:11.681Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/66e5b7d01445e0eeb1d4ab419c30315f2c90cf7a8a8cd4ecc47f894dba54/websockets-17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fd8f47dbf2e8adb15c847215f83436de3fdb120b51fdae0fbbdf69fd97a3ad80", size = 214947, upload-time = "2026-08-26T14:56:12.923Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ce/033cafe2d2538562efa876b9149a2c7a0f7787870a4b1bb6e28adc9ceb6b/websockets-17.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9f4c0377a83e163a303514fdfab501dbe379bdc13e5b9312a91d112658b29dce", size = 224329, upload-time = "2026-08-26T14:56:14.212Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/e1c2e8a67f6cc0aa43abe0046fb3b7a020980649e6a843751dc7ce9eb170/websockets-17.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c3241d684a76eaaef8b2dc789afde4343cd3aad55ea81e4e8ab3605b529bae51", size = 224611, upload-time = "2026-08-26T14:56:15.702Z" },
+    { url = "https://files.pythonhosted.org/packages/be/de/07c6d48eb3d2069709410c851e7de10ab83d752c4bd09862899627c2729b/websockets-17.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e5f5c7a893507d0e83a80b88aefd6522f7e882cd53f9722c6f23f5a020c9557c", size = 225848, upload-time = "2026-08-26T14:56:16.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/dd/3c68572d20509648cc2fb6f50ccf3deeb4b87270f2c8966e99476e278ea3/websockets-17.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:00bf34b64501e3477e81fc281532ff3cbf4da26633c10b63979d5085d46602d3", size = 227290, upload-time = "2026-08-26T14:56:18.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4a/8f6651c8a22093539c9215af0c5bbf217b87b382c99d2112039b92d593c2/websockets-17.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ce0305b702b20d1e1d60a9aaace6bc89970e1753565543f310d549eab22c2435", size = 226476, upload-time = "2026-08-26T14:56:19.459Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/f6fc33cea86b1127fd1297b18c107e81580ab55a73a39f9a934441ef321f/websockets-17.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29176d8b429cfa0fa443c473878d37a5c06cfd0cb36b71ba4314accc71e05906", size = 225233, upload-time = "2026-08-26T14:56:20.939Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/83/65edaf05f7c9b1dea82f4d252fdc37706a84571646f06119a27b0a16fe19/websockets-17.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3709a1ab30b4b922027d22f68d2b61a0656a91680ac894a537624e6be7dd7f7c", size = 222488, upload-time = "2026-08-26T14:56:22.208Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/d1169c2f7f1f0032b0d4b0c00f0711a070cd7c735de37bfeb876bc0f9606/websockets-17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:43bd0c1ceb924d67f5c1a5254d8361dd9d94246e6331a726064dfa2917880780", size = 225295, upload-time = "2026-08-26T14:56:23.445Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f4/64e2a386c3899b917c2933225c9b47887874229d159797f3bf1a11c20d51/websockets-17.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:1fce0f43e0d41422e0b2cad6561e1970df22f212f4c7e884967df7cf591b031c", size = 223891, upload-time = "2026-08-26T14:56:24.647Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b3/dfb5c482f7e310a3432fdbb045ddfe6d34114680e89a233d4ff900a32961/websockets-17.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4031152769179ab8dcdeafc7b0e58052a49117560a28671700b47b2c7b717aad", size = 224661, upload-time = "2026-08-26T14:56:26.027Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cf/94865130a336029f46412adc127c4fbe380f46172b90ce251369e35c4302/websockets-17.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a06f3b5085176763182449559e20391d7ce616a8972a9f7a33deda87ea6d4f3c", size = 225766, upload-time = "2026-08-26T14:56:27.455Z" },
+    { url = "https://files.pythonhosted.org/packages/96/34/eb8c658f86dfe562ed49a887a27424bfe9e618c26ea6f865b093d075d3a6/websockets-17.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:77b37cceca17291897c3c73bd30a7c7c7909593554b5da574ec852af83c1742a", size = 223323, upload-time = "2026-08-26T14:56:28.807Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/7e/2629609652ece5ca0c7ac235927dd4511b08131e3a5d53439b798fddf002/websockets-17.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d8e83333385cac6030a5167fd18bf96cc6c58b914c308e683f05b0cf94bc8dd0", size = 224276, upload-time = "2026-08-26T14:56:29.991Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6b/8525737fe840b38e5f40956c198fb586a4fac1e07144d41a5b949b989cf8/websockets-17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:073c5c3f7e127041fa9d34a9e29ceefee8c3cafbd267ed2927318f425144380d", size = 224558, upload-time = "2026-08-26T14:56:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ab/3a958c6cbcf74b118f601c20a80ac8bd5e8dfec0bcf7345116feaeefb121/websockets-17.1-cp313-cp313-win32.whl", hash = "sha256:2afb58c7ba48b329d56769f8dfd89f394efe587b65ef806bae810a484d6d3608", size = 217475, upload-time = "2026-08-26T14:56:32.431Z" },
+    { url = "https://files.pythonhosted.org/packages/22/36/fb521f0f2994c25509651f169efe5582dddd8713d57a0757ba87859372ef/websockets-17.1-cp313-cp313-win_amd64.whl", hash = "sha256:0340bbef6bfbe16da888b3983d666a4db4954ac3253c38f13bc7aba0c7db5a2f", size = 217784, upload-time = "2026-08-26T14:56:33.608Z" },
+    { url = "https://files.pythonhosted.org/packages/68/92/9b8419584681a12a7534b746dfb2737c466efe2455483e2fbf8b941a04ec/websockets-17.1-cp313-cp313-win_arm64.whl", hash = "sha256:7a72efa3bf4fa3a6669a54420a472ad056da3973d827f10e3a536da463f926c2", size = 217715, upload-time = "2026-08-26T14:56:34.865Z" },
+    { url = "https://files.pythonhosted.org/packages/41/63/23572870e01836a98346075b9e17a8bc24a6ddd9800a3204ceee58677f3c/websockets-17.1-py3-none-any.whl", hash = "sha256:f221081107b8c48184d99f7019604486376e7ef826037e70aad6b02540732c23", size = 211134, upload-time = "2026-08-26T17:25:31.397Z" },
 ]
 
 [[package]]
@@ -4535,53 +4605,35 @@ wheels = [
 
 [[package]]
 name = "xxhash"
-version = "3.8.1"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/63/71aa56b151a1b28770037a61bd4e461c2619cfc8866a4fcaf1548605e325/xxhash-3.8.1.tar.gz", hash = "sha256:b0de4bf3aa66363552d52c6a89003c479911f12098cd48a53d44a0f7a25f7c46", size = 86223, upload-time = "2026-07-06T10:49:58.937Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/a5/1386f35da1475fcaeef42581deae73417c6d2a6a0b2d2e8914de18844dcd/xxhash-4.0.1.tar.gz", hash = "sha256:d55bf4ef10eb09b8b6866790e083d26d087d84caa3cc0946ba87c3ca7ecaf7b7", size = 101513, upload-time = "2026-08-17T08:24:08.557Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/8c/446bb782cd0d27007a917b5569a08dd73219c3e8d6e459014db104b27bdb/xxhash-3.8.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:3c682fcd96eb4bf64be32a4d95f96107e1588005831bd8a741b324fdda01b913", size = 38562, upload-time = "2026-07-06T10:45:12.425Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ec/c0c45627eaa6be7a5d6117423adf8f7a15b17ee74b4b17072cca5959a225/xxhash-3.8.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:036a024d8b9c01f70782e09ed98d532e76fd23f950ae7154bd950fe94e90ebec", size = 36656, upload-time = "2026-07-06T10:45:13.932Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/94/8324c04cc7597154caaeba6c094e01fbd2e7601d01e7a13eea9f5420e77b/xxhash-3.8.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d6a5c0bce213b23b0166fe0d35bcbbe23ce4b968f257cc7eb6fd57cb8e1e6297", size = 31169, upload-time = "2026-07-06T10:45:15.687Z" },
-    { url = "https://files.pythonhosted.org/packages/40/a4/beb6bb26e1184e126dbe7a5682330214ef54dcfbf882078aa9f4b5428d42/xxhash-3.8.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:5177aa44eddaa97c6ef0cc00c6d540edb64d51781d2f8fb941612ec61a92c9ed", size = 32177, upload-time = "2026-07-06T10:45:17.035Z" },
-    { url = "https://files.pythonhosted.org/packages/56/0f/fc4c92a5a528f839b34b6419b2e53c8597f2a629d5a1f5d721f65bfa1fd6/xxhash-3.8.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7801b7223db017b9c0c9ccf37e44524edb35a1544a1c032add22c061c6af0276", size = 34642, upload-time = "2026-07-06T10:45:18.39Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/58/edbfb141d4000767ac6a9694f8ac0763e2c2e983e65c9e31620ba56e2667/xxhash-3.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e80238259655bf69d7bcd08226a970d7f42605f3157786bfa76dd13472d7fa0", size = 34684, upload-time = "2026-07-06T10:45:20.033Z" },
-    { url = "https://files.pythonhosted.org/packages/07/3f/5072f1f0f5714186f0ac2a0b5a4929ce30d4b845e94886b6c01b6ebda0be/xxhash-3.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bcab50a389cc04d87f90092af78a6adba2ab3deca63175a3344ca83514045315", size = 32401, upload-time = "2026-07-06T10:45:21.414Z" },
-    { url = "https://files.pythonhosted.org/packages/49/c7/802ea2f9c2ed59219934d6d65c470d502b1788043eae277a52af8658bda6/xxhash-3.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a2489d3a776fa380cb8e71f54c7fda268a9baf3de9b1395093fd280f95735907", size = 220617, upload-time = "2026-07-06T10:45:23.234Z" },
-    { url = "https://files.pythonhosted.org/packages/99/a8/e10488efd31fcb13fcd6acbc6e788f10c6f8e3a0cc4ae3eb89dc19c55a12/xxhash-3.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32ab1e5432690276e71192be7401b55f96db2d0eedea5d44eb1f164505669cc0", size = 241295, upload-time = "2026-07-06T10:45:25.364Z" },
-    { url = "https://files.pythonhosted.org/packages/18/cc/14180b17d44892a631f8ae7323c30bfbb1328efc8209e528a480293528ac/xxhash-3.8.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b30e01a0b97a4bc3f519a4d7a82da3dc53251fb0de5eeea8660dcd4ff094c0c2", size = 264688, upload-time = "2026-07-06T10:45:27.09Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/72/a14019d0c5f6c41ee407a503036ae32787c91325ca218a96a9b5627be651/xxhash-3.8.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1f44275ddb0978b67a58a951501903f04d49335a91f7681c9ce122ecb8ccb329", size = 242740, upload-time = "2026-07-06T10:45:28.753Z" },
-    { url = "https://files.pythonhosted.org/packages/68/08/92550e556c6fcfcb96c6a336945eb53a431ed43120ed749636debb16c5cf/xxhash-3.8.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3b87cbd974512c0c5fc7b469c36b2cdc9ee6d76e4ec78bccb2c7184611c49b0", size = 473599, upload-time = "2026-07-06T10:45:30.524Z" },
-    { url = "https://files.pythonhosted.org/packages/29/83/e361d3c1acd1b21e1d489616de6fa4aaf843365d8179f612e3743eac20a9/xxhash-3.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98ee81b4b7f3023c9cb04a78cc67610baffcb5812d92f2096cb5a5efc6f19437", size = 220559, upload-time = "2026-07-06T10:45:32.979Z" },
-    { url = "https://files.pythonhosted.org/packages/05/01/006a4243c2c2a6831827f9999f6d1c23feeef100eb023c1f886022a00bf3/xxhash-3.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2666f059a1588a99267e33605365ed89cea92f424b3522806a9f4bd8ad2e3d62", size = 310383, upload-time = "2026-07-06T10:45:35.875Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/20/af388e8bf9f9a0f89eeef7d2a1935d176ee1c20bc6adeda05035879379cf/xxhash-3.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0093cf7eeb91b84776e8742113afa4bdf47533d36cf719179aaaf1f56f6f8bf", size = 238228, upload-time = "2026-07-06T10:45:38.02Z" },
-    { url = "https://files.pythonhosted.org/packages/63/6b/4666579a87eebd1744663c404297355fa0658617b015cedfa58810ee7036/xxhash-3.8.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3a800912a2e5e975d4128969d645c4a2a80aa886ccd6c9b1c6f44529e327e8cf", size = 269137, upload-time = "2026-07-06T10:45:39.954Z" },
-    { url = "https://files.pythonhosted.org/packages/de/d3/e963a8a46f900a137d91b02144d8ea07a8f812971b138204a3b2f8b8e55c/xxhash-3.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0fe37f72a207223d22a4eddc3149d4298993385aa9daef25c039246ca5a309f3", size = 225068, upload-time = "2026-07-06T10:45:41.718Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/80/9d181dbcde4b0fe48375f48833a5832d4b8cd2b349b15110c92ee472d874/xxhash-3.8.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5db43f249b4be9f99ef4b967863f37094fb40e67effafb78ba4f0356b6396104", size = 240874, upload-time = "2026-07-06T10:45:43.414Z" },
-    { url = "https://files.pythonhosted.org/packages/39/15/ce3ab5a1cd27ead25a5196e55a7284220f6ad6e316da494ffd900b2b600f/xxhash-3.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c4ed42965c2cd9081f011be22f69d0e65d3b6165fe7734072fd0c232840bbd4e", size = 300702, upload-time = "2026-07-06T10:45:45.135Z" },
-    { url = "https://files.pythonhosted.org/packages/96/c0/2281a8ab5f2a62dbf57a23c58a01ccc1d98abf40f71193c8a81f59e759b5/xxhash-3.8.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3557bec8fcb11738a8920eeb68974bc76b75262f6947998d3147954ce0a4b893", size = 443351, upload-time = "2026-07-06T10:45:47.188Z" },
-    { url = "https://files.pythonhosted.org/packages/81/2e/071a58c1a53a52d4f7a3aa0987be0c396dffd40da8204805fe1b130a81f4/xxhash-3.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00de40f3b42240db23a82a5c682b55d7263d84a26a953240c1aee463409660e3", size = 217396, upload-time = "2026-07-06T10:45:48.925Z" },
-    { url = "https://files.pythonhosted.org/packages/68/44/36ab58134badd9d3433fc7b53c4ca8d113d8e807782885628640f8297a4d/xxhash-3.8.1-cp313-cp313-win32.whl", hash = "sha256:b5196cc2574cfec572a5f3fb7cfa5ade27305ae3d06516a082132441aff4c83a", size = 31974, upload-time = "2026-07-06T10:45:50.591Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2a/2a0b84798448e766f7b89ceed073cb0cb5a43fc9ebbacbdea74a38de18e3/xxhash-3.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:538f5f865df6cd8c32dd63158a0e5b4f5dd08d732a7da8b7228a5a0776c8ce55", size = 32739, upload-time = "2026-07-06T10:45:52.221Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/60/bb51dbf7c363ff88a7cbd50b7959718219577ef44d7cf255929ffc4a2194/xxhash-3.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:a6617f30641ba0d8baa1635fbefb1dffc5165ec36d26921bd5cee13497cd937a", size = 29239, upload-time = "2026-07-06T10:45:53.714Z" },
-    { url = "https://files.pythonhosted.org/packages/56/d3/827ca123c2ee5443a6aaed3c5dd199237dc2f010e2bebd7ec09ef36f3a5f/xxhash-3.8.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:bfcd82852c62a60e314670a9602de354c4460f8adad916e2e42a20860c7870bc", size = 34964, upload-time = "2026-07-06T10:45:55.535Z" },
-    { url = "https://files.pythonhosted.org/packages/05/67/67ae2a3ccdeb8b8ef025d35aee9edd1d26c3abe5051d47da9286232afbf8/xxhash-3.8.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:08ea2081f5e88615fec8622a9f87fbe21b8ea58d88cfc02163ca11026ee62a92", size = 32697, upload-time = "2026-07-06T10:45:57.288Z" },
-    { url = "https://files.pythonhosted.org/packages/38/5a/3d3994346e1f45493679cb5c1ffc2bf454e410e9d1e8a662d253becee91e/xxhash-3.8.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2e32855b6f9e5b18f449e59d45e3d5778bdeb660632ef2693cca267a11246c75", size = 225954, upload-time = "2026-07-06T10:45:58.897Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/2c/53169270309b7cd8e05504e07fe123bac053b89d00ac63617faacf0a2ec0/xxhash-3.8.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6e088bd7870775624256a0d84c2a6714afd223b2eeb56b0ca58398e52a32fda", size = 249776, upload-time = "2026-07-06T10:46:00.977Z" },
-    { url = "https://files.pythonhosted.org/packages/70/e0/5c551d8d592f944506f7c5185e210255c15e672a3c6008c156a1bd9b775e/xxhash-3.8.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:72eb5ae575cc7ae2b23f6f8064a8b10f638c7149819ae9cc6d20ebd4d37a1629", size = 274776, upload-time = "2026-07-06T10:46:02.869Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/2a/d3a762270cee2d7bcd0e25e28c623e5f3f5c0dc637b66e3e47dd5b0bb3f0/xxhash-3.8.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d0b48cdf690a64cedf7258c3dc9506cc41fc86edd7739c40e3098952265dc068", size = 252056, upload-time = "2026-07-06T10:46:04.688Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/8f/b78e4373b2cb6d1c42af60ea2d7e9146ad0710b239ac7f706d5d31d5bb98/xxhash-3.8.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb9e256a357dfcede7818c6d34e70db2d6b664394803d1de4b6984d2de76c0f1", size = 482108, upload-time = "2026-07-06T10:46:06.498Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/0d/642d923336ea61a15f8ce64fc7e078729e6e06c3a026e517fa79b2c23b7a/xxhash-3.8.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51f71a6e2ad071e70c937e41fcb6c19f82c3f9f49831eba850ed4a106ffbb647", size = 226739, upload-time = "2026-07-06T10:46:08.598Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/0a/a37d6da6427d45a8d23e3ee3a0ca9c9d4a90364849c6637fe2963a755f9b/xxhash-3.8.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e4a6443968c4e8dc69967e12776776a5952c119cc1bd94168ad1c5ad667c2be1", size = 319658, upload-time = "2026-07-06T10:46:10.504Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/51/ebbd40da8a3f1bc53b4b7a9a87f8e28bd95c5f21bc14b8a57860cf367d1b/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:714503083a1f2065c9ad15340dd49ac8a8e948a505a705ffa1750cb951519113", size = 246059, upload-time = "2026-07-06T10:46:12.634Z" },
-    { url = "https://files.pythonhosted.org/packages/24/4c/d9014030147e1f0bb26e7da47aa240dd9ec61c763c573e558111d869f8e1/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:77f74e45a1e5574bbbf80181c8027b3a4c65c2248fffbd557bd596fff13102f9", size = 275535, upload-time = "2026-07-06T10:46:14.614Z" },
-    { url = "https://files.pythonhosted.org/packages/84/86/caee2db41fadcd5a25aa4323213f9afec5a8586d4e419241e3d659362bd7/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:4e0e1b0fb0259c1b75d1251ac0bb4d7ab675d36f7a6bf4ba6aa630dae94f9ffa", size = 231292, upload-time = "2026-07-06T10:46:16.452Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/60/f52f08bcdc904c4514ea5c25caa19e9f3214144434a6ff96dc82dc1cbddd/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:10e4393ec33633c2f05ad01869e546ad080b1a18f2650503731f153774608b31", size = 250490, upload-time = "2026-07-06T10:46:18.318Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a0/94dc7ae310838f250669c6ad7168e6d6fca17d49dac1053f06dc232c4a56/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:b3ba794c3d885803db6c3116686923f1ec13bc86e621e169a375282b63ea1cc6", size = 309861, upload-time = "2026-07-06T10:46:20.503Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f9/adeead7d0eb28cdfc2832544ea639ffbc6749ccde47a8e228d667459182e/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:57189a69c0891e4818853feaa521c972d22c880a001453addea015f48e3c3398", size = 448739, upload-time = "2026-07-06T10:46:22.79Z" },
-    { url = "https://files.pythonhosted.org/packages/04/a4/22ec0e07db57d901c9298ae98aa3cf2be45bafded6f07c13131e85b89032/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d59e71153fe9ff85648d00e18649b07e9b22c797291abb7e27274fa06df8b838", size = 223657, upload-time = "2026-07-06T10:46:24.831Z" },
-    { url = "https://files.pythonhosted.org/packages/94/32/8a9531f37b59e5a013003db7cb7414baf4ce7e0e1268e0d5947cd3d6a2df/xxhash-3.8.1-cp313-cp313t-win32.whl", hash = "sha256:5b96f0024e9840f449bd91b2d005c921a4b666055a0d1b6492463799f32aae22", size = 32377, upload-time = "2026-07-06T10:46:26.86Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ab/2ca45fd7f671de5f81fc297ef1c95080b40c86ec6be0cc6034b8f7707ac8/xxhash-3.8.1-cp313-cp313t-win_amd64.whl", hash = "sha256:37d5a56c36dcc0b9a87b814cd992598d33863ff683749de6c86081f278d5e629", size = 33274, upload-time = "2026-07-06T10:46:28.39Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/54/20d7163463ddb6438b73a427d1655a77a502cf9b9b0c3ada3599629d9c0a/xxhash-3.8.1-cp313-cp313t-win_arm64.whl", hash = "sha256:6696c8752aded28ff3b16f33ef28ce28fb5d209b80c206746f943199fcf5fd65", size = 29375, upload-time = "2026-07-06T10:46:29.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/dd/c707286b527722f776e1fb81dd202c45623355ba1a2972337a2a26075b2b/xxhash-4.0.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:8c9fe122444e129881afd1d4d1c7ac0d3ce2d91b68c2b40173b6025ff1c31f9a", size = 43639, upload-time = "2026-08-17T08:20:54.945Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3b/bb71639a0f95635f61936a6f2653599c4261b645ddddd8d00f9dfe3613e2/xxhash-4.0.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:1f3346c5c287ac3c7f38b20380f55e8768230e7252af59fabcf3b87ab21e4256", size = 40657, upload-time = "2026-08-17T08:22:12.616Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/91/76f3f5385faa9886a36f21fcc603f40b4c0c40ce622382f133160c48b4d9/xxhash-4.0.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:4e5141543c7f7fe3087500bbb4ac2845cb528a980aa91f8f1e661e2292ff4a5d", size = 34708, upload-time = "2026-08-17T08:35:24.614Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4a/f48f0e3e1b1ab072979fff2a5be899234e28090883e8b519d0b10215d708/xxhash-4.0.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f09ee747e2a5f876cc5ad56947734811828335e13b403dd8ea1e06d77a9dd48d", size = 35650, upload-time = "2026-08-17T08:21:09.337Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/53/b73d7472b196101ad1f57ed0674af3af803ac3e9ec2feadd650a7b262562/xxhash-4.0.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:acf52474b2494ef66dc7e0fb6d5e2b50c18313039ad4d275fbf9f9907c804bc5", size = 37958, upload-time = "2026-08-17T08:22:10.616Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/024946ad8fa532074af4e4380179da54b7ec9facc8bd0b279ec0fac4e63a/xxhash-4.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1b3cccf75eeb5b01639b2feadb042a8e07889293b7ca72fa2985e7dcb64763cf", size = 38032, upload-time = "2026-08-17T08:22:09.535Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e0/934af8d99bb5885711006bec30a691f728edd513d2c40f053f887d8e7577/xxhash-4.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cd878d32f5c6cbce9783f8d6897561fb772211edba9dde49d85672b88ed45276", size = 35895, upload-time = "2026-08-17T08:35:16.53Z" },
+    { url = "https://files.pythonhosted.org/packages/20/5f/a8011f6a1558f7ca66d9077bb4f192b1871afcea62fbd5733605d2015755/xxhash-4.0.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:41e579025a6e13a99e6d71e39c9cfc621a0dcdbbf19106325e145fa858f2d794", size = 259464, upload-time = "2026-08-17T08:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/89/9665a44397547e7a3d58c0942425a976d58dcfd4b538f33220a312bf6912/xxhash-4.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74379a577a9f3b6afbdedf1b90e5c7764467051977f18a326d7d607336d743bd", size = 283949, upload-time = "2026-08-17T08:22:17.003Z" },
+    { url = "https://files.pythonhosted.org/packages/34/2d/78774141266457468f29f3f5803092df4db87d8148ba74e4debd041649db/xxhash-4.0.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:acb31ecdd1a97fab5cd39a84ee9f515e727d319f796fec48703b8339b9998360", size = 303898, upload-time = "2026-08-17T08:35:27.951Z" },
+    { url = "https://files.pythonhosted.org/packages/59/48/d78d22de576b42528bff87c14207de50de4f0b888221a50ff7c9d675d670/xxhash-4.0.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5b7875ac1a2edcb691f27642b8b94b904baa6bcecb7d79c72df2228ba8cb5c51", size = 287241, upload-time = "2026-08-17T08:21:13.042Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/de/7a1755a59c59fd46176f293bbdd99e399a6537ba9537fc723aa4d1bf6e27/xxhash-4.0.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4751f1d7eecae6b2d2a773630f1a7248f125c9a92a456694d03c15bceffc9d68", size = 519856, upload-time = "2026-08-17T08:22:15.35Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fb/76580c08e916507859b0f335393cb5fdc59452c4402edbc6bcca6e47e7df/xxhash-4.0.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a51b061d54cda8b83e62c44458bfbf0dabbef9b975dd9649952ba5076b9f349", size = 268572, upload-time = "2026-08-17T08:22:14.533Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/1abde3e07b8f2077a38b4fbfaf764115008bfe0ff03bc7756a52c9fd0607/xxhash-4.0.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:74a164e8b63f1e9cf35c9a7809d082b033d1a00e7375d5d814415436e7867e57", size = 344967, upload-time = "2026-08-17T08:35:23.569Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/80b6ddf0732eef48a8b5fe717398274794392bd6dbe82af38d189d214772/xxhash-4.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f5e5c6df4b703afcbe9352d238a51efd97c3b91fdc3a2052e40fdacb1e7505f", size = 279956, upload-time = "2026-08-17T08:21:24.97Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e0/11cbc43c205bf81fad50d69c7319cd1b1ccc01a66cd4fb8766357126c43d/xxhash-4.0.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d54b8ae068af532c8cdf56abb9e09a60fbe7b10792444c9c27987bb6d3b450fa", size = 307583, upload-time = "2026-08-17T08:22:22.541Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/11/cf0bc07feb2791045b6ac075d4bf64f1a5beedef2f46ae70d7104d63a19f/xxhash-4.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1749f0688020209fe0d357ce1e1cd9ec9c6161ed0405ea949d24581c4c43fa91", size = 265848, upload-time = "2026-08-17T08:35:31.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c4/7ada4bea2a2795073dfc42d96842930efbe7a0c1857ef4b522e4e90e5d83/xxhash-4.0.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:94ac8a6b8c47951173f0b67bf862bcb971bf24e493b9fbbdb0e010cbbc7d9f54", size = 284409, upload-time = "2026-08-17T08:21:23.156Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f4/d8ce83dd6b99ccfbdadaf2db968ae40334d2e5f73a0297e593b9ddb3df39/xxhash-4.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a33de7633c948ab2dc144af370a66e7e7af29b425dcd0f7e4f59689fb9391b53", size = 335921, upload-time = "2026-08-17T08:22:21.802Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9f/f47d8724bd8bc45b395b06b7cacea2dae0d00031af1b707184a091161df6/xxhash-4.0.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:247ece770647c0aef080561fa996f9774b4dadce2d0c42eeb98229db7dcf820d", size = 487023, upload-time = "2026-08-17T08:22:19.729Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/2d87098f3371cc1e42dd04d2285ad56bca4c56667bc501bff02d2b9fd6b5/xxhash-4.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a4553d36cc0b7fce1f35ba8a94dfd775aa3ed12f5eab2dc3b46ac75a0706b0bb", size = 264333, upload-time = "2026-08-17T08:35:27.001Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b8/93795ca5898ec7d7d0455283ad261c0fc76b4f0c0a69e86233bd7badb0bd/xxhash-4.0.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:87aa309a93bd5ec13f14309a305ff4e9bf74c5363fc46c264c0a22edfd5b0670", size = 20581, upload-time = "2026-08-17T08:21:39.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/96/926f7335a0a1647952c00421e8da877f658094f61336306c7cadc335c94d/xxhash-4.0.1-cp313-cp313-win32.whl", hash = "sha256:cba763d84b06bda2c38d5185dee76f1b9dfdc0789e96e476d9e10005526d0788", size = 34449, upload-time = "2026-08-17T08:22:29.362Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/61/8a5aeb811de093bab3434e77eff0e9461624a1a56a6a93d315d080aab2aa/xxhash-4.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:97b94fb29abf21f5f0bde15f7dbdd3a4aa2dc59f37026adc7b4bee8563b84375", size = 36520, upload-time = "2026-08-17T08:35:34.852Z" },
+    { url = "https://files.pythonhosted.org/packages/04/14/97f3c74000ca36955e9cb86f6d270dcd5848b5c65afa623453f5cf2d83d6/xxhash-4.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:08ed8da18cd4fd0a6a5d6a444852d8fbd0e565388a74a4937085451b5f1a312a", size = 33428, upload-time = "2026-08-17T08:21:31.713Z" },
 ]
 
 [[package]]
@@ -4617,7 +4669,7 @@ wheels = [
 
 [[package]]
 name = "yfinance"
-version = "1.6.0"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -4633,9 +4685,9 @@ dependencies = [
     { name = "requests" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/ab/55578b5b7f0ccb4862dc0ee2b03defc09062fb51937e3c83a0bf61eafe02/yfinance-1.6.0.tar.gz", hash = "sha256:c32c45b42480d64981e89d65da3f480fd6910fe1972d7e78f1e2d91b45d9ee1b", size = 173489, upload-time = "2026-08-13T13:38:52.295Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/94/fefb0afc174ac1ce4f6b231c62ca30168ac29d8c937cab8d01a748d9cd0e/yfinance-1.7.0.tar.gz", hash = "sha256:442f780d13d3e52fefa6c721c2c9bfee321078c1987d6585ec193b5c24382f8a", size = 176142, upload-time = "2026-08-26T17:25:08.102Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/eb/7d0fefa48c2a6b1b192b08fc95af206e6e6d14359053670cb76b9ec1a817/yfinance-1.6.0-py3-none-any.whl", hash = "sha256:2ced6339a90e5721269a18d245757c7592163c897a7cd2b9a2dfd1d8fd30590e", size = 148022, upload-time = "2026-08-13T13:38:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/12/7efaf78fcf63711ad7271704dd22963b4cbe05d95d89b9865a1c5c0bad6f/yfinance-1.7.0-py3-none-any.whl", hash = "sha256:91281ecd1f71069a37155ff8653aff2d3085f3492bd8721f18b70955da62911a", size = 149341, upload-time = "2026-08-26T17:25:06.726Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hardens the Dependabot auto-merge workflow. `fjacquet/ci` lints workflows with **zizmor**, which rejected the version this repo has on two counts:

```
dependabot-automerge.yml:2:  use of fundamentally insecure workflow trigger
dependabot-automerge.yml:11: spoofable bot actor check
```

### bot-conditions — fixed, not suppressed

The guard now reads the PR author from the event payload:

```yaml
if: github.event.pull_request.user.login == 'dependabot[bot]'
```

instead of `github.actor`, which zizmor's `bot-conditions` audit flags as spoofable. This is a real weakness, not a false positive.

### dangerous-triggers — suppressed with justification

`pull_request_target` is required, not incidental: on a `pull_request` event a Dependabot PR gets a **read-only** `GITHUB_TOKEN`, which cannot enable auto-merge. It is the trigger GitHub's own *Automating Dependabot with GitHub Actions* guidance uses for this job.

It is safe here **only** because the job never checks out the PR — there is no `actions/checkout` step, so no untrusted code runs with the write-scoped token. That reasoning is now written into the file itself, so the next person editing it does not add a checkout step and silently turn this into a real vulnerability.

Verified with `uvx zizmor`: *No findings to report.*

