### PR TITLE
fix: BRK-B share class, and keep the traceback when a backtest fails

### DIFF
--- a/src/finwiz/discovery/ticker_hygiene.py
+++ b/src/finwiz/discovery/ticker_hygiene.py
@@ -8,6 +8,14 @@ Single source of truth for two classes of yfinance noise observed in runs:
 * **Non-tradable placeholders** — instrument codes that are not quotable
   securities (e.g. ``XTSLA``, a BlackRock cash-sweep line that leaks in from
   ETF holdings expansion) and 404 on every yfinance lookup.
+* **Dotted share classes** — Yahoo writes a US share class with a dash
+  (``BRK-B``) while the screening universe carries the dot form (``BRK.B``),
+  which returns "No data found" on every lookup.
+
+The share-class map is an explicit allow-list, never a pattern: a dot is also
+an exchange suffix, and London's is a single letter (``IDPE.L``), so a rule
+like "one letter after the dot becomes a dash" would silently break every
+LSE holding.
 
 Apply :func:`canonical_symbol` at the bare-ticker stage (before the ``-USD``
 suffix) and filter with :func:`is_tradable` at fetch boundaries so the old
@@ -24,6 +32,12 @@ CRYPTO_SYMBOL_RENAMES: dict[str, str] = {
     "FTM": "S",  # Fantom rebranded to Sonic (S) (2024)
 }
 
+# Dot-form share classes that Yahoo quotes with a dash. Explicit entries only —
+# see the module docstring for why this must not be a pattern.
+SHARE_CLASS_RENAMES: dict[str, str] = {
+    "BRK.B": "BRK-B",  # Berkshire Hathaway class B, in the static stock universe
+}
+
 # Symbols that are not quotable securities and 404 on every yfinance call.
 NON_TRADABLE_SYMBOLS: frozenset[str] = frozenset(
     {
@@ -38,6 +52,7 @@ def canonical_symbol(ticker: str) -> str:
     Idempotent and case-insensitive on input; returns an upper-cased symbol.
     """
     symbol = ticker.strip().upper()
+    symbol = SHARE_CLASS_RENAMES.get(symbol, symbol)
     return CRYPTO_SYMBOL_RENAMES.get(symbol, symbol)
 
 

--- a/src/finwiz/quantitative/backtesting.py
+++ b/src/finwiz/quantitative/backtesting.py
@@ -172,7 +172,13 @@ class BacktestingEngine:
         except Exception as e:
             # Cerebro itself failed (data feed, analyzer setup, etc.). Bubble
             # up — the caller still wants visibility into "no backtest at all".
-            self.logger.error(f"Error during backtest execution: {e}")
+            #
+            # Log the traceback, not just the message. The 2026-09-05 run lost
+            # three holdings to `index 252 is out of bounds for axis 0 with
+            # size 252` raised somewhere inside cerebro.run(), and the bare
+            # message names neither the frame nor the array — the failure could
+            # not be reproduced afterwards from the log alone.
+            self.logger.exception(f"Error during backtest execution: {e}")
             raise
 
         # Calculate performance metrics with a safe-default fallback. The

--- a/src/finwiz/tools/quantitative_comprehensive_analyzer.py
+++ b/src/finwiz/tools/quantitative_comprehensive_analyzer.py
@@ -93,7 +93,10 @@ def perform_comprehensive_analysis(
         if backtest_result is not None:
             quant_backtest = _create_backtest_result(input_data.symbol, backtest_result)
     except Exception as e:
-        logger.error(f"Backtest failed for {input_data.symbol}: {e}")
+        # exception(), not error(): this boundary swallows the raise so the
+        # other two analyses survive, so it is the last place the traceback
+        # can still be recorded.
+        logger.exception(f"Backtest failed for {input_data.symbol}: {e}")
 
     metrics = None
     quant_perf = None

--- a/tests/unit/discovery/test_ticker_hygiene.py
+++ b/tests/unit/discovery/test_ticker_hygiene.py
@@ -29,6 +29,46 @@ class TestCanonicalSymbol:
         assert canonical_symbol(canonical_symbol("MATIC")) == "POL"
 
 
+class TestShareClassRenames:
+    """Yahoo writes share classes with a dash; the screening universe uses a dot."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("BRK.B", "BRK-B"),
+            ("brk.b", "BRK-B"),
+            ("  BRK.B  ", "BRK-B"),
+        ],
+    )
+    def test_dotted_share_class_becomes_dashed(self, raw: str, expected: str) -> None:
+        assert canonical_symbol(raw) == expected
+
+    def test_idempotent(self) -> None:
+        assert canonical_symbol(canonical_symbol("BRK.B")) == "BRK-B"
+
+    @pytest.mark.parametrize(
+        "ticker",
+        [
+            "IDPE.L",  # London — a one-letter suffix, same shape as a share class
+            "HYLD.L",
+            "IJPA.L",
+            "SUAS.L",
+            "NESN.SW",
+            "EL.PA",
+            "VOW.DE",
+            "SCL.F",
+            "IESE.AS",
+            "QDV5.DU",
+        ],
+    )
+    def test_exchange_suffixes_are_left_alone(self, ticker: str) -> None:
+        """A dot is also an exchange suffix. Only known share classes may move."""
+        assert canonical_symbol(ticker) == ticker
+
+    def test_sanitize_applies_share_class_rename(self) -> None:
+        assert sanitize_symbols(["BRK.B", "AAPL", "IDPE.L"]) == ["AAPL", "BRK-B", "IDPE.L"]
+
+
 class TestIsTradable:
     def test_non_tradable_excluded(self) -> None:
         assert is_tradable("XTSLA") is False

--- a/tests/unit/discovery/test_ticker_utils.py
+++ b/tests/unit/discovery/test_ticker_utils.py
@@ -13,11 +13,20 @@ from finwiz.discovery.ticker_utils import to_yfinance_symbol
 
 
 class TestStockAndETFPassThrough:
-    """Stock and ETF tickers should be returned unchanged (beyond upper-casing)."""
+    """Stock and ETF tickers are returned unchanged, apart from known renames.
 
-    @pytest.mark.parametrize("ticker", ["AAPL", "MSFT", "GOOG", "BRK.B"])
+    ``BRK.B`` used to be listed here as a pass-through example. It is not one:
+    Yahoo quotes that share class as ``BRK-B`` and returns "No data found" for
+    the dot form, so ``canonical_symbol`` rewrites it. See
+    ``TestShareClassRenames`` in ``test_ticker_hygiene.py``.
+    """
+
+    @pytest.mark.parametrize("ticker", ["AAPL", "MSFT", "GOOG", "NESN.SW", "IDPE.L"])
     def test_stock_pass_through(self, ticker: str) -> None:
         assert to_yfinance_symbol(ticker, "stock") == ticker.upper()
+
+    def test_dotted_share_class_is_rewritten_for_yahoo(self) -> None:
+        assert to_yfinance_symbol("BRK.B", "stock") == "BRK-B"
 
     @pytest.mark.parametrize("ticker", ["QQQ", "SPY", "VOO", "IEMG"])
     def test_etf_pass_through(self, ticker: str) -> None:

--- a/tests/unit/quantitative/test_backtesting.py
+++ b/tests/unit/quantitative/test_backtesting.py
@@ -1228,3 +1228,53 @@ class TestStrategyExecution:
         assert len(result.portfolio_values) > 0
         # Portfolio values should be tracked daily
         assert len(result.portfolio_values) >= 100  # At least 100 days of data
+
+
+class TestBacktestFailureLeavesATrace:
+    """A cerebro failure must record the traceback, not just the message.
+
+    The 2026-09-05 run lost CVLT, GOOGL and HPE to `index 252 is out of bounds
+    for axis 0 with size 252`, raised inside cerebro.run(). The bare message
+    named neither the frame nor the array, and the failure did not reproduce
+    afterwards — the evidence needed to fix it had already been discarded.
+    """
+
+    def test_cerebro_failure_logs_the_traceback(self, mocker, caplog) -> None:
+        import logging
+
+        from finwiz.quantitative.backtesting import (
+            BacktestingEngine,
+            SimpleMovingAverageStrategy,
+        )
+
+        engine = BacktestingEngine()
+        bars = 300
+        frame = pd.DataFrame(
+            {
+                "Open": [100.0] * bars,
+                "High": [101.0] * bars,
+                "Low": [99.0] * bars,
+                "Close": [100.5] * bars,
+                "Volume": [1_000] * bars,
+            },
+            index=pd.date_range("2025-01-01", periods=bars, freq="D"),
+        )
+        mocker.patch.object(engine.data_manager, "fetch_historical_data", return_value=frame)
+        mocker.patch.object(
+            bt.Cerebro,
+            "run",
+            side_effect=IndexError("index 252 is out of bounds for axis 0 with size 252"),
+        )
+
+        with caplog.at_level(logging.ERROR), pytest.raises(IndexError):
+            engine.run_strategy_backtest(
+                SimpleMovingAverageStrategy,
+                "GOOGL",
+                datetime(2025, 1, 1),
+                datetime(2025, 12, 31),
+                strategy_params={"short_period": 20, "long_period": 50},
+            )
+
+        failures = [r for r in caplog.records if "Error during backtest execution" in r.message]
+        assert failures, "the cerebro failure was not logged at all"
+        assert failures[0].exc_info is not None, "logged without a traceback — the evidence is gone"


### PR DESCRIPTION
Two defects the 2026-09-05 live run surfaced. Independent; separate commits.

## 1. `BRK.B` never resolves

Every momentum and breakout scan logs `$BRK.B: No data found, symbol may be delisted` — twice in yesterday's run, four times across the August runs. Berkshire can never surface as a discovery candidate.

Yahoo quotes US share classes with a dash. Verified directly:

| symbol | rows over 1 month |
|---|---|
| `BRK.B` | 0 |
| `BRK-B` | 23 |

Fixed in `discovery/ticker_hygiene.py`, which its own docstring already calls the single source of truth for yfinance noise observed in runs. Every universe path funnels through it (`universe_provider.get_universe` sanitises both the dynamic result and the static top-up), and it also reaches `ticker_utils.to_yfinance_symbol`, which composes `canonical_symbol`.

**The map is an explicit allow-list, deliberately not a pattern.** A dot is also an exchange suffix, and London's is a single letter — `IDPE.L`, `HYLD.L`, `IJPA.L`, `SUAS.L` are all current holdings. A rule like "one letter after the dot becomes a dash" would break every LSE line. The new test pins ten exchange-suffixed tickers as untouched for exactly that reason.

Verified against the real universe: 66 raw symbols in, `BRK.B` absent from the sanitised output, `BRK-B` present.

**Upstream note:** the dot form originates in `crewai_custom_tools/tools/analytics/screening_utils.py:194`, a separate repo. Fixing it at the hygiene seam covers both consumers here, but a new dotted share class added upstream will re-enter the same way. Worth a follow-up there.

## 2. A failing backtest destroys its own evidence

The run lost CVLT, GOOGL and HPE to:

```
Error during backtest execution: index 252 is out of bounds for axis 0 with size 252
```

raised inside `cerebro.run()`. The message names neither the frame nor the array, and none of the three reproduce afterwards — the same strategy over the same 365-day window succeeds for all of them. The information needed to find the off-by-one was thrown away at the one moment it existed.

Both failure paths now log with the traceback attached. `logger.exception` is already the codebase convention for this — `data_processors.py:148` documents the same reasoning, `crew_factory` uses `exc_info=True` throughout.

**This is not a fix for the off-by-one.** The root cause is not known, and guessing at it would be worse than waiting. This is what makes the next occurrence diagnosable.

## Verification

- `make check` green: 5156 passed, 31 skipped.
- The traceback test was checked negatively: it fails against `logger.error`, passes against `logger.exception`.
- `plotly 7.0` was separately exercised while investigating — both visualisation paths in `quantitative/performance_benchmarks.py` build figures and write valid HTML. No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwsV4WdanisV9UBdGadCWe