### PR TITLE
fix(llm): stop sharing one LLM object across crews — it inflated usage 32×

### DIFF
--- a/docs/superpowers/plans/2026-09-05-optimal-allocation.md
+++ b/docs/superpowers/plans/2026-09-05-optimal-allocation.md
@@ -740,10 +740,7 @@ class AllocationOrchestrator:
             return None
 
         return OptimalAllocation(
-            targets=[
-                HoldingTarget(ticker=t, asset_class=class_of.get(t, "unknown"), current_weight=current.get(t, 0.0), target_weight=w)
-                for t, w in weights.items()
-            ],
+            targets=[HoldingTarget(ticker=t, asset_class=class_of.get(t, "unknown"), current_weight=current.get(t, 0.0), target_weight=w) for t, w in weights.items()],
             excluded=sorted(excluded, key=lambda e: e.ticker),
             observations=len(matrix),
             window_start=str(matrix.index.min().date()),

--- a/docs/superpowers/roadmaps/2026-09-05-reevaluation.md
+++ b/docs/superpowers/roadmaps/2026-09-05-reevaluation.md
@@ -53,6 +53,10 @@ Per-holding call counts by asset class:
 
 *Open unknown.* The `deep_analysis` crew has **1 agent, 1 task, `max_iter=2`, `reasoning=False`** (`crews/deep_analysis/deep_analysis.py:294-353`). That configuration cannot account for 62 calls per holding — nor for 18. Either the counter aggregates something else (retries, tool-internal LLM calls, several crews per holding) or there is a loop. This must be measured, not guessed. It is a spike, and it gates any decision about F2's phases, whose real cost is currently unknown.
 
+*Resolved by the workstream B spike, same day.* The counter aggregates. CrewAI keeps token usage on the **LLM object** (`BaseLLM._token_usage`, `+=` per request, never reset by `kickoff`) and `Crew.calculate_usage_metrics` reads it as the crew's own usage. finwiz's `config/llm/llm_config.py` cached LLM instances by `(model, type, max_tokens, json, reasoning)`, so all 64 holdings shared one object and each kickoff reported the running total of every holding before it. The summary then summed running totals. Signature: 35 stocks at one request each, cumulative, is 1+2+…+35 = 630; measured 633.
+
+Consequences: the real deep-analysis spend is ≈ 65–70 requests and ≈ 0.5 M tokens — a **32× overstatement**. The per-class asymmetry above is an artifact of record ordering; **crypto is not more expensive than stocks. Retracted.** The cache saved 13.5 ms per crew (1.1 s per 23-minute run) and had already forced a second bug-class into its own key (`LLM_REASONING_EFFORT` staleness). Deleted rather than bypassed. The pricing half stands: `openrouter/google/gemini-3.7-flash` is unpriced in litellm while `gemini/gemini-3.7-flash` is ($0.75 / $3.75 per M); a fallback lookup now prices through the vendor-native id and says so.
+
 ### F4. A requirement that 100 % of outputs violate
 
 128 warnings `Quality validation warnings for <ticker>: Word count N < M (Requirement 9.2); Executive summary N words < M` — exactly 64 × 2. Every holding fails, twice. A requirement violated by every output is either wrong or ignored; either way it hides real signal under constant noise.

--- a/src/finwiz/config/llm/llm_config.py
+++ b/src/finwiz/config/llm/llm_config.py
@@ -199,9 +199,6 @@ def _apply_reasoning_effort(extra_body: dict[str, Any], model: str, reasoning_ef
 # LLM Instance Cache
 # =============================================================================
 
-# Cache for LLM instances to avoid repeated initialization
-_llm_cache: dict[str, LLM] = {}
-
 
 def _get_model_from_env(env_var: str, fallback: str = "openai/gpt-4o-mini") -> str:
     """
@@ -326,19 +323,8 @@ def get_configured_llm(
         fallback = "openai/gpt-4o" if model_type == "baseline" else "openai/gpt-4o-mini"
         model = _get_model_from_env(env_var, fallback)
 
-    # Reasoning effort is resolved up front (env-driven) because it affects
-    # extra_body, which must be part of the cache key below — otherwise a
-    # changed LLM_REASONING_EFFORT would silently return a stale cached
-    # instance built with the old effort.
     reasoning_effort = _resolve_reasoning_effort()
     reasoning_params = _get_reasoning_params(model, reasoning_effort)
-
-    # Check cache first (include max_tokens + json mode + reasoning effort so callers
-    # with different needs get distinct instances)
-    cache_key = f"{model}:{model_type}:{max_tokens}:json={force_json_object}:reasoning={reasoning_effort}"
-    if cache_key in _llm_cache:
-        logger.debug(f"Returning cached LLM instance for {cache_key}")
-        return _llm_cache[cache_key]
 
     # Validate API key for the model's provider
     _validate_api_key_for_model(model)
@@ -416,9 +402,6 @@ def get_configured_llm(
             # Extra params for provider-specific features
             extra_body=extra_body if extra_body else None,
         )
-
-        # Cache the instance
-        _llm_cache[cache_key] = llm
 
         parallel_status = "disabled" if disable_parallel else "enabled"
         reasoning_status = reasoning_effort if reasoning_params else "none"

--- a/src/finwiz/infrastructure/monitoring/litellm_callback.py
+++ b/src/finwiz/infrastructure/monitoring/litellm_callback.py
@@ -29,6 +29,23 @@ def clear_crew_context() -> None:
     _current_crew_name.set("unknown")
 
 
+# OpenRouter model ids are not in litellm's price table, but the vendor-native
+# id usually is (`openrouter/google/gemini-3.7-flash` → `gemini/gemini-3.7-flash`).
+# Pricing through the twin is a proxy — OpenRouter's rate is not necessarily the
+# vendor's — so a hit through this map is logged as an estimate, once per model.
+# Only vendors listed here are tried; an unknown vendor stays honestly unpriced.
+_OPENROUTER_NATIVE_PREFIX: dict[str, str] = {"google": "gemini"}
+
+
+def _price_candidates(model: str) -> list[str]:
+    """Return the model ids to try for pricing, most faithful first."""
+    candidates = [model]
+    parts = model.split("/", 2)
+    if len(parts) == 3 and parts[0] == "openrouter" and parts[1] in _OPENROUTER_NATIVE_PREFIX:
+        candidates.append(f"{_OPENROUTER_NATIVE_PREFIX[parts[1]]}/{parts[2]}")
+    return candidates
+
+
 class TokenMonitorCallback(CustomLogger):
     """
     LiteLLM callback to monitor token usage and prompt sizes.
@@ -47,6 +64,8 @@ class TokenMonitorCallback(CustomLogger):
         # not price (unknown/unpriced model). Lets the summary show "cost n/a"
         # instead of implying $0 — honesty over a false zero.
         self.crew_cost_known: dict[str, bool] = {}
+        # Proxy model ids already announced in the log — one line per model, not per kickoff.
+        self._priced_via_proxy: set[str] = set()
 
     def log_success_event(self, kwargs: dict, response_obj: Any, start_time: float, end_time: float) -> None:
         """Called after successful LLM call. Tracks cost and crew attribution."""
@@ -102,15 +121,22 @@ class TokenMonitorCallback(CustomLogger):
 
         cost: float | None = None
         if model:
-            try:
-                prompt_cost, completion_cost = litellm.cost_per_token(
-                    model=model,
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                )
+            for candidate in _price_candidates(model):
+                try:
+                    prompt_cost, completion_cost = litellm.cost_per_token(
+                        model=candidate,
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                    )
+                except Exception as exc:
+                    # Expected for an unpriced id: try the next candidate, or stay honestly unknown.
+                    logger.debug(f"No litellm price for {candidate}: {exc}")
+                    continue
                 cost = float(prompt_cost) + float(completion_cost)
-            except Exception:
-                cost = None  # unpriced model: tokens stay honest, cost unknown
+                if candidate != model and candidate not in self._priced_via_proxy:
+                    self._priced_via_proxy.add(candidate)
+                    logger.info(f"Pricing {model} via {candidate}: OpenRouter's rate may differ from the vendor's, so this cost is an estimate")
+                break
 
         self.call_count += calls
         self.crew_calls[crew_name] = self.crew_calls.get(crew_name, 0) + calls

--- a/tests/unit/config/test_llm_config_json_mode.py
+++ b/tests/unit/config/test_llm_config_json_mode.py
@@ -15,7 +15,6 @@ def _capture_llm_kwargs(mocker):
     """Patch the LLM ctor + API-key validation; return a Mock capturing LLM() kwargs."""
     mock_llm = mocker.patch.object(llm_config, "LLM")
     mocker.patch.object(llm_config, "_validate_api_key_for_model")
-    llm_config._llm_cache.clear()
     return mock_llm
 
 

--- a/tests/unit/config/test_llm_config_reasoning_effort.py
+++ b/tests/unit/config/test_llm_config_reasoning_effort.py
@@ -21,7 +21,6 @@ def _capture_llm_kwargs(mocker):
     """Patch the LLM ctor + API-key validation; return a Mock capturing LLM() kwargs."""
     mock_llm = mocker.patch.object(llm_config, "LLM")
     mocker.patch.object(llm_config, "_validate_api_key_for_model")
-    llm_config._llm_cache.clear()
     return mock_llm
 
 
@@ -143,17 +142,3 @@ class TestGetConfiguredLlmReasoningEffort:
         extra_body = mock_llm.call_args.kwargs["extra_body"]
         assert extra_body["reasoning"] == {"effort": "low"}
         assert extra_body["response_format"] == {"type": "json_object"}
-
-    def test_should_cache_distinct_instances_per_reasoning_effort(self, mocker, monkeypatch):
-        mock_llm = _capture_llm_kwargs(mocker)
-        mock_llm.side_effect = lambda **kw: mocker.Mock(name="llm")
-        model = "openrouter/z-ai/glm-5.2"
-
-        monkeypatch.setenv("LLM_REASONING_EFFORT", "low")
-        low_instance = llm_config.get_configured_llm(model_override=model)
-
-        monkeypatch.setenv("LLM_REASONING_EFFORT", "high")
-        high_instance = llm_config.get_configured_llm(model_override=model)
-
-        assert low_instance is not high_instance
-        assert mock_llm.call_count == 2

--- a/tests/unit/crews/test_llm_instance_isolation.py
+++ b/tests/unit/crews/test_llm_instance_isolation.py
@@ -1,0 +1,39 @@
+"""Each crew must own its LLM object, or CrewAI's per-LLM token counter bleeds across crews.
+
+CrewAI accumulates token usage on the LLM instance (``BaseLLM._token_usage``,
+``+=`` on every request, never reset by ``kickoff``) and reports it through
+``Crew.calculate_usage_metrics`` as if it were this crew's usage. When two crews
+share one LLM object, each kickoff reports the running total of every crew that
+used the object before it. The 2026-09-05 run summed those running totals into
+2 080 "calls" for ~65 real requests — a 32x overstatement that made crypto look
+3.4x more expensive than stocks. It was an artifact of record ordering.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from finwiz.crews.deep_analysis.deep_analysis import DeepAnalysisCrew
+
+
+@pytest.fixture(autouse=True)
+def _keys(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-placeholder")
+    monkeypatch.setenv("SERPER_API_KEY", "x")
+
+
+class TestLLMInstanceIsolation:
+    def test_two_crews_do_not_share_an_llm_object(self) -> None:
+        a = DeepAnalysisCrew().asset_analyst().llm
+        b = DeepAnalysisCrew().asset_analyst().llm
+        assert a is not b, "two crews share one LLM object; CrewAI's token counter will bleed across them"
+
+    def test_usage_recorded_on_one_crew_is_invisible_to_another(self) -> None:
+        first, second = DeepAnalysisCrew(), DeepAnalysisCrew()
+        llm_first = first.asset_analyst().llm
+
+        # Simulate one request landing on the first crew's LLM, the way CrewAI does.
+        llm_first._track_token_usage_internal({"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120})
+
+        assert second.crew().calculate_usage_metrics().successful_requests == 0
+        assert first.crew().calculate_usage_metrics().successful_requests == 1

--- a/tests/unit/infrastructure/monitoring/test_litellm_callback_cost.py
+++ b/tests/unit/infrastructure/monitoring/test_litellm_callback_cost.py
@@ -192,3 +192,50 @@ class TestHonestSummary:
         msgs = " ".join(r.message for r in caplog.records)
         assert "cost n/a" in msgs
         assert "estimated" in msgs
+
+
+class TestOpenRouterPricingFallback:
+    """OpenRouter ids are unpriced in litellm; the vendor-native id usually is not.
+
+    `openrouter/google/gemini-3.7-flash` has no litellm price while
+    `gemini/gemini-3.7-flash` does. Pricing through the native id is a proxy —
+    OpenRouter's rate is not necessarily the vendor's — so it must be logged as
+    one, and it must never be tried for vendors without a known native twin.
+    """
+
+    @staticmethod
+    def _gemini_only(model: str, prompt_tokens: int, completion_tokens: int):
+        if model.startswith("openrouter/"):
+            raise Exception("no pricing for model")
+        assert model == "gemini/gemini-3.7-flash"
+        return (0.001, 0.002)
+
+    def test_openrouter_google_model_is_priced_through_the_gemini_id(self, mocker):
+        spy = mocker.patch("litellm.cost_per_token", side_effect=self._gemini_only)
+        cb = TokenMonitorCallback()
+
+        cb.record_usage("deep_analysis_stock", _usage(100, 50), model="openrouter/google/gemini-3.7-flash")
+
+        assert cb.crew_cost_known["deep_analysis_stock"] is True
+        assert cb.total_cost == pytest.approx(0.003)
+        assert [c.kwargs["model"] for c in spy.call_args_list] == ["openrouter/google/gemini-3.7-flash", "gemini/gemini-3.7-flash"]
+
+    def test_proxy_pricing_is_logged_once_per_model(self, mocker, caplog):
+        mocker.patch("litellm.cost_per_token", side_effect=self._gemini_only)
+        cb = TokenMonitorCallback()
+
+        with caplog.at_level(logging.INFO):
+            cb.record_usage("a", _usage(), model="openrouter/google/gemini-3.7-flash")
+            cb.record_usage("b", _usage(), model="openrouter/google/gemini-3.7-flash")
+
+        proxy_lines = [r for r in caplog.records if "gemini/gemini-3.7-flash" in r.message and "estimate" in r.message]
+        assert len(proxy_lines) == 1
+
+    def test_no_fallback_for_vendors_without_a_native_twin(self, mocker):
+        spy = mocker.patch("litellm.cost_per_token", side_effect=Exception("no pricing for model"))
+        cb = TokenMonitorCallback()
+
+        cb.record_usage("x", _usage(), model="openrouter/z-ai/glm-5.2")
+
+        assert cb.crew_cost_known["x"] is False
+        assert spy.call_count == 1


### PR DESCRIPTION
Workstream **B** of the reevaluation roadmap (#160). Spike verdict, then the fix.

## The symptom

The 2026-09-05 run reported **2 080 LLM calls, 15.9 M tokens** for deep analysis, with crypto at **62 calls per holding** against 18 for stocks. The crew behind those numbers has one agent, one task, `tools=[]`, `max_iter=2`. It makes about one request per kickoff.

## The cause

CrewAI keeps token usage **on the LLM object** (`BaseLLM._token_usage`, `+=` per request, never reset by `kickoff`), and `Crew.calculate_usage_metrics` reads it as the crew's own usage. `config/llm/llm_config.py` cached LLM instances by `(model, type, max_tokens, json, reasoning)` — so all 64 holdings' crews held **the same object**. Each kickoff reported the running total of every holding before it; the summary summed running totals.

The signature is exact: 35 stocks at one request each, cumulative, is 1+2+…+35 = **630**. Measured: **633**.

| Claim from the run | Reality |
|---|---|
| 2 080 calls | ≈ 65–70 |
| 15.9 M tokens | ≈ 0.5 M |
| crypto 3.4× a stock | artifact of record ordering under 10 workers — **retracted** |

## Why delete rather than bypass

The cache saved **13.5 ms per crew build — 1.1 s on a 23-minute run**. It had already forced a second bug class into its own key (a changed `LLM_REASONING_EFFORT` returned a stale instance; the comment justifying the key is the evidence). Nothing in `src/` depends on shared identity; the 67 call sites are unchanged.

## Pricing, the other half

`openrouter/google/gemini-3.7-flash` has no litellm price, so the summary read `$0.0000`. `gemini/gemini-3.7-flash` is priced ($0.75 / $3.75 per M). `record_usage` now tries the vendor-native twin for OpenRouter ids of **known vendors only**, and logs once per model that the figure is an estimate — OpenRouter's rate is not necessarily Google's. Unknown vendors stay honestly unpriced.

## Verification

- Regression tests: two fresh crews must not share an LLM object; usage tracked on one crew's LLM is invisible to another's `calculate_usage_metrics`. **Both failed before the change.**
- Pricing fallback: priced through the twin, logged once, not attempted for unknown vendors. Two of three failed before.
- `make check` green: 5 138 passed.
- **The real proof is the next `crewai flow kickoff`**: deep analysis should read ≈ 65–70 calls, ≈ 0.5 M tokens, and a **priced** cost of roughly $0.50 instead of `n/a`.

The roadmap's F3 is corrected in place, under the original reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwsV4WdanisV9UBdGadCWe