### PR TITLE
fix(reporting): retire the Requirement 9.2 quality thresholds nothing enforced

### DIFF
--- a/src/finwiz/config/settings.py
+++ b/src/finwiz/config/settings.py
@@ -76,35 +76,6 @@ class HybridAnalysisSettings(BaseModel):
         description="Maximum LLM cost per holding in dollars (default: $0.10)",
     )
 
-    # Quality Thresholds (Requirements 7.3, 7.4)
-    min_report_word_count: int = Field(
-        default=2000,
-        ge=500,
-        le=10000,
-        description="Minimum report word count (default: 2000 words)",
-    )
-
-    min_unique_insights_count: int = Field(
-        default=5,
-        ge=1,
-        le=50,
-        description="Minimum number of unique qualitative insights (default: 5)",
-    )
-
-    min_executive_summary_words: int = Field(
-        default=200,
-        ge=50,
-        le=1000,
-        description="Minimum executive summary word count (default: 200 words)",
-    )
-
-    min_investment_rationale_words: int = Field(
-        default=500,
-        ge=100,
-        le=2000,
-        description="Minimum investment rationale word count (default: 500 words)",
-    )
-
     # Batch Processing Thresholds (Requirements 10.1, 10.2)
     max_batch_processing_time_seconds: float = Field(
         default=1800.0,
@@ -142,11 +113,6 @@ class HybridAnalysisSettings(BaseModel):
     log_performance_warnings: bool = Field(
         default=True,
         description="Log warnings when performance thresholds are exceeded (default: True)",
-    )
-
-    log_quality_warnings: bool = Field(
-        default=True,
-        description="Log warnings when quality thresholds are not met (default: True)",
     )
 
 

--- a/src/finwiz/reporting/enriched_analysis_report_generator.py
+++ b/src/finwiz/reporting/enriched_analysis_report_generator.py
@@ -28,11 +28,11 @@ class EnrichedAnalysisReportGenerator:
     EnrichedAnalysis data. Provides fast, deterministic, and testable
     report generation combining quantitative and qualitative insights.
 
-    Validates:
-        - Word count ≥2000 words (Requirement 9.2)
-        - Insights count ≥5 insights (Requirement 9.2)
-        - Executive summary ≥200 words (Requirement 9.2)
-        - Investment rationale ≥500 words (Requirement 9.3)
+    Logs the rendered report's word and insight counts; it does not enforce a
+    minimum. The 2000/200/500-word thresholds this class once warned about
+    came from a 2025-11 prose-heavy design whose requirements document no
+    longer exists, were violated by every holding of every run (128 warnings
+    per run, 64 x 2), and were acted upon by nothing.
     """
 
     def __init__(self, template_dir: str | Path | None = None):
@@ -87,9 +87,6 @@ class EnrichedAnalysisReportGenerator:
             else:
                 result_data = enriched_analysis
 
-            # Validate quality thresholds
-            self._validate_quality_thresholds(result_data)
-
             # Prepare template variables
             template_vars = self._prepare_template_variables(result_data)
 
@@ -113,57 +110,6 @@ class EnrichedAnalysisReportGenerator:
             ticker = result_data.get("ticker", "unknown") if "result_data" in locals() else "unknown"
             self.logger.error(f"❌ Report generation failed after {execution_time * 1000:.1f}ms for {ticker}: {e}")
             raise RuntimeError(f"Failed to generate report: {e}") from e
-
-    def _validate_quality_thresholds(self, data: dict[str, Any]) -> None:
-        """
-        Validate quality thresholds for the report.
-
-        Validates:
-            - Word count ≥2000 words (Requirement 9.2)
-            - Insights count ≥5 insights (Requirement 9.2)
-            - Executive summary ≥200 words (Requirement 9.2)
-            - Investment rationale ≥500 words (Requirement 9.3)
-
-        Args:
-            data: EnrichedAnalysis data dictionary
-
-        Raises:
-            ValueError: If quality thresholds are not met
-
-        """
-        ticker = data.get("ticker", "unknown")
-        errors = []
-
-        # Validate word count (≥2000 words)
-        word_count = data.get("report_word_count", 0)
-        if word_count < 2000:
-            errors.append(f"Word count {word_count} < 2000 (Requirement 9.2)")
-
-        # Validate insights count (≥5 insights)
-        insights_count = data.get("unique_insights_count", 0)
-        if insights_count < 5:
-            errors.append(f"Insights count {insights_count} < 5 (Requirement 9.2)")
-
-        # Validate executive summary length (≥200 words)
-        executive_summary = data.get("executive_summary", "")
-        exec_word_count = len(executive_summary.split())
-        if exec_word_count < 200:
-            errors.append(f"Executive summary {exec_word_count} words < 200 (Requirement 9.2)")
-
-        # Validate investment rationale length (≥500 words)
-        investment_rationale = data.get("investment_rationale", "")
-        rationale_word_count = len(investment_rationale.split())
-        if rationale_word_count < 500:
-            errors.append(f"Investment rationale {rationale_word_count} words < 500 (Requirement 9.3)")
-
-        if errors:
-            # Log as warning instead of raising error - allow HTML generation to proceed
-            warning_msg = f"Quality validation warnings for {ticker}: " + "; ".join(errors)
-            self.logger.warning(f"⚠️ {warning_msg}")
-        else:
-            self.logger.info(
-                f"✅ Quality validation passed for {ticker}: {word_count} words, {insights_count} insights, {exec_word_count} exec words, {rationale_word_count} rationale words"
-            )
 
     def _prepare_template_variables(self, data: dict[str, Any]) -> dict[str, Any]:
         """

--- a/tests/property/test_enriched_analysis_report_properties.py
+++ b/tests/property/test_enriched_analysis_report_properties.py
@@ -205,57 +205,34 @@ class TestRendererToleratesSkippedAnalysis:
 class TestEnrichedAnalysisReportProperties:
     """Property-based tests for EnrichedAnalysisReportGenerator."""
 
-    # Property 15: Executive Summary Length
     @given(enriched_data=enriched_analysis_strategy())
     @settings(max_examples=50, deadline=500, suppress_health_check=[HealthCheck.function_scoped_fixture])
-    def test_executive_summary_meets_minimum_length(self, enriched_data):
+    def test_report_renders_summary_and_thesis_sections(self, enriched_data):
+        """The executive summary and investment thesis sections render for any valid input.
+
+        Replaces Properties 15 and 16, which asserted that the *fixture* produced
+        >=200 / >=500 words -- a test of the strategy, not of the generator -- in
+        the name of a requirements document that no longer exists.
         """
-        **Feature: python-ai-hybrid-analysis, Property 15: Executive Summary Length**
-        **Validates: Requirements 9.2**
+        html_content = EnrichedAnalysisReportGenerator().generate_report(enriched_data)
 
-        Property: Executive summary has at least 200 words.
-
-        For any EnrichedAnalysis with an executive_summary, the word count
-        of that summary should be ≥200 words.
-        """
-        # Arrange
-        generator = EnrichedAnalysisReportGenerator()
-
-        # Act - Generate report (this validates the data)
-        html_content = generator.generate_report(enriched_data)
-
-        # Assert - Executive summary length
-        exec_summary = enriched_data["executive_summary"]
-        word_count = len(exec_summary.split())
-
-        assert word_count >= 200, f"Executive summary has {word_count} words, expected ≥200"
         assert "résumé exécutif" in html_content.lower() or "executive" in html_content.lower(), "Report must contain executive summary section"
-
-    # Property 16: Investment Rationale Length
-    @given(enriched_data=enriched_analysis_strategy())
-    @settings(max_examples=50, deadline=500, suppress_health_check=[HealthCheck.function_scoped_fixture])
-    def test_investment_rationale_meets_minimum_length(self, enriched_data):
-        """
-        **Feature: python-ai-hybrid-analysis, Property 16: Investment Rationale Length**
-        **Validates: Requirements 9.3**
-
-        Property: Investment rationale has at least 500 words.
-
-        For any EnrichedAnalysis with an investment_rationale, the word count
-        should be ≥500 words.
-        """
-        # Arrange
-        generator = EnrichedAnalysisReportGenerator()
-
-        # Act - Generate report (this validates the data)
-        html_content = generator.generate_report(enriched_data)
-
-        # Assert - Investment rationale length
-        investment_rationale = enriched_data["investment_rationale"]
-        word_count = len(investment_rationale.split())
-
-        assert word_count >= 500, f"Investment rationale has {word_count} words, expected ≥500"
         assert "investissement" in html_content.lower(), "Report must contain investment thesis section"
+
+    @given(enriched_data=enriched_analysis_strategy())
+    @settings(max_examples=25, deadline=500, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_report_generation_emits_no_quality_validation_warning(self, enriched_data, caplog):
+        """Generating a report must not log the retired 'Quality validation warnings'.
+
+        The 2026-09-05 run logged it 128 times -- 64 holdings x 2 -- for
+        thresholds nothing enforced. Noise at that volume hides real warnings.
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            EnrichedAnalysisReportGenerator().generate_report(enriched_data)
+
+        assert not [r for r in caplog.records if "Quality validation" in r.message]
 
     # Property 17: Action Plan Completeness
     @given(enriched_data=enriched_analysis_strategy())
@@ -392,102 +369,3 @@ class TestRendererShowsPriceTargets:
         assert "</html>" in html_content, "Report must close html tag"
         assert enriched_data["ticker"] in html_content, "Report must contain ticker"
         assert enriched_data["final_recommendation"] in html_content, "Report must contain recommendation"
-
-    # Additional property: Quality validation logs warnings for insufficient data
-    @given(
-        word_count=st.integers(min_value=0, max_value=1999),
-        insights_count=st.integers(min_value=0, max_value=4),
-    )
-    @settings(max_examples=20, deadline=500, suppress_health_check=[HealthCheck.function_scoped_fixture])
-    def test_quality_validation_warns_for_insufficient_data(self, word_count, insights_count, caplog):
-        """
-        Property: Quality validation logs warnings for data below thresholds.
-
-        For any EnrichedAnalysis data with word_count < 2000 or insights_count < 5,
-        quality validation should log appropriate warnings (but not block generation).
-
-        Note: The generator uses non-blocking validation - it logs warnings but
-        allows HTML generation to proceed. This test verifies warnings are logged.
-        """
-        import logging
-
-        # Arrange
-        generator = EnrichedAnalysisReportGenerator()
-
-        # Create data that violates quality thresholds but has all required template fields
-        insufficient_data = {
-            "ticker": "TEST",
-            "company_name": "Test Company",
-            "asset_class": "stock",
-            "analysis_date": datetime.now(),
-            "report_word_count": word_count,
-            "unique_insights_count": insights_count,
-            "executive_summary": " ".join(["word"] * 50),  # Too short
-            "investment_rationale": " ".join(["word"] * 100),  # Too short
-            "final_grade": "C",
-            "final_score": 0.5,
-            "final_recommendation": "HOLD",
-            "recommendation_confidence": "LOW",
-            "processing_time_seconds": 1.0,
-            "llm_cost_dollars": 0.01,
-            "quantitative": {
-                "composite_score": 0.5,
-                "fundamental_score": 0.5,
-                "technical_score": 0.5,
-                "risk_score": 2.5,
-                "grade": "C",
-                "preliminary_recommendation": "HOLD",
-                "fundamental_metrics": {},
-                "technical_indicators": {},
-                "risk_metrics": {},
-                "calculation_timestamp": datetime.now(),
-                "data_quality": {
-                    "completeness_score": 0.5,
-                    "freshness_score": 0.5,
-                    "accuracy_confidence": 0.5,
-                    "source_reliability": 0.5,
-                    "missing_fields": [],
-                },
-                "data_lineage": {
-                    "primary_sources": [],
-                    "collection_timestamp": datetime.now(),
-                    "transformation_steps": [],
-                    "cache_status": "unknown",
-                },
-                "confidence_level": 0.5,
-                "python_rationale": "",
-            },
-            "qualitative": {
-                "sec_insights": {"business_model": "", "competitive_advantages": [], "risk_factors": [], "strategic_initiatives": []},
-                "fundamental_context": {"industry_analysis": "", "growth_drivers": [], "competitive_positioning": "", "management_assessment": ""},
-                "technical_strategy": {"chart_patterns": [], "support_resistance": "", "entry_exit_strategy": "", "timing_assessment": ""},
-                "contextual_risks": {"regulatory_risks": [], "geopolitical_risks": [], "competitive_risks": [], "operational_risks": [], "stress_scenarios": []},
-                "investment_synthesis": {
-                    "investment_thesis": "",
-                    "bull_case": "",
-                    "base_case": "",
-                    "bear_case": "",
-                    "scenario_probabilities": {"bull": 0.33, "base": 0.34, "bear": 0.33},
-                    "final_recommendation": "HOLD",
-                    "recommendation_confidence": "LOW",
-                    "action_plan": {"immediate_actions": [], "monitoring_points": [], "exit_triggers": []},
-                },
-                "analysis_timestamp": datetime.now(),
-                "ai_confidence": 0.5,
-            },
-        }
-
-        # Act - capture log output
-        with caplog.at_level(logging.WARNING):
-            try:
-                generator.generate_report(insufficient_data)
-            except RuntimeError:
-                # Template rendering may fail for other reasons, that's OK
-                pass
-
-        # Assert - quality validation should have logged warnings
-        warning_logs = [record.message for record in caplog.records if record.levelno == logging.WARNING]
-        quality_warnings = [msg for msg in warning_logs if "Quality validation" in msg or "Word count" in msg or "words <" in msg]
-
-        # At least one quality warning should be logged
-        assert len(quality_warnings) > 0, f"Expected quality validation warnings, got: {warning_logs}"


### PR DESCRIPTION
Workstream **F** of the reevaluation roadmap (#160).

## The noise

128 warnings per run — 64 holdings × 2:

```
Quality validation warnings for <ticker>: Word count 1470 < 2000 (Requirement 9.2); Executive summary 46 words < 200 (Requirement 9.2); ...
```

A requirement violated by 100 % of outputs is either wrong or ignored. This one was both.

## What it encoded, and why it is gone

A 2025-11 prose-heavy design: 2 000-word reports, 200-word executive summaries, 500-word rationales, five insights. `REQUIREMENTS.md`, which it cites, **no longer exists in the repo**. The 2026-08-15 report rethink went the other way — today's reports run 1 400–1 500 words with 35–85-word summaries (median 46), and read better for it.

**Nothing acted on the warning.** No gate, no retry, no flag in the report. The validator hard-coded its thresholds and ignored the four `min_*` settings that existed for them; nothing else read those settings either.

## Removed

- `_validate_quality_thresholds` and its call site. The INFO line logging actual word/insight counts stays — that is the useful observability.
- Four `min_*` settings and `log_quality_warnings` — read by nothing.
- Properties 15/16 in the report property tests: each asserted the **fixture** produced enough words — a test of the Hypothesis strategy, not the generator. Their render assertions survive in one test.
- The property test asserting the warnings are emitted (it tested the retired behaviour).

## Added

A property test: report generation emits **no** `Quality validation` warning for any valid input. That is the deliverable.

## Noted, out of scope

`tests/property/test_deep_analysis_orchestrator_properties.py` calls `_validate_analysis_quality`, which exists nowhere in `src/`. The whole file is `pytest.mark.skip`ped, so it can never fail — a dead test file. Separate cleanup.

## Verification

`make check` green: 5 137 passed, 31 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwsV4WdanisV9UBdGadCWe