### PR TITLE
feat(analysis): one line per run on fact-pack freshness

### DIFF
--- a/docs/superpowers/roadmaps/2026-09-05-reevaluation.md
+++ b/docs/superpowers/roadmaps/2026-09-05-reevaluation.md
@@ -27,6 +27,8 @@ This document indexes workstreams. It does not design them. Each row of the tabl
 
 Evidence: `grep -c 'using stale cache' logs/finwiz.log` → 18; `analysis/stages/fact_pack.py:68-69` (fallback); `infrastructure/resilience/perplexity_retry.py` (133 warnings).
 
+*Workstream C, same day.* The empty message is not finwiz's to fix: the central tool swallows the exception and returns `None`, and its log line writes `{exc}` — empty for every httpx transport exception. Fixed upstream as crewai-custom-tools PR #37 (`{exc!r}`). finwiz pins `v0.6.0` while upstream is at `v0.31.1`, so the fix reaches finwiz only through a pin migration — workstream H below. On the finwiz side, Phase 3 now ends with one line — `fact_pack freshness: 40 fresh, 6 recent, 18 stale (oldest 2026-08-17, 19 days ago), 0 missing — 64 holdings` — at WARNING when anything is stale (PR #164). No retry or backoff was tuned: without the exception types, that would be guessing.
+
 ### F2. Three phases run and deliver nothing
 
 | Phase | What happened | What the reader got |
@@ -63,6 +65,8 @@ Consequences: the real deep-analysis spend is ≈ 65–70 requests and ≈ 0.5 M
 
 Evidence: `reporting/enriched_analysis_report_generator.py` (128 WARNING lines).
 
+*Workstream F, same day (PR #163).* Removed, not recalibrated. The requirements document it cited no longer exists; the validator hard-coded 2000/200/500 words and ignored the four `min_*` settings that existed for them; nothing read those settings either; nothing acted on the warning. Two property tests asserted their own fixture produced enough words. A new property test asserts the warning is never emitted.
+
 ### F5. Safety comes from the test suite, not from the product
 
 - **5 134 tests, all network-mocked** under the pytest-socket guard. Strong on logic, blind on integrations: yfinance 1.7.0 shipped in 5.14.1 with zero real API calls exercised. There is no scheduled integration tier.
@@ -85,36 +89,42 @@ Grades, decisions, current allocation, posture, stress tests — yes. Not receiv
 | #157 | Release 5.14.1 |
 | #158 | `BRK.B → BRK-B` at the ticker-hygiene seam; backtest failures keep their traceback |
 | #159 | Delete the dead scipy optimiser stack (1 578 lines) |
-| — | Spec + plan for optimal allocation, on branch `docs/optimal-allocation-spec` |
+| #160 / #161 | This roadmap; optimal-allocation spec + plan (workstream G) |
+| #162 | **B** — LLM cache deleted; usage was overstated 32×; OpenRouter ids priced through the vendor twin |
+| #163 | **F** — Requirement 9.2 thresholds retired |
+| #164 | **C** (finwiz half) — per-run fact-pack freshness line |
+| crewai-custom-tools #37 | **C** (upstream half) — transport errors logged with `repr` |
 
 ## Workstreams
 
 | # | Workstream | Nature | Size | Depends on | Addresses |
 |---|---|---|---|---|---|
 | A | **Run gate** — after `kickoff`, verify coverage, freshness ratio, active phases, known cost; fail otherwise | new tooling | medium | better with B | F5 |
-| B | **Cost** — spike: where do 62 calls per crypto come from with `max_iter=2`? then add `gemini-3.7-flash` to the pricing table | spike → bounded | small | — | F3 |
-| C | **Perplexity reliability** — log the full exception; characterise the 128 transport errors; review backoff | infrastructure | small | — | F1 |
+| B | ~~**Cost**~~ — **done, #162.** The count aggregated across a shared LLM object; deleted the cache. | spike → bounded | small | — | F3 |
+| C | ~~**Perplexity reliability**~~ — **done, #164 + upstream #37.** Backoff deliberately untouched until the types are visible, which needs H. | infrastructure | small | — | F1 |
 | D | **Dead phases** — decide per phase: finish or remove discovery, alternatives, rebalancing | product + flow | **large** | B (real cost of phases) | F2, F6 |
 | E | **CI** — nightly `integration` smoke tier; "imported from `src/`" dead-code check; markdownlint in a workflow | CI | medium | — | F5 |
-| F | **Requirement 9.2** — recalibrate or remove | bounded | very small | — | F4 |
+| F | ~~**Requirement 9.2**~~ — **done, #163.** Removed. | bounded | very small | — | F4 |
 | G | **Optimal allocation** | spec + plan ready | — | — | F6 |
+| H | **Central-tools pin migration** — finwiz pins `crewai-custom-tools @ v0.6.0`; upstream is at `v0.31.1`, 36 tags on. Every upstream fix, including C's, is invisible until this moves. | migration | **large** | — | F1, F5 |
 
 ### Dependencies
 
 - **B before D.** Deciding to keep or kill a phase without knowing what it costs is deciding blind. B is an hour.
 - **B improves A.** A run gate that checks "cost is known" needs the pricing table first.
 - C, E, F, G are independent of everything else and of each other.
+- **H unblocks C's effect.** The `repr` fix is merged upstream but finwiz runs v0.6.0; until the pin moves, the transport errors stay blank in finwiz logs.
 
 ### Suggested order
 
-B → C, F → A → E → D → G at any point.
+~~B → C, F~~ → **A** → E → D → G at any point; H when the appetite for a 36-tag migration exists — it is large and it gates nothing else on this list except C's visibility.
 
-Small and independent first, the gate before the big decision, the big decision last and informed. This is a suggestion; the order is the open decision this document exists to support.
+B, C and F shipped on 2026-09-05. Next is A, the run gate — with B done the cost is measurable and with C done the freshness ratio is one line, so the gate has clean inputs to check.
 
 ## Open unknowns
 
-1. What the 62 calls per crypto are (B, spike).
-2. What the 128 empty-message Perplexity errors actually were (C — unrecoverable for this run; the fix is to log them next time).
+1. ~~What the 62 calls per crypto are~~ — resolved: a shared LLM object's cumulative counter (B, #162).
+2. What the 128 empty-message Perplexity errors actually were — unrecoverable for this run. The upstream fix logs the type next time, **once finwiz's pin reaches it (H)**.
 3. Root cause of the backtest off-by-one (instrumented; wait for the next occurrence and read the traceback).
 
 ## How to use this document

--- a/src/finwiz/analysis/fact_pack_freshness.py
+++ b/src/finwiz/analysis/fact_pack_freshness.py
@@ -1,0 +1,83 @@
+"""One line per run on how fresh the fact packs were.
+
+`FactPack.freshness` is Python-derived from `fetched_at` and already rendered
+per holding in the report. What was missing is the aggregate: the 2026-09-05
+run served 18 of 64 fact packs from a 2026-08-17 cache, and finding that out
+took three greps over the log. This module turns the per-holding results into
+one number and one sentence, for the log now and for the run gate later.
+
+Pure: reads `enriched.qualitative.fact_pack.{freshness, fetched_at}` and
+nothing else, so a test needs no FactPack, no network and no flow.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+_BUCKETS = ("fresh", "recent", "stale")
+
+
+@dataclass(frozen=True)
+class FactPackFreshnessSummary:
+    """Counts by freshness bucket, plus the age of the oldest stale pack."""
+
+    total: int
+    fresh: int
+    recent: int
+    stale: int
+    missing: int
+    oldest_stale_fetched_at: datetime | None
+
+    @property
+    def stale_ratio(self) -> float:
+        return self.stale / self.total if self.total else 0.0
+
+    def line(self, now: datetime | None = None) -> str:
+        """The sentence to log. `now` is injectable so the age is testable."""
+        oldest = ""
+        if self.oldest_stale_fetched_at is not None:
+            # Calendar days, not truncated elapsed time: a pack fetched on the 17th read
+            # on the 5th is "19 days ago" to a reader, even 22 hours short of 19x24h.
+            age_days = ((now or datetime.now(UTC)).date() - _as_utc(self.oldest_stale_fetched_at).date()).days
+            oldest = f" (oldest {self.oldest_stale_fetched_at.date()}, {age_days} days ago)"
+        return f"fact_pack freshness: {self.fresh} fresh, {self.recent} recent, {self.stale} stale{oldest}, {self.missing} missing — {self.total} holdings"
+
+
+def summarize_fact_pack_freshness(enriched_by_ticker: Mapping[str, Any]) -> FactPackFreshnessSummary:
+    """Aggregate per-holding fact-pack freshness for one run.
+
+    A holding is *missing* when the analysis, its qualitative stage or its
+    fact_pack stage produced nothing — or when freshness carries a value that is
+    not one of the three buckets, which must never be counted as fresh.
+    """
+    counts = dict.fromkeys(_BUCKETS, 0)
+    missing = 0
+    oldest_stale: datetime | None = None
+
+    for enriched in enriched_by_ticker.values():
+        fact_pack = getattr(getattr(enriched, "qualitative", None), "fact_pack", None)
+        freshness = getattr(fact_pack, "freshness", None)
+        if freshness not in counts:
+            missing += 1
+            continue
+        counts[freshness] += 1
+        fetched_at = getattr(fact_pack, "fetched_at", None)
+        if freshness == "stale" and fetched_at is not None and (oldest_stale is None or _as_utc(fetched_at) < _as_utc(oldest_stale)):
+            oldest_stale = fetched_at
+
+    return FactPackFreshnessSummary(
+        total=len(enriched_by_ticker),
+        fresh=counts["fresh"],
+        recent=counts["recent"],
+        stale=counts["stale"],
+        missing=missing,
+        oldest_stale_fetched_at=oldest_stale,
+    )
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """A naive `fetched_at` is treated as UTC rather than left incomparable."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)

--- a/src/finwiz/orchestrators/deep_analysis_orchestrator.py
+++ b/src/finwiz/orchestrators/deep_analysis_orchestrator.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from finwiz.analysis.fact_pack_freshness import summarize_fact_pack_freshness
 from finwiz.analysis.stages._ledger import RunLedger
 from finwiz.flow_state import DeepAnalysisResult, FinwizState
 from finwiz.infrastructure.resilience.crew_execution import CREW_TIMEOUT
@@ -549,6 +550,12 @@ class DeepAnalysisOrchestrator:
                 self.logger.info(f"Analysis complete: {ticker} grade={result.grade}")
 
         self.logger.info(f"Concurrent analysis completed: {len(results)}/{len(holdings)} holdings")
+
+        # One line on fact-pack freshness for the whole run. Per-holding freshness is
+        # already in the report; the aggregate is what a reader of the log — and the
+        # run gate — needs. WARNING when anything is stale or missing, so it is found.
+        freshness = summarize_fact_pack_freshness(self._enriched_analyses)
+        (self.logger.warning if freshness.stale or freshness.missing else self.logger.info)(freshness.line())
         return results
 
     def _ensure_macro_snapshot_on_state(self) -> None:

--- a/tests/unit/analysis/test_fact_pack_freshness.py
+++ b/tests/unit/analysis/test_fact_pack_freshness.py
@@ -1,0 +1,64 @@
+"""Per-run fact-pack freshness summary.
+
+The 2026-09-05 run served 18 of 64 fact packs from a 2026-08-17 cache. Finding
+that out took three greps over the log. One line at the end of Phase 3 should
+say it — and it is the freshness-ratio input the run gate (workstream A) needs.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from finwiz.analysis.fact_pack_freshness import summarize_fact_pack_freshness
+
+NOW = datetime(2026, 9, 5, 12, 0, tzinfo=UTC)
+
+
+def _enriched(freshness: str | None, fetched_at: datetime | None = None) -> SimpleNamespace:
+    """An EnrichedAnalysis stand-in: only .qualitative.fact_pack.{freshness,fetched_at} are read."""
+    fact_pack = None if freshness is None else SimpleNamespace(freshness=freshness, fetched_at=fetched_at or NOW)
+    return SimpleNamespace(qualitative=SimpleNamespace(fact_pack=fact_pack))
+
+
+class TestSummarizeFactPackFreshness:
+    def test_counts_every_bucket_and_every_way_of_being_missing(self) -> None:
+        by_ticker = {
+            "A": _enriched("fresh"),
+            "B": _enriched("fresh"),
+            "C": _enriched("recent"),
+            "D": _enriched("stale", datetime(2026, 8, 23, tzinfo=UTC)),
+            "E": _enriched("stale", datetime(2026, 8, 17, 13, 15, tzinfo=UTC)),
+            "F": None,  # holding failed outright
+            "G": SimpleNamespace(qualitative=None),  # qualitative stage failed
+            "H": _enriched(None),  # fact_pack stage failed
+        }
+        s = summarize_fact_pack_freshness(by_ticker)
+        assert (s.total, s.fresh, s.recent, s.stale, s.missing) == (8, 2, 1, 2, 3)
+        assert s.oldest_stale_fetched_at == datetime(2026, 8, 17, 13, 15, tzinfo=UTC)
+        assert s.stale_ratio == pytest.approx(0.25)
+
+    def test_line_reads_like_the_thing_you_would_otherwise_grep_for(self) -> None:
+        by_ticker = {"A": _enriched("fresh"), "E": _enriched("stale", datetime(2026, 8, 17, 13, 15, tzinfo=UTC)), "F": None}
+        line = summarize_fact_pack_freshness(by_ticker).line(now=NOW)
+        assert line == "fact_pack freshness: 1 fresh, 0 recent, 1 stale (oldest 2026-08-17, 19 days ago), 1 missing — 3 holdings"
+
+    def test_no_stale_means_no_oldest_clause(self) -> None:
+        line = summarize_fact_pack_freshness({"A": _enriched("fresh"), "B": _enriched("recent")}).line(now=NOW)
+        assert "oldest" not in line
+        assert line.endswith("0 missing — 2 holdings")
+
+    def test_empty_run(self) -> None:
+        s = summarize_fact_pack_freshness({})
+        assert s.total == 0 and s.stale_ratio == 0.0
+        assert s.line(now=NOW) == "fact_pack freshness: 0 fresh, 0 recent, 0 stale, 0 missing — 0 holdings"
+
+    def test_naive_fetched_at_is_treated_as_utc(self) -> None:
+        s = summarize_fact_pack_freshness({"E": _enriched("stale", datetime(2026, 8, 17, 13, 15))})
+        assert "19 days ago" in s.line(now=NOW)
+
+    def test_unknown_freshness_value_counts_as_missing_not_as_fresh(self) -> None:
+        s = summarize_fact_pack_freshness({"X": _enriched("bogus")})
+        assert (s.fresh, s.missing) == (0, 1)


### PR DESCRIPTION
Workstream **C** of the reevaluation roadmap (#160), finwiz half.

## What the run could not tell you

18 of 64 fact packs on 2026-09-05 came from a 2026-08-17 cache — 19 days old. Each holding's freshness is already a pill in the report, but the **aggregate** lived nowhere. Establishing "28 % stale" took three greps.

## What Phase 3 now says

```
fact_pack freshness: 40 fresh, 6 recent, 18 stale (oldest 2026-08-17, 19 days ago), 0 missing — 64 holdings
```

`WARNING` when anything is stale or missing, `INFO` otherwise — so a degraded run is found by anyone scanning for warnings. This is also the freshness-ratio input the run gate (workstream A) will consume.

`analysis/fact_pack_freshness.py` is pure: it reads `enriched.qualitative.fact_pack.{freshness, fetched_at}` and nothing else. Age is in **calendar days**, not truncated elapsed time. An unrecognised freshness value counts as missing, never as fresh.

## Why not touch retry or backoff

The 128 Perplexity `transport error` lines behind those stale packs carry an **empty message**: the central tool logs `{exc}`, and every httpx transport exception (`RemoteProtocolError`, `ReadTimeout`, `ConnectError`, `TimeoutError`) stringifies to `''` — verified. finwiz never sees the exception; the tool swallows it and returns `None`. Tuning backoff without knowing whether those were timeouts, resets or refusals would be guessing.

The one-line fix (`{exc!r}`) is proposed against **crewai-custom-tools**. Note: finwiz pins `v0.6.0` and upstream is at `v0.31.1` — 36 tags apart — so finwiz only benefits after a pin migration, which is its own workstream. The roadmap is updated accordingly in this PR's follow-up commit.

## Verification

`make check` green: 5 144 passed. Six tests on the summary: every bucket and every way of being missing; the exact log line; no `oldest` clause without stale packs; empty run; naive `fetched_at` treated as UTC; unknown freshness counted as missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwsV4WdanisV9UBdGadCWe