### PR TITLE
docs: run gate — design spec and implementation plan (workstream A)

### DIFF
--- a/docs/superpowers/plans/2026-09-05-run-gate.md
+++ b/docs/superpowers/plans/2026-09-05-run-gate.md
@@ -1,0 +1,1483 @@
+# Run Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After every `crewai flow kickoff`, write `output/run_summary.json`, log one grep-able line per check, and exit with the verdict — `0` PASS/WARN, `1` FAIL, `2` the gate could not evaluate.
+
+**Architecture:** A pure evaluator (`analysis/run_gate.py`) turns five typed input models into checks and a verdict. An orchestrator collects those inputs from flow state, calls the evaluator, writes the JSON and logs the block; it never raises. The flow calls it last; `app_initializer` turns the verdict into the process exit code. A standalone script re-evaluates any existing JSON against current thresholds without the flow.
+
+**Tech Stack:** Pydantic v2, `FinWizSettings` (pydantic-settings, `env_prefix="FINWIZ_"`, `env_nested_delimiter="__"`), pytest + pytest-mock.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-run-gate-design.md`
+
+## Global Constraints
+
+- **unittest.mock is BANNED.** Use pytest-mock (`mocker.patch`) only. Enforced by ruff and `make check-unittest-mock`.
+- **All Pydantic models live in `schemas/`**, never in domain folders. Settings *groups* are the one exception the codebase already makes: they are `BaseModel`s inside `config/settings.py`.
+- **Line length 180** (ruff config).
+- **No network in tests.** pytest-socket blocks it; mock the seam.
+- **Severities are code, not settings.** Only thresholds are configurable: `FINWIZ_GATE__MIN_COVERAGE_RATIO`, `FINWIZ_GATE__MIN_PRICED_RATIO`, `FINWIZ_GATE__MAX_STALE_RATIO`. Defaults `0.95`, `0.95`, `0.25`.
+- **A check whose input is `available=False` FAILs with detail `not measured`.** Never skipped.
+- **Exit codes:** PASS→0, WARN→0, FAIL→1, ERROR→2. A `None` verdict (the gate never ran) is ERROR.
+- **The report is written before the gate runs; the gate never raises into the flow.**
+- **`logger.exception`, not `logger.error`, on the gate's own failure** (convention from PR #158).
+- **Valuation counts `weight is not None`** — the same set the allocation hero counts. Never a different denominator.
+- Run `make check` before every commit that touches `src/`.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/finwiz/schemas/run_summary.py` (new) | `Verdict`, `Severity`, five input models, `GateCheck`, `RunSummary` — the contract |
+| `src/finwiz/config/settings.py` (modify) | `RunGateSettings` (three thresholds) nested as `gate` on `FinWizSettings` |
+| `src/finwiz/analysis/run_gate.py` (new) | `evaluate`, `verdict`, `exit_code_for`, `format_block` — pure |
+| `src/finwiz/flow_state_models.py` (modify) | `fact_pack_freshness`, `run_summary`, `gate_verdict` |
+| `src/finwiz/orchestrators/deep_analysis_orchestrator.py` (modify) | persist the freshness summary to state where it is logged |
+| `src/finwiz/orchestrators/run_gate_orchestrator.py` (new) | collectors from state, JSON, log block, ERROR path |
+| `src/finwiz/flows/orchestrator.py` (modify) | one guarded call after `_log_post_flow_summaries()` |
+| `src/finwiz/core/app_initializer.py` (modify) | `os._exit(exit_code_for(verdict))` |
+| `scripts/run_gate.py` (new) + `Makefile` (modify) | standalone re-evaluation, `make gate` |
+
+**Order note against the spec.** The spec lists the evaluator (step 2) before settings (step 3). The evaluator's `thresholds` parameter is typed as `RunGateSettings`, so settings must exist first. Tasks 2 and 3 below are swapped accordingly; nothing else moves.
+
+---
+
+### Task 1: The contract
+
+**Files:**
+
+- Create: `src/finwiz/schemas/run_summary.py`
+- Test: `tests/unit/schemas/test_run_summary.py`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `Verdict(StrEnum)` with `PASS WARN FAIL ERROR`; `Severity(StrEnum)` with `FAIL WARN`; `CoverageInput(available, analyzed, degraded, failed, total)`; `ValuationInput(available, priced, total)`; `FactPackInput(available, fresh, recent, stale, missing, total, oldest_stale_fetched_at)`; `PhasesInput(discovery_candidates, alternatives_found, underperformers, stress_scenarios, optimal_allocation)`; `CostInput(available, total_usd, call_count, cost_known, unpriced_crews)`; `GateCheck(name, severity, passed, observed, threshold, detail)`; `RunSummary(run_id, started_at, finished_at, duration_seconds, coverage, valuation, fact_pack, phases, cost, checks, verdict)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Unit tests for the run-summary contract."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from finwiz.schemas.run_summary import (
+    CostInput,
+    CoverageInput,
+    FactPackInput,
+    GateCheck,
+    PhasesInput,
+    RunSummary,
+    Severity,
+    ValuationInput,
+    Verdict,
+)
+
+
+class TestInputsDefaultToNotMeasured:
+    def test_every_measured_input_starts_unavailable(self) -> None:
+        assert CoverageInput().available is False
+        assert ValuationInput().available is False
+        assert FactPackInput().available is False
+        assert CostInput().available is False
+
+    def test_phases_have_no_availability_flag_because_absence_is_a_zero(self) -> None:
+        assert PhasesInput().discovery_candidates == 0
+        assert PhasesInput().optimal_allocation is False
+
+
+class TestRunSummaryRoundTrip:
+    def test_json_round_trip_preserves_everything(self) -> None:
+        summary = RunSummary(
+            run_id="abc123",
+            started_at=datetime(2026, 9, 5, 9, 4, 46, tzinfo=UTC),
+            finished_at=datetime(2026, 9, 5, 9, 28, 9, tzinfo=UTC),
+            duration_seconds=1403.0,
+            coverage=CoverageInput(available=True, analyzed=64, degraded=0, failed=0, total=64),
+            valuation=ValuationInput(available=True, priced=63, total=64),
+            fact_pack=FactPackInput(available=True, fresh=40, recent=6, stale=18, missing=0, total=64, oldest_stale_fetched_at=datetime(2026, 8, 17, tzinfo=UTC)),
+            phases=PhasesInput(discovery_candidates=0, alternatives_found=0, underperformers=17, stress_scenarios=6, optimal_allocation=False),
+            cost=CostInput(available=True, total_usd=0.0, call_count=2080, cost_known=False, unpriced_crews=["deep_analysis_etf"]),
+            checks=[GateCheck(name="coverage", severity=Severity.FAIL, passed=True, observed="64/64", threshold="min 95%", detail="")],
+            verdict=Verdict.FAIL,
+        )
+        again = RunSummary.model_validate_json(summary.model_dump_json())
+        assert again == summary
+        assert again.verdict is Verdict.FAIL
+        assert again.cost.unpriced_crews == ["deep_analysis_etf"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/schemas/test_run_summary.py -v --no-cov`
+Expected: FAIL with `ModuleNotFoundError: No module named 'finwiz.schemas.run_summary'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""The run gate's contract: what a run measured, what it was held to, what it concluded.
+
+Every measured input carries ``available``. "We could not measure this" is a
+value here, not an absence -- a check whose input is unavailable FAILs as
+"not measured" rather than being skipped. Phase counts have no flag because
+an absent phase result is honestly a zero.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class Verdict(StrEnum):
+    """PASS and WARN exit 0; FAIL exits 1; ERROR -- the gate could not evaluate -- exits 2."""
+
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+    ERROR = "ERROR"
+
+
+class Severity(StrEnum):
+    """FAIL: the report is not trustworthy. WARN: a known gap is still a gap."""
+
+    FAIL = "FAIL"
+    WARN = "WARN"
+
+
+class CoverageInput(BaseModel):
+    """From ``RunLedger.coverage()``."""
+
+    available: bool = False
+    analyzed: int = Field(default=0, ge=0)
+    degraded: int = Field(default=0, ge=0)
+    failed: int = Field(default=0, ge=0)
+    total: int = Field(default=0, ge=0)
+
+
+class ValuationInput(BaseModel):
+    """Priced holdings -- ``weight is not None`` -- over all holdings. The hero's denominator."""
+
+    available: bool = False
+    priced: int = Field(default=0, ge=0)
+    total: int = Field(default=0, ge=0)
+
+
+class FactPackInput(BaseModel):
+    """The persisted workstream-C freshness summary."""
+
+    available: bool = False
+    fresh: int = Field(default=0, ge=0)
+    recent: int = Field(default=0, ge=0)
+    stale: int = Field(default=0, ge=0)
+    missing: int = Field(default=0, ge=0)
+    total: int = Field(default=0, ge=0)
+    oldest_stale_fetched_at: datetime | None = None
+
+
+class PhasesInput(BaseModel):
+    """Outcomes of the phases the roadmap tracks as known gaps."""
+
+    discovery_candidates: int = Field(default=0, ge=0)
+    alternatives_found: int = Field(default=0, ge=0)
+    underperformers: int = Field(default=0, ge=0)
+    stress_scenarios: int = Field(default=0, ge=0)
+    optimal_allocation: bool = False
+
+
+class CostInput(BaseModel):
+    """From the cost monitor's summary. ``cost_known`` is False if any crew was unpriced."""
+
+    available: bool = False
+    total_usd: float = Field(default=0.0, ge=0.0)
+    call_count: int = Field(default=0, ge=0)
+    cost_known: bool = False
+    unpriced_crews: list[str] = Field(default_factory=list)
+
+
+class GateCheck(BaseModel):
+    """One check: what was observed, what it was held to, whether it passed."""
+
+    name: str
+    severity: Severity
+    passed: bool
+    observed: str
+    threshold: str
+    detail: str = ""
+
+
+class RunSummary(BaseModel):
+    """One document per run. Written to ``output/run_summary.json``."""
+
+    run_id: str
+    started_at: datetime | None = None
+    finished_at: datetime
+    duration_seconds: float | None = Field(default=None, ge=0.0)
+    coverage: CoverageInput = Field(default_factory=CoverageInput)
+    valuation: ValuationInput = Field(default_factory=ValuationInput)
+    fact_pack: FactPackInput = Field(default_factory=FactPackInput)
+    phases: PhasesInput = Field(default_factory=PhasesInput)
+    cost: CostInput = Field(default_factory=CostInput)
+    checks: list[GateCheck] = Field(default_factory=list)
+    verdict: Verdict
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/schemas/test_run_summary.py -v --no-cov`
+Expected: PASS, 3 tests
+
+- [ ] **Step 5: Quality gate and commit**
+
+Run: `make lint && make mypy`
+Expected: clean
+
+```bash
+git add src/finwiz/schemas/run_summary.py tests/unit/schemas/test_run_summary.py
+git commit -m "feat(schemas): run-summary contract for the post-run gate"
+```
+
+---
+
+### Task 2: Thresholds in settings
+
+**Files:**
+
+- Modify: `src/finwiz/config/settings.py` (a new `BaseModel` group beside `HybridAnalysisSettings` at line ~53; a new field on `FinWizSettings` beside `hybrid_analysis` at line ~147)
+- Test: `tests/unit/config/test_run_gate_settings.py`
+
+**Interfaces:**
+
+- Consumes: `FinWizSettings`, `get_settings()`, `reset_settings()` — all existing in `config/settings.py`.
+- Produces: `RunGateSettings(min_coverage_ratio: float = 0.95, min_priced_ratio: float = 0.95, max_stale_ratio: float = 0.25)`; `get_settings().gate: RunGateSettings`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The gate's thresholds are settings; its severities are not."""
+
+from __future__ import annotations
+
+import pytest
+
+from finwiz.config import settings as settings_module
+from finwiz.config.settings import RunGateSettings, get_settings, reset_settings
+
+
+@pytest.fixture(autouse=True)
+def _fresh_settings():
+    reset_settings()
+    yield
+    reset_settings()
+
+
+class TestRunGateSettings:
+    def test_defaults_match_the_spec(self) -> None:
+        gate = RunGateSettings()
+        assert (gate.min_coverage_ratio, gate.min_priced_ratio, gate.max_stale_ratio) == (0.95, 0.95, 0.25)
+
+    def test_is_nested_on_finwiz_settings(self) -> None:
+        assert isinstance(get_settings().gate, RunGateSettings)
+
+    def test_env_override_through_the_nested_delimiter(self, monkeypatch) -> None:
+        monkeypatch.setenv("FINWIZ_GATE__MAX_STALE_RATIO", "0.10")
+        reset_settings()
+        assert get_settings().gate.max_stale_ratio == pytest.approx(0.10)
+
+    def test_ratios_are_bounded(self) -> None:
+        with pytest.raises(ValueError):
+            RunGateSettings(max_stale_ratio=1.5)
+
+    def test_module_exposes_no_severity_knob(self) -> None:
+        """Moving a check between FAIL and WARN is a design decision, made in code."""
+        assert not [f for f in RunGateSettings.model_fields if "severity" in f or "fail" in f or "warn" in f]
+        assert not hasattr(settings_module, "GateSeveritySettings")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/config/test_run_gate_settings.py -v --no-cov`
+Expected: FAIL with `ImportError: cannot import name 'RunGateSettings'`
+
+- [ ] **Step 3: Add the settings group**
+
+Insert immediately before `class FinWizSettings(BaseSettings):`:
+
+```python
+class RunGateSettings(BaseModel):
+    """Thresholds for the post-run gate (``analysis/run_gate.py``).
+
+    Only thresholds live here. Which checks FAIL and which WARN is decided in
+    code and reviewed -- a gate whose severities can be turned down from the
+    environment is a gate that gets turned down.
+    """
+
+    min_coverage_ratio: float = Field(
+        default=0.95,
+        ge=0.0,
+        le=1.0,
+        description="Minimum analyzed/total from the run ledger before the run FAILs (default: 0.95)",
+    )
+    min_priced_ratio: float = Field(
+        default=0.95,
+        ge=0.0,
+        le=1.0,
+        description="Minimum priced/total holdings before the run FAILs (default: 0.95)",
+    )
+    max_stale_ratio: float = Field(
+        default=0.25,
+        ge=0.0,
+        le=1.0,
+        description="Maximum stale/total fact packs before the run FAILs (default: 0.25)",
+    )
+
+
+```
+
+Then inside `FinWizSettings`, immediately after the `hybrid_analysis` field:
+
+```python
+    gate: RunGateSettings = Field(
+        default_factory=RunGateSettings,
+        description="Post-run gate thresholds; override with FINWIZ_GATE__<NAME>",
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/config/test_run_gate_settings.py -v --no-cov`
+Expected: PASS, 5 tests
+
+- [ ] **Step 5: Quality gate and commit**
+
+Run: `make lint && make mypy`
+
+```bash
+git add src/finwiz/config/settings.py tests/unit/config/test_run_gate_settings.py
+git commit -m "feat(config): run-gate thresholds, overridable via FINWIZ_GATE__*"
+```
+
+---
+
+### Task 3: The pure evaluator
+
+**Files:**
+
+- Create: `src/finwiz/analysis/run_gate.py`
+- Test: `tests/unit/analysis/test_run_gate.py`
+
+**Interfaces:**
+
+- Consumes: every model from Task 1; `RunGateSettings` from Task 2.
+- Produces: `evaluate(coverage: CoverageInput, valuation: ValuationInput, fact_pack: FactPackInput, phases: PhasesInput, cost: CostInput, thresholds: RunGateSettings) -> list[GateCheck]`; `verdict(checks: list[GateCheck]) -> Verdict`; `exit_code_for(v: Verdict | str | None) -> int`; `format_block(checks: list[GateCheck], v: Verdict, summary_path: str) -> list[str]`; constant `NOT_MEASURED = "not measured"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The gate is a pure function: numbers in, checks and a verdict out."""
+
+from __future__ import annotations
+
+import pytest
+
+from finwiz.analysis.run_gate import NOT_MEASURED, evaluate, exit_code_for, format_block, verdict
+from finwiz.config.settings import RunGateSettings
+from finwiz.schemas.run_summary import CostInput, CoverageInput, FactPackInput, GateCheck, PhasesInput, Severity, ValuationInput, Verdict
+
+T = RunGateSettings()
+
+
+def _run_2026_09_05() -> dict:
+    """The measured values of the run that motivated the gate."""
+    return {
+        "coverage": CoverageInput(available=True, analyzed=64, degraded=0, failed=0, total=64),
+        "valuation": ValuationInput(available=True, priced=63, total=64),
+        "fact_pack": FactPackInput(available=True, fresh=40, recent=6, stale=18, missing=0, total=64),
+        "phases": PhasesInput(discovery_candidates=0, alternatives_found=0, underperformers=17, stress_scenarios=6),
+        "cost": CostInput(available=True, total_usd=0.0, call_count=2080, cost_known=False, unpriced_crews=["deep_analysis_crypto", "deep_analysis_etf", "deep_analysis_stock"]),
+    }
+
+
+def _by_name(checks: list[GateCheck]) -> dict[str, GateCheck]:
+    return {c.name: c for c in checks}
+
+
+class TestTheMotivatingRun:
+    def test_verdict_is_fail_for_the_right_reasons(self) -> None:
+        checks = evaluate(**_run_2026_09_05(), thresholds=T)
+        by = _by_name(checks)
+        assert by["coverage"].passed and by["valuation"].passed and by["stress_tests"].passed and by["fact_pack_missing"].passed
+        assert not by["cost_known"].passed and by["cost_known"].severity is Severity.FAIL
+        assert not by["fact_pack_stale"].passed and by["fact_pack_stale"].severity is Severity.FAIL
+        assert not by["discovery"].passed and by["discovery"].severity is Severity.WARN
+        assert not by["alternatives"].passed and by["alternatives"].severity is Severity.WARN
+        assert verdict(checks) is Verdict.FAIL
+
+    def test_eight_checks_always_present_in_stable_order(self) -> None:
+        names = [c.name for c in evaluate(**_run_2026_09_05(), thresholds=T)]
+        assert names == ["coverage", "valuation", "cost_known", "fact_pack_stale", "discovery", "alternatives", "stress_tests", "fact_pack_missing"]
+
+
+class TestThresholdsBothSides:
+    @pytest.mark.parametrize(("analyzed", "passed"), [(64, True), (61, True), (60, False)])  # 61/64 = 95.3%, 60/64 = 93.75%
+    def test_coverage(self, analyzed: int, passed: bool) -> None:
+        d = _run_2026_09_05() | {"coverage": CoverageInput(available=True, analyzed=analyzed, total=64)}
+        assert _by_name(evaluate(**d, thresholds=T))["coverage"].passed is passed
+
+    @pytest.mark.parametrize(("priced", "passed"), [(64, True), (61, True), (60, False)])
+    def test_valuation(self, priced: int, passed: bool) -> None:
+        d = _run_2026_09_05() | {"valuation": ValuationInput(available=True, priced=priced, total=64)}
+        assert _by_name(evaluate(**d, thresholds=T))["valuation"].passed is passed
+
+    @pytest.mark.parametrize(("stale", "passed"), [(0, True), (16, True), (17, False)])  # 16/64 = 25% exactly passes; 17/64 fails
+    def test_stale_ratio_boundary_is_inclusive(self, stale: int, passed: bool) -> None:
+        d = _run_2026_09_05() | {"fact_pack": FactPackInput(available=True, fresh=64 - stale, stale=stale, total=64)}
+        assert _by_name(evaluate(**d, thresholds=T))["fact_pack_stale"].passed is passed
+
+    def test_a_changed_threshold_changes_the_outcome(self) -> None:
+        loose = RunGateSettings(max_stale_ratio=0.30)
+        assert _by_name(evaluate(**_run_2026_09_05(), thresholds=loose))["fact_pack_stale"].passed is True
+
+    def test_alternatives_pass_when_there_is_nobody_to_replace(self) -> None:
+        d = _run_2026_09_05() | {"phases": PhasesInput(alternatives_found=0, underperformers=0, stress_scenarios=6)}
+        assert _by_name(evaluate(**d, thresholds=T))["alternatives"].passed is True
+
+    def test_cost_known_passes_only_with_no_unpriced_crew(self) -> None:
+        d = _run_2026_09_05() | {"cost": CostInput(available=True, total_usd=0.51, call_count=68, cost_known=True, unpriced_crews=[])}
+        assert _by_name(evaluate(**d, thresholds=T))["cost_known"].passed is True
+
+
+class TestNotMeasuredIsAFailNotASkip:
+    @pytest.mark.parametrize(("field", "empty", "check"), [
+        ("coverage", CoverageInput(), "coverage"),
+        ("valuation", ValuationInput(), "valuation"),
+        ("fact_pack", FactPackInput(), "fact_pack_stale"),
+        ("cost", CostInput(), "cost_known"),
+    ])
+    def test_unavailable_input_fails_its_check(self, field: str, empty, check: str) -> None:
+        d = _run_2026_09_05() | {field: empty}
+        c = _by_name(evaluate(**d, thresholds=T))[check]
+        assert c.passed is False
+        assert c.detail == NOT_MEASURED
+        assert c.severity is Severity.FAIL
+
+    def test_zero_total_is_not_measured_either(self) -> None:
+        d = _run_2026_09_05() | {"coverage": CoverageInput(available=True, analyzed=0, total=0)}
+        assert _by_name(evaluate(**d, thresholds=T))["coverage"].detail == NOT_MEASURED
+
+
+class TestVerdictAndExitCode:
+    def _check(self, sev: Severity, passed: bool) -> GateCheck:
+        return GateCheck(name="x", severity=sev, passed=passed, observed="", threshold="")
+
+    def test_fail_beats_warn_beats_pass(self) -> None:
+        assert verdict([self._check(Severity.WARN, False), self._check(Severity.FAIL, False)]) is Verdict.FAIL
+        assert verdict([self._check(Severity.WARN, False), self._check(Severity.FAIL, True)]) is Verdict.WARN
+        assert verdict([self._check(Severity.WARN, True), self._check(Severity.FAIL, True)]) is Verdict.PASS
+
+    def test_three_warns_stay_warn(self) -> None:
+        assert verdict([self._check(Severity.WARN, False)] * 3) is Verdict.WARN
+
+    def test_no_checks_is_pass(self) -> None:
+        assert verdict([]) is Verdict.PASS
+
+    @pytest.mark.parametrize(("v", "code"), [(Verdict.PASS, 0), (Verdict.WARN, 0), (Verdict.FAIL, 1), (Verdict.ERROR, 2), ("FAIL", 1), (None, 2), ("garbage", 2)])
+    def test_exit_codes(self, v, code: int) -> None:
+        assert exit_code_for(v) == code
+
+
+class TestFormatBlock:
+    def test_one_line_per_check_then_the_verdict(self) -> None:
+        checks = evaluate(**_run_2026_09_05(), thresholds=T)
+        lines = format_block(checks, verdict(checks), "output/run_summary.json")
+        assert len(lines) == len(checks) + 1
+        assert all(line.startswith("run gate: ") for line in lines)
+        assert "run gate: fact_pack_stale   FAIL  18/64 stale = 28% (max 25%)" in lines  # name padded to the longest check name, fact_pack_missing
+        assert lines[-1] == "run gate: verdict FAIL — output/run_summary.json"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/analysis/test_run_gate.py -v --no-cov`
+Expected: FAIL with `ModuleNotFoundError: No module named 'finwiz.analysis.run_gate'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""The run gate, as a pure function.
+
+Five measured inputs and a set of thresholds go in; eight checks and a verdict
+come out. Nothing here reads state, touches the disk or consults a clock, so a
+test needs five small models and nothing else.
+
+Severity is decided here, in code. FAIL means the report is not trustworthy --
+coverage, valuation, cost visibility, fact-pack freshness. WARN means a gap the
+roadmap already tracks is still a gap -- discovery, alternatives, stress tests.
+A gate that FAILs on the known gaps is red from its first run until they are
+closed, and a gate that is always red is the mechanism by which Requirement 9.2
+became noise.
+
+A check whose input is unavailable FAILs as "not measured". It is never
+skipped: a gate that skips a check when the data is missing is a gate that is
+passed by breaking the data.
+"""
+
+from __future__ import annotations
+
+from finwiz.config.settings import RunGateSettings
+from finwiz.schemas.run_summary import CostInput, CoverageInput, FactPackInput, GateCheck, PhasesInput, Severity, ValuationInput, Verdict
+
+NOT_MEASURED = "not measured"
+
+_EXIT_CODES: dict[Verdict, int] = {Verdict.PASS: 0, Verdict.WARN: 0, Verdict.FAIL: 1, Verdict.ERROR: 2}
+
+
+def evaluate(
+    coverage: CoverageInput,
+    valuation: ValuationInput,
+    fact_pack: FactPackInput,
+    phases: PhasesInput,
+    cost: CostInput,
+    thresholds: RunGateSettings,
+) -> list[GateCheck]:
+    """Return the eight checks, always all of them, always in this order."""
+    return [
+        _ratio_at_least("coverage", coverage.available, coverage.analyzed, coverage.total, thresholds.min_coverage_ratio, "analysed"),
+        _ratio_at_least("valuation", valuation.available, valuation.priced, valuation.total, thresholds.min_priced_ratio, "priced"),
+        _cost_known(cost),
+        _ratio_at_most("fact_pack_stale", fact_pack.available, fact_pack.stale, fact_pack.total, thresholds.max_stale_ratio, "stale"),
+        GateCheck(
+            name="discovery",
+            severity=Severity.WARN,
+            passed=phases.discovery_candidates > 0,
+            observed=f"{phases.discovery_candidates} candidates",
+            threshold="> 0",
+        ),
+        GateCheck(
+            name="alternatives",
+            severity=Severity.WARN,
+            passed=phases.alternatives_found > 0 or phases.underperformers == 0,
+            observed=f"{phases.alternatives_found} found for {phases.underperformers} underperformers",
+            threshold="> 0 when there are underperformers",
+        ),
+        GateCheck(
+            name="stress_tests",
+            severity=Severity.WARN,
+            passed=phases.stress_scenarios > 0,
+            observed=f"{phases.stress_scenarios} scenarios",
+            threshold="> 0",
+        ),
+        GateCheck(
+            name="fact_pack_missing",
+            severity=Severity.WARN,
+            passed=fact_pack.available and fact_pack.missing == 0,
+            observed=f"{fact_pack.missing} missing" if fact_pack.available else NOT_MEASURED,
+            threshold="= 0",
+            detail="" if fact_pack.available else NOT_MEASURED,
+        ),
+    ]
+
+
+def verdict(checks: list[GateCheck]) -> Verdict:
+    """Any failed FAIL → FAIL; else any failed WARN → WARN; else PASS. WARNs never escalate."""
+    failed = [c for c in checks if not c.passed]
+    if any(c.severity is Severity.FAIL for c in failed):
+        return Verdict.FAIL
+    if failed:
+        return Verdict.WARN
+    return Verdict.PASS
+
+
+def exit_code_for(v: Verdict | str | None) -> int:
+    """PASS/WARN → 0, FAIL → 1, anything else -- ERROR, None, unknown -- → 2.
+
+    None means the gate never ran. "Nothing to report" and "I did not look" must
+    never share an exit code.
+    """
+    try:
+        return _EXIT_CODES[Verdict(v)] if v is not None else 2
+    except ValueError:
+        return 2
+
+
+def format_block(checks: list[GateCheck], v: Verdict, summary_path: str) -> list[str]:
+    """One grep-able line per check, the verdict last."""
+    width = max(len(c.name) for c in checks) if checks else 0
+    lines = [f"run gate: {c.name:<{width}} {'PASS' if c.passed else c.severity.value:<5} {c.observed} ({c.threshold})" for c in checks]
+    lines.append(f"run gate: verdict {v.value} — {summary_path}")
+    return lines
+
+
+def _ratio_at_least(name: str, available: bool, part: int, total: int, minimum: float, noun: str) -> GateCheck:
+    if not available or total == 0:
+        return GateCheck(name=name, severity=Severity.FAIL, passed=False, observed=NOT_MEASURED, threshold=f"min {minimum:.0%}", detail=NOT_MEASURED)
+    return GateCheck(name=name, severity=Severity.FAIL, passed=part / total >= minimum, observed=f"{part}/{total} {noun}", threshold=f"min {minimum:.0%}")
+
+
+def _ratio_at_most(name: str, available: bool, part: int, total: int, maximum: float, noun: str) -> GateCheck:
+    if not available or total == 0:
+        return GateCheck(name=name, severity=Severity.FAIL, passed=False, observed=NOT_MEASURED, threshold=f"max {maximum:.0%}", detail=NOT_MEASURED)
+    return GateCheck(name=name, severity=Severity.FAIL, passed=part / total <= maximum, observed=f"{part}/{total} {noun} = {part / total:.0%}", threshold=f"max {maximum:.0%}")
+
+
+def _cost_known(cost: CostInput) -> GateCheck:
+    if not cost.available:
+        return GateCheck(name="cost_known", severity=Severity.FAIL, passed=False, observed=NOT_MEASURED, threshold="every crew priced", detail=NOT_MEASURED)
+    if cost.unpriced_crews:
+        n = len(cost.unpriced_crews)
+        return GateCheck(name="cost_known", severity=Severity.FAIL, passed=False, observed=f"{n} crew{'s' if n > 1 else ''} unpriced: {', '.join(cost.unpriced_crews)}", threshold="every crew priced")
+    return GateCheck(name="cost_known", severity=Severity.FAIL, passed=True, observed=f"${cost.total_usd:.2f} over {cost.call_count} calls", threshold="every crew priced")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/analysis/test_run_gate.py -v --no-cov`
+Expected: PASS, all tests. The `fact_pack_stale` line carries three spaces after the name because names are padded to the longest check name (`fact_pack_missing`, 17 characters).
+
+- [ ] **Step 5: Quality gate and commit**
+
+Run: `make lint && make mypy`
+
+```bash
+git add src/finwiz/analysis/run_gate.py tests/unit/analysis/test_run_gate.py
+git commit -m "feat(analysis): the run gate as a pure evaluator"
+```
+
+---
+
+### Task 4: State fields, and persist the freshness summary
+
+**Files:**
+
+- Modify: `src/finwiz/flow_state_models.py` (beside `stress_test_error` at line ~284)
+- Modify: `src/finwiz/orchestrators/deep_analysis_orchestrator.py` (the freshness block after `Concurrent analysis completed`, ~line 552-557)
+- Test: `tests/unit/flow/test_run_gate_state.py`
+
+**Interfaces:**
+
+- Consumes: `FactPackFreshnessSummary` from `analysis/fact_pack_freshness.py` (merged in PR #164): fields `total fresh recent stale missing oldest_stale_fetched_at`.
+- Produces: `state.fact_pack_freshness: dict[str, Any] | None`, `state.run_summary: dict[str, Any] | None`, `state.gate_verdict: str | None`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The gate reads three new state fields; the freshness summary must be one of them."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from finwiz.flow_state_models import FinwizState
+
+
+class TestRunGateStateFields:
+    def test_fields_exist_and_default_to_none(self) -> None:
+        s = FinwizState()
+        assert s.fact_pack_freshness is None
+        assert s.run_summary is None
+        assert s.gate_verdict is None
+
+
+class TestFreshnessIsPersistedNotJustLogged:
+    def test_summary_lands_on_state_as_a_plain_dict(self) -> None:
+        from finwiz.orchestrators.deep_analysis_orchestrator import DeepAnalysisOrchestrator
+
+        state = FinwizState()
+        orch = DeepAnalysisOrchestrator(state=state)
+        fact_pack = SimpleNamespace(freshness="stale", fetched_at=datetime(2026, 8, 17, tzinfo=UTC))
+        orch._enriched_analyses = {"E": SimpleNamespace(qualitative=SimpleNamespace(fact_pack=fact_pack))}
+
+        orch._record_fact_pack_freshness()
+
+        assert state.fact_pack_freshness == {
+            "total": 1,
+            "fresh": 0,
+            "recent": 0,
+            "stale": 1,
+            "missing": 0,
+            "oldest_stale_fetched_at": datetime(2026, 8, 17, tzinfo=UTC),
+        }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/flow/test_run_gate_state.py -v --no-cov`
+Expected: FAIL with `AttributeError: 'FinwizState' object has no attribute 'fact_pack_freshness'`
+
+- [ ] **Step 3: Add the state fields**
+
+In `src/finwiz/flow_state_models.py`, immediately after `stress_test_error: str | None = None`:
+
+```python
+    # Fact-pack freshness summary from Phase 3 (analysis/fact_pack_freshness.py),
+    # persisted so the run gate can read it. Plain dict: FactPackFreshnessSummary as asdict().
+    fact_pack_freshness: dict[str, Any] | None = None
+
+    # Run gate (last act of the flow). run_summary is RunSummary.model_dump();
+    # gate_verdict drives the process exit code in core/app_initializer.py.
+    run_summary: dict[str, Any] | None = None
+    gate_verdict: str | None = None
+```
+
+- [ ] **Step 4: Persist the summary where it is logged**
+
+In `src/finwiz/orchestrators/deep_analysis_orchestrator.py`, the current block reads:
+
+```python
+        freshness = summarize_fact_pack_freshness(self._enriched_analyses)
+        (self.logger.warning if freshness.stale or freshness.missing else self.logger.info)(freshness.line())
+        return results
+```
+
+Replace it with:
+
+```python
+        self._record_fact_pack_freshness()
+        return results
+```
+
+and add this method to `DeepAnalysisOrchestrator` (anywhere after `run_deep_analysis_concurrent`):
+
+```python
+    def _record_fact_pack_freshness(self) -> None:
+        """Log the per-run freshness line and persist the same numbers for the run gate.
+
+        Logged at WARNING when anything is stale or missing so it is found by
+        anyone scanning for warnings; stored as a plain dict so state stays
+        serialisable.
+        """
+        from dataclasses import asdict
+
+        freshness = summarize_fact_pack_freshness(self._enriched_analyses)
+        (self.logger.warning if freshness.stale or freshness.missing else self.logger.info)(freshness.line())
+        self.state.fact_pack_freshness = asdict(freshness)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/flow/test_run_gate_state.py tests/unit/analysis/test_fact_pack_freshness.py -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 6: Quality gate and commit**
+
+Run: `make check`
+Expected: all quality checks pass
+
+```bash
+git add src/finwiz/flow_state_models.py src/finwiz/orchestrators/deep_analysis_orchestrator.py tests/unit/flow/test_run_gate_state.py
+git commit -m "feat(state): persist fact-pack freshness; add run-gate fields"
+```
+
+---
+
+### Task 5: The orchestrator
+
+**Files:**
+
+- Create: `src/finwiz/orchestrators/run_gate_orchestrator.py`
+- Test: `tests/unit/orchestrators/test_run_gate_orchestrator.py`
+
+**Interfaces:**
+
+- Consumes: Task 1 models; `evaluate`, `verdict`, `format_block` (Task 3); `get_settings().gate` (Task 2); `state.fact_pack_freshness` (Task 4); `RunLedger.coverage() -> CoverageSummary(analyzed, degraded, failed, total)` and `RunLedger.run_id` (existing, `analysis/stages/_ledger.py`).
+- Produces: `RunGateOrchestrator(state, output_dir: Path = Path("output"), thresholds: RunGateSettings | None = None, now: Callable[[], datetime] | None = None)`, method `run() -> RunSummary | None` (None on ERROR). Module-level collectors `coverage_from(ledger) -> CoverageInput`, `valuation_from(portfolio_review) -> ValuationInput`, `fact_pack_from(freshness: dict | None) -> FactPackInput`, `phases_from(state) -> PhasesInput`, `cost_from(summary: dict | None) -> CostInput`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The orchestrator collects from state, evaluates, writes, logs -- and never raises."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from finwiz.config.settings import RunGateSettings
+from finwiz.orchestrators.run_gate_orchestrator import (
+    RunGateOrchestrator,
+    cost_from,
+    coverage_from,
+    fact_pack_from,
+    phases_from,
+    valuation_from,
+)
+from finwiz.schemas.run_summary import RunSummary, Verdict
+
+NOW = datetime(2026, 9, 5, 9, 28, 9, tzinfo=UTC)
+
+
+def _holding(weight: float | None) -> SimpleNamespace:
+    return SimpleNamespace(weight=weight)
+
+
+def _ledger(analyzed: int = 64, total: int = 64) -> SimpleNamespace:
+    return SimpleNamespace(run_id="run-abc", coverage=lambda: SimpleNamespace(analyzed=analyzed, degraded=0, failed=total - analyzed, total=total))
+
+
+def _state(**overrides) -> SimpleNamespace:
+    base = {
+        "id": "state-id",
+        "timestamp": "2026-09-05 09:04:46",
+        "run_ledger": _ledger(),
+        "portfolio_review": SimpleNamespace(holdings=[_holding(0.5), _holding(0.5), _holding(None)]),
+        "fact_pack_freshness": {"total": 3, "fresh": 2, "recent": 0, "stale": 1, "missing": 0, "oldest_stale_fetched_at": datetime(2026, 8, 17, tzinfo=UTC)},
+        "investment_discovery_result": {"opportunities": [{"ticker": "X"}, {"ticker": "Y"}]},
+        "alternatives_count": 0,
+        "portfolio_gap_profile": {"underperformer_slots": [{}, {}, {}]},
+        "stress_test_count": 6,
+        "optimal_allocation": None,
+        "llm_cost_summary": {"total_cost": 0.51, "call_count": 68, "per_crew": {"deep_analysis_stock": {"cost": 0.51, "calls": 68, "cost_known": True}}},
+        "run_summary": None,
+        "gate_verdict": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestCollectors:
+    def test_coverage_from_ledger(self) -> None:
+        c = coverage_from(_ledger(analyzed=60, total=64))
+        assert (c.available, c.analyzed, c.failed, c.total) == (True, 60, 4, 64)
+
+    def test_coverage_from_none_is_unavailable(self) -> None:
+        assert coverage_from(None).available is False
+
+    def test_valuation_uses_the_heros_denominator(self) -> None:
+        """Unpriced holdings leave `priced`, never `total` -- the 5.14.1 lesson."""
+        v = valuation_from(SimpleNamespace(holdings=[_holding(0.4), _holding(0.6), _holding(None)]))
+        assert (v.available, v.priced, v.total) == (True, 2, 3)
+
+    def test_valuation_from_none_is_unavailable(self) -> None:
+        assert valuation_from(None).available is False
+
+    def test_fact_pack_from_dict(self) -> None:
+        f = fact_pack_from({"total": 64, "fresh": 40, "recent": 6, "stale": 18, "missing": 0, "oldest_stale_fetched_at": None})
+        assert (f.available, f.stale, f.total) == (True, 18, 64)
+
+    def test_fact_pack_from_none_is_unavailable(self) -> None:
+        assert fact_pack_from(None).available is False
+
+    def test_phases_read_the_named_state_fields(self) -> None:
+        p = phases_from(_state())
+        assert (p.discovery_candidates, p.alternatives_found, p.underperformers, p.stress_scenarios, p.optimal_allocation) == (2, 0, 3, 6, False)
+
+    def test_phases_treat_none_discovery_and_raw_output_as_zero(self) -> None:
+        assert phases_from(_state(investment_discovery_result=None)).discovery_candidates == 0
+        assert phases_from(_state(investment_discovery_result={"raw_output": "text"})).discovery_candidates == 0
+
+    def test_cost_lists_every_unpriced_crew(self) -> None:
+        c = cost_from({"total_cost": 0.0, "call_count": 10, "per_crew": {"a": {"cost_known": False}, "b": {"cost_known": True}, "c": {"cost_known": False}}})
+        assert (c.available, c.cost_known, c.unpriced_crews) == (True, False, ["a", "c"])
+
+    def test_cost_from_none_is_unavailable(self) -> None:
+        assert cost_from(None).available is False
+
+
+class TestRun:
+    def test_writes_json_logs_block_and_sets_state(self, tmp_path, caplog) -> None:
+        state = _state()
+        with caplog.at_level(logging.INFO):
+            summary = RunGateOrchestrator(state, output_dir=tmp_path, thresholds=RunGateSettings(), now=lambda: NOW).run()
+
+        assert summary is not None and summary.verdict is Verdict.FAIL  # 1/3 stale = 33% > 25%
+        assert state.gate_verdict == "FAIL"
+        assert state.run_summary == summary.model_dump(mode="json")
+
+        written = RunSummary.model_validate_json((tmp_path / "run_summary.json").read_text())
+        assert written == summary
+        assert (tmp_path / "run_ledger" / "run-abc.summary.json").exists()
+
+        lines = [r.message for r in caplog.records if r.message.startswith("run gate: ")]
+        assert len(lines) == 9
+        assert lines[-1].startswith("run gate: verdict FAIL")
+
+    def test_duration_is_computed_from_state_timestamp(self, tmp_path) -> None:
+        summary = RunGateOrchestrator(_state(), output_dir=tmp_path, now=lambda: NOW).run()
+        assert summary is not None
+        assert summary.duration_seconds == pytest.approx((NOW.replace(tzinfo=None) - datetime(2026, 9, 5, 9, 4, 46)).total_seconds())
+
+    def test_a_collector_raising_yields_error_not_an_exception(self, tmp_path, caplog, mocker) -> None:
+        mocker.patch("finwiz.orchestrators.run_gate_orchestrator.coverage_from", side_effect=RuntimeError("ledger exploded"))
+        state = _state()
+
+        with caplog.at_level(logging.ERROR):
+            result = RunGateOrchestrator(state, output_dir=tmp_path).run()
+
+        assert result is None
+        assert state.gate_verdict == "ERROR"
+        failures = [r for r in caplog.records if "run gate" in r.message.lower() and r.levelno >= logging.ERROR]
+        assert failures and failures[0].exc_info is not None, "the gate's own failure must keep its traceback"
+
+    def test_unavailable_inputs_still_produce_a_summary(self, tmp_path) -> None:
+        state = _state(run_ledger=None, llm_cost_summary=None, fact_pack_freshness=None)
+        summary = RunGateOrchestrator(state, output_dir=tmp_path, now=lambda: NOW).run()
+        assert summary is not None and summary.verdict is Verdict.FAIL
+        assert [c.name for c in summary.checks if c.detail == "not measured"] == ["coverage", "cost_known", "fact_pack_stale", "fact_pack_missing"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/orchestrators/test_run_gate_orchestrator.py -v --no-cov`
+Expected: FAIL with `ModuleNotFoundError: No module named 'finwiz.orchestrators.run_gate_orchestrator'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""Orchestrator for the run gate -- the flow's last act.
+
+Collects what the run already knows about itself from state, evaluates it
+through ``analysis/run_gate.py``, writes ``output/run_summary.json`` and a
+dated copy beside the ledger, logs one line per check, and leaves the verdict
+on state for ``core/app_initializer.py`` to turn into an exit code.
+
+Never raises. The report was written before this ran; a failure here is
+recorded as verdict ERROR (exit 2), with its traceback, and the run ends.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from finwiz.analysis.run_gate import evaluate, format_block, verdict
+from finwiz.config.settings import RunGateSettings, get_settings
+from finwiz.schemas.run_summary import CostInput, CoverageInput, FactPackInput, PhasesInput, RunSummary, ValuationInput, Verdict
+from finwiz.tools.logger import get_logger
+
+logger = get_logger(__name__)
+
+_STATE_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"  # FinwizState.timestamp
+
+
+def coverage_from(ledger: Any) -> CoverageInput:
+    if ledger is None:
+        return CoverageInput()
+    c = ledger.coverage()
+    return CoverageInput(available=True, analyzed=c.analyzed, degraded=c.degraded, failed=c.failed, total=c.total)
+
+
+def valuation_from(portfolio_review: Any) -> ValuationInput:
+    """Priced = ``weight is not None`` -- the same set the allocation hero counts."""
+    holdings = getattr(portfolio_review, "holdings", None)
+    if holdings is None:
+        return ValuationInput()
+    return ValuationInput(available=True, priced=sum(1 for h in holdings if getattr(h, "weight", None) is not None), total=len(holdings))
+
+
+def fact_pack_from(freshness: dict[str, Any] | None) -> FactPackInput:
+    if not freshness:
+        return FactPackInput()
+    return FactPackInput(available=True, **{k: freshness.get(k, 0) for k in ("fresh", "recent", "stale", "missing", "total")}, oldest_stale_fetched_at=freshness.get("oldest_stale_fetched_at"))
+
+
+def phases_from(state: Any) -> PhasesInput:
+    discovery = getattr(state, "investment_discovery_result", None) or {}
+    opportunities = discovery.get("opportunities") if isinstance(discovery, dict) else None
+    gap_profile = getattr(state, "portfolio_gap_profile", None) or {}
+    return PhasesInput(
+        discovery_candidates=len(opportunities) if isinstance(opportunities, list) else 0,
+        alternatives_found=int(getattr(state, "alternatives_count", 0) or 0),
+        underperformers=len(gap_profile.get("underperformer_slots") or []),
+        stress_scenarios=int(getattr(state, "stress_test_count", 0) or 0),
+        optimal_allocation=getattr(state, "optimal_allocation", None) is not None,
+    )
+
+
+def cost_from(summary: dict[str, Any] | None) -> CostInput:
+    if not summary:
+        return CostInput()
+    per_crew = summary.get("per_crew") or {}
+    unpriced = sorted(name for name, entry in per_crew.items() if not entry.get("cost_known", True))
+    return CostInput(
+        available=True,
+        total_usd=float(summary.get("total_cost") or 0.0),
+        call_count=int(summary.get("call_count") or 0),
+        cost_known=not unpriced,
+        unpriced_crews=unpriced,
+    )
+
+
+class RunGateOrchestrator:
+    """Evaluates the finished run and records the verdict. See module docstring."""
+
+    def __init__(
+        self,
+        state: Any,
+        output_dir: Path = Path("output"),
+        thresholds: RunGateSettings | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.state = state
+        self.output_dir = output_dir
+        self.thresholds = thresholds
+        self._now = now or (lambda: datetime.now(UTC))
+
+    def run(self) -> RunSummary | None:
+        try:
+            summary = self._evaluate()
+            self._write(summary)
+            for line in format_block(summary.checks, summary.verdict, str(self.output_dir / "run_summary.json")):
+                logger.info(line)
+            self.state.run_summary = summary.model_dump(mode="json")
+            self.state.gate_verdict = summary.verdict.value
+            return summary
+        except Exception:
+            # The report is already written. Record that we could not judge it --
+            # with the traceback, or the next person cannot either.
+            logger.exception("run gate could not evaluate this run; verdict ERROR")
+            self.state.gate_verdict = Verdict.ERROR.value
+            return None
+
+    def _evaluate(self) -> RunSummary:
+        thresholds = self.thresholds or get_settings().gate
+        coverage = coverage_from(getattr(self.state, "run_ledger", None))
+        valuation = valuation_from(getattr(self.state, "portfolio_review", None))
+        fact_pack = fact_pack_from(getattr(self.state, "fact_pack_freshness", None))
+        phases = phases_from(self.state)
+        cost = cost_from(getattr(self.state, "llm_cost_summary", None))
+        checks = evaluate(coverage, valuation, fact_pack, phases, cost, thresholds)
+
+        finished = self._now()
+        started = self._started_at()
+        ledger = getattr(self.state, "run_ledger", None)
+        return RunSummary(
+            run_id=getattr(ledger, "run_id", None) or str(getattr(self.state, "id", "unknown")),
+            started_at=started,
+            finished_at=finished,
+            duration_seconds=(finished.replace(tzinfo=None) - started).total_seconds() if started else None,
+            coverage=coverage,
+            valuation=valuation,
+            fact_pack=fact_pack,
+            phases=phases,
+            cost=cost,
+            checks=checks,
+            verdict=verdict(checks),
+        )
+
+    def _started_at(self) -> datetime | None:
+        raw = getattr(self.state, "timestamp", None)
+        try:
+            return datetime.strptime(raw, _STATE_TIMESTAMP_FORMAT) if raw else None
+        except ValueError:
+            return None
+
+    def _write(self, summary: RunSummary) -> None:
+        payload = summary.model_dump_json(indent=2)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        (self.output_dir / "run_summary.json").write_text(payload)
+        dated = self.output_dir / "run_ledger"
+        dated.mkdir(parents=True, exist_ok=True)
+        (dated / f"{summary.run_id}.summary.json").write_text(payload)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/orchestrators/test_run_gate_orchestrator.py -v --no-cov`
+Expected: PASS, all tests
+
+- [ ] **Step 5: Quality gate and commit**
+
+Run: `make check`
+Expected: all quality checks pass
+
+```bash
+git add src/finwiz/orchestrators/run_gate_orchestrator.py tests/unit/orchestrators/test_run_gate_orchestrator.py
+git commit -m "feat(orchestrators): run gate -- collect, evaluate, write, log, never raise"
+```
+
+---
+
+### Task 6: Wire the flow and the exit code
+
+**Files:**
+
+- Modify: `src/finwiz/flows/orchestrator.py` (inside `run_sequential_workflow`, after `self._log_post_flow_summaries()` at line ~293)
+- Modify: `src/finwiz/core/app_initializer.py` (the `os._exit(0)` at line ~75)
+- Test: `tests/unit/flow/test_app_initializer_exit_code.py`
+
+**Interfaces:**
+
+- Consumes: `RunGateOrchestrator(state).run()` (Task 5); `exit_code_for` (Task 3); `state.gate_verdict` (Task 4).
+- Produces: the process exit code.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""The process exit code is the gate's verdict, not a constant 0."""
+
+from __future__ import annotations
+
+import pytest
+
+from finwiz.core import app_initializer
+
+
+class _FakeFlow:
+    """Stands in for FinwizFlow: kickoff() leaves a verdict on state, like the real gate does."""
+
+    verdict: str | None = "FAIL"
+
+    def __init__(self, state) -> None:
+        self.state = state
+
+    def kickoff(self) -> None:
+        self.state.gate_verdict = self.verdict
+
+
+@pytest.fixture()
+def quiet_startup(mocker):
+    mocker.patch("finwiz.validation.validate_template_variables_at_startup")
+    mocker.patch.object(app_initializer, "initialize_configuration")
+    mocker.patch.object(app_initializer, "initialize_environment")
+    mocker.patch.object(app_initializer.logging, "shutdown")
+    return mocker.patch.object(app_initializer.os, "_exit")
+
+
+class TestExitCodeFollowsTheVerdict:
+    @pytest.mark.parametrize(("verdict", "code"), [("PASS", 0), ("WARN", 0), ("FAIL", 1), ("ERROR", 2), (None, 2)])
+    def test_exit_code(self, mocker, quiet_startup, verdict, code) -> None:
+        _FakeFlow.verdict = verdict
+        mocker.patch.object(app_initializer, "FinwizFlow", _FakeFlow)
+
+        app_initializer.kickoff()
+
+        quiet_startup.assert_called_once_with(code)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/flow/test_app_initializer_exit_code.py -v --no-cov`
+Expected: FAIL — `assert_called_once_with(1)` fails because `_exit` was called with `0`
+
+- [ ] **Step 3: Wire the gate into the flow**
+
+In `src/finwiz/flows/orchestrator.py`, the sequential method currently ends:
+
+```python
+        self._log_post_flow_summaries()
+
+        logger.info("Sequential workflow completed")
+        return {"status": "completed"}
+```
+
+Change to:
+
+```python
+        self._log_post_flow_summaries()
+
+        # Run gate -- the last act. Reads coverage, valuation, freshness, phases
+        # and cost from state, writes output/run_summary.json, and leaves the
+        # verdict on state for app_initializer to turn into the exit code. The
+        # orchestrator never raises; this guard only covers its construction.
+        try:
+            from finwiz.orchestrators.run_gate_orchestrator import RunGateOrchestrator
+
+            RunGateOrchestrator(self.state).run()
+        except Exception:
+            logger.exception("run gate could not start; verdict ERROR")
+            self.state.gate_verdict = "ERROR"
+
+        logger.info("Sequential workflow completed")
+        return {"status": "completed"}
+```
+
+- [ ] **Step 4: Turn the verdict into the exit code**
+
+In `src/finwiz/core/app_initializer.py`, add to the imports:
+
+```python
+from finwiz.analysis.run_gate import exit_code_for
+```
+
+and replace
+
+```python
+        finwiz_flow.kickoff()
+        logger.info("✅ FinWiz analysis workflow completed successfully")
+        # Step 7: Force-exit the process so third-party thread pools
+        # (CrewAI, LiteLLM, httpx) don't block Python's threading._shutdown().
+        # Flush logs first to ensure nothing is lost.
+        logging.shutdown()
+        os._exit(0)
+```
+
+with
+
+```python
+        finwiz_flow.kickoff()
+        # Step 6: The run gate left its verdict on state. PASS/WARN → 0, FAIL → 1,
+        # ERROR or no verdict at all → 2. "Nothing to report" and "I did not look"
+        # must never share an exit code.
+        gate_verdict = getattr(flow_state, "gate_verdict", None)
+        exit_code = exit_code_for(gate_verdict)
+        logger.info(f"✅ FinWiz analysis workflow completed — run gate {gate_verdict or 'ERROR'} (exit {exit_code})")
+        # Step 7: Force-exit the process so third-party thread pools
+        # (CrewAI, LiteLLM, httpx) don't block Python's threading._shutdown().
+        # Flush logs first to ensure nothing is lost.
+        logging.shutdown()
+        os._exit(exit_code)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/flow/test_app_initializer_exit_code.py -v --no-cov && uv run python -c "from finwiz.flows.orchestrator import FinwizFlow; print('flow imports')"`
+Expected: PASS, 5 tests; `flow imports`
+
+- [ ] **Step 6: Quality gate and commit**
+
+Run: `make check`
+Expected: all quality checks pass
+
+```bash
+git add src/finwiz/flows/orchestrator.py src/finwiz/core/app_initializer.py tests/unit/flow/test_app_initializer_exit_code.py
+git commit -m "feat(flow): run the gate last and exit with its verdict"
+```
+
+---
+
+### Task 7: The standalone
+
+**Files:**
+
+- Create: `scripts/run_gate.py`
+- Modify: `Makefile` (`.PHONY` line 3; help block ~line 25; a target beside `check-stage-contract` ~line 167)
+- Test: `tests/unit/scripts/test_run_gate_script.py`
+
+**Interfaces:**
+
+- Consumes: `RunSummary` (Task 1); `evaluate`, `verdict`, `exit_code_for`, `format_block` (Task 3); `get_settings().gate` (Task 2). **Nothing from `finwiz.flows` or `finwiz.orchestrators`.**
+- Produces: `main(argv: list[str] | None = None) -> int`; `make gate`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""`make gate` re-evaluates an existing run_summary.json against current thresholds."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "scripts"))
+
+from run_gate import main  # noqa: E402
+
+from finwiz.config.settings import reset_settings  # noqa: E402
+
+REPO_SCRIPT = Path(__file__).parent.parent.parent.parent / "scripts" / "run_gate.py"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_settings():
+    reset_settings()
+    yield
+    reset_settings()
+
+
+def _summary_json(stale: int = 18) -> dict:
+    return {
+        "run_id": "run-abc",
+        "started_at": "2026-09-05T09:04:46",
+        "finished_at": "2026-09-05T09:28:09",
+        "duration_seconds": 1403.0,
+        "coverage": {"available": True, "analyzed": 64, "degraded": 0, "failed": 0, "total": 64},
+        "valuation": {"available": True, "priced": 63, "total": 64},
+        "fact_pack": {"available": True, "fresh": 64 - stale, "recent": 0, "stale": stale, "missing": 0, "total": 64, "oldest_stale_fetched_at": None},
+        "phases": {"discovery_candidates": 3, "alternatives_found": 2, "underperformers": 17, "stress_scenarios": 6, "optimal_allocation": False},
+        "cost": {"available": True, "total_usd": 0.51, "call_count": 68, "cost_known": True, "unpriced_crews": []},
+        "checks": [],
+        "verdict": "PASS",  # deliberately wrong: the script must re-evaluate, not trust this
+    }
+
+
+class TestRunGateScript:
+    def test_reevaluates_rather_than_trusting_the_stored_verdict(self, tmp_path, capsys) -> None:
+        p = tmp_path / "run_summary.json"
+        p.write_text(json.dumps(_summary_json(stale=18)))
+
+        code = main([str(p)])
+
+        out = capsys.readouterr().out
+        assert code == 1
+        assert "run gate: verdict FAIL" in out
+
+    def test_a_changed_threshold_changes_the_verdict(self, tmp_path, monkeypatch) -> None:
+        p = tmp_path / "run_summary.json"
+        p.write_text(json.dumps(_summary_json(stale=18)))
+        monkeypatch.setenv("FINWIZ_GATE__MAX_STALE_RATIO", "0.30")
+        reset_settings()
+
+        assert main([str(p)]) == 0
+
+    def test_missing_file_is_exit_2(self, tmp_path) -> None:
+        assert main([str(tmp_path / "nope.json")]) == 2
+
+    def test_script_never_imports_the_flow(self) -> None:
+        source = REPO_SCRIPT.read_text()
+        assert "finwiz.flows" not in source
+        assert "finwiz.orchestrators" not in source
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/scripts/test_run_gate_script.py -v --no-cov`
+Expected: FAIL with `ModuleNotFoundError: No module named 'run_gate'`
+
+- [ ] **Step 3: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""Re-evaluate a run's summary against the current gate thresholds.
+
+    make gate                       # output/run_summary.json
+    uv run python scripts/run_gate.py path/to/run_summary.json
+
+Loads the JSON the flow wrote, re-runs the same pure evaluator with the
+thresholds currently in settings (FINWIZ_GATE__*), prints the same block the
+flow logged, and exits with the same code: 0 PASS/WARN, 1 FAIL, 2 could not
+evaluate. The stored verdict is ignored on purpose -- change a threshold in
+.env, run this, see the effect without a 23-minute kickoff.
+
+Imports the schema and the evaluator only. No flow, no state, no network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from finwiz.analysis.run_gate import evaluate, exit_code_for, format_block, verdict
+from finwiz.config.settings import get_settings
+from finwiz.schemas.run_summary import RunSummary, Verdict
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("summary", nargs="?", default="output/run_summary.json", help="path to a run_summary.json (default: output/run_summary.json)")
+    args = parser.parse_args(argv)
+
+    path = Path(args.summary)
+    try:
+        summary = RunSummary.model_validate_json(path.read_text())
+    except (OSError, ValueError) as exc:
+        print(f"run gate: could not read {path}: {exc}", file=sys.stderr)
+        return exit_code_for(Verdict.ERROR)
+
+    thresholds = get_settings().gate
+    checks = evaluate(summary.coverage, summary.valuation, summary.fact_pack, summary.phases, summary.cost, thresholds)
+    v = verdict(checks)
+    for line in format_block(checks, v, str(path)):
+        print(line)
+    return exit_code_for(v)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Add the Makefile target**
+
+Add `gate` to the `.PHONY` list on line 3. In the help block, after the `check-stage-contract`-area entries, add:
+
+```makefile
+	@echo "  make gate        - Re-evaluate output/run_summary.json against current gate thresholds"
+```
+
+Beside `check-stage-contract`, add:
+
+```makefile
+# Run gate — re-evaluate the last run's summary with the thresholds currently in settings.
+# Exit 0 PASS/WARN, 1 FAIL, 2 could not evaluate. See docs/superpowers/specs/2026-09-05-run-gate-design.md.
+.PHONY: gate
+gate:
+	uv run python scripts/run_gate.py output/run_summary.json
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/scripts/test_run_gate_script.py -v --no-cov`
+Expected: PASS, 4 tests
+
+- [ ] **Step 6: Quality gate and commit**
+
+Run: `make check`
+Expected: all quality checks pass
+
+```bash
+git add scripts/run_gate.py Makefile tests/unit/scripts/test_run_gate_script.py
+git commit -m "feat(scripts): make gate -- re-evaluate a run summary without the flow"
+```
+
+---
+
+### Task 8: Live verification
+
+**Files:** none changed. This task produces evidence.
+
+**Interfaces:**
+
+- Consumes: everything above.
+- Produces: the numbers for the PR body, and a first real `run_summary.json`.
+
+- [ ] **Step 1: Run the flow and capture the exit code**
+
+Run: `uv run crewai flow kickoff; echo "exit=$?"`
+Expected: the run completes; `exit=1` is the expected outcome for a portfolio still at ~28 % stale fact packs. `exit=0` is fine if Perplexity behaved. `exit=2` means the gate itself failed — read the traceback (`grep -A20 'run gate could not' logs/finwiz.log`) before anything else.
+
+- [ ] **Step 2: Read the block**
+
+Run: `grep 'run gate:' logs/finwiz.log | tail -9`
+Expected: eight check lines and one verdict line.
+
+- [ ] **Step 3: Cross-check every number against its source, once, by hand**
+
+Run:
+
+```bash
+uv run python -c "
+import json; s = json.load(open('output/run_summary.json'))
+print('coverage ', s['coverage']); print('valuation', s['valuation']); print('fact_pack', {k: v for k, v in s['fact_pack'].items() if k != 'oldest_stale_fetched_at'}); print('cost     ', s['cost']); print('verdict  ', s['verdict'])
+"
+grep -E 'Concurrent analysis completed|Valuation coverage|fact_pack freshness|TOTAL:' logs/finwiz.log | tail -4
+```
+
+Expected: `coverage.analyzed/total` equals the `Concurrent analysis completed: N/M` line; `valuation.priced/total` equals `Valuation coverage: N of M`; `fact_pack.*` equals the `fact_pack freshness:` line; `cost.total_usd` equals the `TOTAL:` line. Any mismatch is a collector bug — fix the collector, not the expectation.
+
+- [ ] **Step 4: Confirm the dated copy and the standalone**
+
+Run: `ls output/run_ledger/*.summary.json | tail -1 && make gate; echo "exit=$?"`
+Expected: one dated file; `make gate` reproduces the same block and the same exit code as the flow.
+
+- [ ] **Step 5: Prove a threshold moves the verdict**
+
+Run: `FINWIZ_GATE__MAX_STALE_RATIO=0.99 make gate; echo "exit=$?"`
+Expected: `fact_pack_stale` now PASS; the exit code drops to 0 if nothing else FAILed. Do **not** commit this threshold.
+
+- [ ] **Step 6: Record and open the PR**
+
+The PR body states: the verdict and exit code, the eight lines, the cross-check result of step 3, and the threshold experiment of step 5.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Placement after `_log_post_flow_summaries()` (Task 6). Seven components: schema (T1), settings (T2), evaluator (T3), state fields + freshness persistence (T4), orchestrator (T5), flow call + exit code (T6), script + Makefile (T7). Contract and exact sources (T1, T5 collectors — including `opportunities`, `underperformer_slots`, `weight is not None`, `per_crew[*].cost_known`). Eight checks with severities and defaults (T2, T3). `not measured` as FAIL never skipped (T3, tested in both the evaluator and the orchestrator). Verdict aggregation and exit codes incl. `None`→2 (T3, T6). Log block format (T3, T5). JSON + dated copy (T5). Gate failure → ERROR with traceback, no raise (T5, plus the construction guard in T6). Standalone re-evaluates rather than trusting the stored verdict, imports no flow (T7). Done-when items map to Task 8.
+
+**Placeholder scan.** None. Every code step carries runnable code; the one conditional instruction (T3 Step 4 padding) tells the implementer which side to change and why.
+
+**Type consistency.** `RunGateSettings` field names (`min_coverage_ratio`, `min_priced_ratio`, `max_stale_ratio`) match between T2, T3 and T7's env var. `evaluate(coverage, valuation, fact_pack, phases, cost, thresholds)` argument order is identical in T3, T5 and T7. `format_block(checks, v, summary_path)` identical in T3, T5, T7. `exit_code_for` accepts `Verdict | str | None` in T3 and is called with a `str | None` in T6. `state.fact_pack_freshness` is written as `asdict(FactPackFreshnessSummary)` in T4 and read by `fact_pack_from` in T5 using the dataclass's field names (`fresh recent stale missing total oldest_stale_fetched_at`). `_record_fact_pack_freshness` is defined in T4 and called by T4's test.

--- a/docs/superpowers/specs/2026-09-05-run-gate-design.md
+++ b/docs/superpowers/specs/2026-09-05-run-gate-design.md
@@ -1,0 +1,195 @@
+# Run Gate — Design
+
+**Date:** 2026-09-05
+**Status:** Approved design, ready for implementation planning
+**Scope:** `src/finwiz/schemas/run_summary.py` (new), `src/finwiz/analysis/run_gate.py` (new), `src/finwiz/orchestrators/run_gate_orchestrator.py` (new), `scripts/run_gate.py` (new), `src/finwiz/config/settings.py`, `src/finwiz/flow_state_models.py`, `src/finwiz/flows/orchestrator.py`, `src/finwiz/core/app_initializer.py`, `src/finwiz/orchestrators/deep_analysis_orchestrator.py`, `Makefile`
+**Roadmap:** workstream A of `docs/superpowers/roadmaps/2026-09-05-reevaluation.md`
+
+## Problem
+
+The 2026-09-05 run was green on every gate the project has. `make check` passed. Every CI workflow passed. The process exited 0. And the run it produced served 28 % of its fact packs from a 19-day-old cache, ran three phases that delivered nothing, and reported a cost of `$0.0000` for 15.9 million tokens because the model was unpriced.
+
+Nothing checks the product after `kickoff()`. `core/app_initializer.py` logs `✅ FinWiz analysis workflow completed successfully` and calls `os._exit(0)` — unconditionally. A degraded run is indistinguishable from a good one to whoever launched it. Establishing each of the three facts above took several greps over `logs/finwiz.log`, which is the weakest artifact the run produces: unstructured, rotated, and written by forty modules with forty ideas of what matters.
+
+The pieces of a verdict already exist, scattered: `RunLedger.coverage()` knows how many holdings reached a verdict; `portfolio_review` knows how many were priced; the cost monitor knows which crews it could price; Phase 3 now logs a fact-pack freshness line (workstream C). What is missing is the place where they meet, the thresholds they are held to, and a consequence.
+
+## Decisions
+
+Three decisions were settled before design and constrain everything below.
+
+1. **A degraded run exits non-zero and writes a structured summary.** `output/run_summary.json` carries every input and every check; the process exits `1` on FAIL. The HTML report is always produced first — it is the evidence of what degraded, and evidence is not destroyed to signal a problem. Nothing consumes the exit code today, so making it truthful costs nothing now and is exactly what a scheduled run (workstream E) needs later.
+
+2. **FAIL means the report is not trustworthy. WARN means a known gap is still a gap.** Coverage, valuation, cost visibility and fact-pack freshness decide trust; they FAIL. Discovery producing nothing, alternatives producing nothing, stress tests missing — these are tracked in the roadmap (workstream D) and WARN. The alternative, failing on everything, makes the gate red from its first run until D ships. A gate that is always red is the mechanism by which Requirement 9.2 became noise (workstream F); this design refuses to build another one.
+
+3. **The gate is the last step of the flow, in-process.** Approach A1 over a post-hoc script (A2) or a report section (A3). The log is too weak a source to parse, and neither freshness nor cost exists in any artifact today — a post-hoc script would need the same JSON persisted first and would then be A1 with extra fragility. The JSON is the contract; the evaluation is a pure function over it.
+
+## Design
+
+### 1. Placement
+
+`FinwizFlow` runs its phases sequentially and ends with `_log_post_flow_summaries()` (`flows/orchestrator.py:293`), which puts the LLM cost summary on state. The gate runs **immediately after that call** — the last act before `Sequential workflow completed`. By then every input exists: the ledger, the priced portfolio, the cost summary, the freshness summary, the phase outcomes.
+
+`core/app_initializer.py` replaces `os._exit(0)` with `os._exit(exit_code_for(flow_state.gate_verdict))`.
+
+### 2. Components
+
+Seven pieces, each with one reason to exist.
+
+| Component | Role | Depends on |
+|---|---|---|
+| `schemas/run_summary.py` — `RunSummary`, `GateCheck`, `Verdict`, per-domain sub-models | the contract | nothing. Models live in `schemas/`, per project rule |
+| `config/settings.py` — `RunGateSettings`, nested as `gate`, env `FINWIZ_GATE__*` | thresholds, overridable without code | the existing `FinWizSettings` with `env_nested_delimiter="__"` |
+| `analysis/run_gate.py` — `evaluate(inputs, thresholds) -> list[GateCheck]`, `verdict(checks) -> Verdict`, `exit_code_for(verdict) -> int` | **pure**: numbers in, checks and a verdict out. No state, no IO, no clock | the schema |
+| `orchestrators/run_gate_orchestrator.py` — `RunGateOrchestrator(state).run() -> RunSummary` | collects inputs from state, calls `evaluate`, writes the JSON, logs the verdict block, sets `state.run_summary` and `state.gate_verdict` | `RunLedger`, `PortfolioReview`, the cost summary dict, `analysis/run_gate.py` |
+| `flows/orchestrator.py` | one guarded call after `_log_post_flow_summaries()` | the orchestrator |
+| `core/app_initializer.py` | the exit code | `exit_code_for` |
+| `scripts/run_gate.py` + `make gate` | re-evaluate an existing `run_summary.json` against current thresholds; same block, same exit code | `analysis/run_gate.py` and the schema only — never the flow |
+
+Two supporting changes:
+
+- `flow_state_models.py` gains `fact_pack_freshness: dict[str, Any] | None`, `run_summary: dict[str, Any] | None`, `gate_verdict: str | None`.
+- `orchestrators/deep_analysis_orchestrator.py` persists the workstream-C freshness summary onto `state.fact_pack_freshness` in the same place it logs it. Today that line is the only trace of the number; after this it is an input.
+
+### 3. The contract
+
+`RunSummary` is one document with one sub-model per domain. Every sub-model carries `available: bool`, so "we could not measure this" is a value, not an absence.
+
+```
+RunSummary
+  run_id, started_at, finished_at, duration_seconds
+  coverage:   available, analyzed, degraded, failed, total          ← RunLedger.coverage()
+  valuation:  available, priced, total                               ← PortfolioReview.holdings
+  fact_pack:  available, fresh, recent, stale, missing, total,
+              oldest_stale_fetched_at                                ← state.fact_pack_freshness
+  phases:     discovery_candidates, alternatives_found,
+              underperformers, stress_scenarios, optimal_allocation  ← state fields (below)
+  cost:       available, total_usd, call_count, cost_known,
+              unpriced_crews                                         ← state.llm_cost_summary
+  checks:     list[GateCheck]
+  verdict:    PASS | WARN | FAIL | ERROR
+
+GateCheck
+  name, severity (FAIL | WARN), passed, observed, threshold, detail
+```
+
+Sources, exactly:
+
+| Field | Read from |
+|---|---|
+| `run_id` | `state.run_ledger.run_id`, else `state.id` |
+| `coverage` | `state.run_ledger.coverage()` — `CoverageSummary(analyzed, degraded, failed, total)` |
+| `valuation.priced` | `len([h for h in portfolio_review.holdings if h.weight is not None])`. **The same set the allocation hero counts.** Deriving the ratio from a different denominator than the one displayed is the defect 5.14.1 fixed |
+| `fact_pack` | `state.fact_pack_freshness`, the persisted workstream-C summary |
+| `phases.discovery_candidates` | length of the candidate list inside `state.investment_discovery_result`, `0` when `None`. The exact key is a data-shape detail the implementation plan pins after reading one real payload |
+| `phases.alternatives_found` | `state.alternatives_count` |
+| `phases.underperformers` | `len(state.portfolio_gap_profile["underperformer_slots"])` — the count Phase 3.6 already computed, not a new definition |
+| `phases.stress_scenarios` | `state.stress_test_count` |
+| `phases.optimal_allocation` | `state.optimal_allocation is not None` — informational until workstream G ships |
+| `cost` | `state.llm_cost_summary`: `total_cost`, `call_count`, and `per_crew[*]["cost_known"]`; `unpriced_crews` lists every crew whose `cost_known` is false |
+
+### 4. Checks and thresholds
+
+| Check | Severity | Passes when | Default |
+|---|---|---|---|
+| `coverage` | FAIL | `analyzed / total ≥ min_coverage_ratio` | 0.95 |
+| `valuation` | FAIL | `priced / total ≥ min_priced_ratio` | 0.95 |
+| `cost_known` | FAIL | `unpriced_crews` is empty | — |
+| `fact_pack_stale` | FAIL | `stale / total ≤ max_stale_ratio` | 0.25 |
+| `discovery` | WARN | `discovery_candidates > 0` | — |
+| `alternatives` | WARN | `alternatives_found > 0` **or** `underperformers == 0` | — |
+| `stress_tests` | WARN | `stress_scenarios > 0` | — |
+| `fact_pack_missing` | WARN | `missing == 0` | — |
+
+**A check whose input is `available=False` FAILS with detail `"not measured"`.** It is never skipped. A gate that skips a check when the data is missing is a gate that is passed by breaking the data.
+
+Thresholds live in `RunGateSettings` and are overridable per environment: `FINWIZ_GATE__MIN_COVERAGE_RATIO=0.9`. Severities are **not** configurable — moving a check between FAIL and WARN is a design decision, made in code, reviewed.
+
+Against the 2026-09-05 run: `coverage` PASS (64/64), `valuation` PASS (63/64 = 98 %), `cost_known` FAIL (three crews unpriced — should PASS after workstream B; to confirm), `fact_pack_stale` FAIL (18/64 = 28 %), `discovery` WARN (0), `alternatives` WARN (0 for 17), `stress_tests` PASS, `fact_pack_missing` PASS. **Verdict: FAIL.** That is the correct verdict for that run.
+
+### 5. Verdict, exit code, output
+
+Aggregation: any FAIL → `FAIL`; else any WARN → `WARN`; else `PASS`. WARNs never escalate by accumulation — three WARNs are `WARN`. That is what keeps the signal legible.
+
+| Verdict | Exit | Meaning |
+|---|---|---|
+| `PASS` | 0 | nothing to report |
+| `WARN` | 0 | known gaps, still gaps |
+| `FAIL` | 1 | the report is not trustworthy |
+| `ERROR` | 2 | the gate itself could not evaluate |
+
+The distinction between `0` and `2` is the point: "nothing to report" and "I did not look" must never share an exit code.
+
+The log block, one line per check, verdict last, each line grep-able by its prefix:
+
+```
+run gate: coverage        PASS  64/64 analysed (min 95%)
+run gate: valuation       PASS  63/64 priced (min 95%)
+run gate: cost_known      FAIL  3 crews unpriced: deep_analysis_crypto, deep_analysis_etf, deep_analysis_stock
+run gate: fact_pack_stale FAIL  18/64 stale = 28% (max 25%)
+run gate: discovery       WARN  0 candidates
+run gate: alternatives    WARN  0 found for 17 underperformers
+run gate: stress_tests    PASS  6 scenarios
+run gate: fact_pack_missing PASS  0 missing
+run gate: verdict FAIL — output/run_summary.json
+```
+
+Output: `RunSummary.model_dump_json(indent=2)` to `output/run_summary.json`, overwritten each run, plus a dated copy at `output/run_ledger/<run_id>.summary.json` beside the ledger — the history workstream E will read.
+
+### 6. Failure of the gate itself
+
+The report is written before the gate runs. The gate never raises into the flow. The orchestrator wraps everything: on any exception it logs **with traceback** (`logger.exception`, the convention established in PR #158), sets `state.gate_verdict = "ERROR"`, and returns. The process exits `2`.
+
+Absent inputs are not exceptions. A `None` ledger, a `None` cost summary, a missing freshness field — each collector returns its sub-model with `available=False`, and the corresponding check FAILs with `"not measured"`. The gate always produces a summary; what varies is what the summary says.
+
+### 7. The standalone
+
+`make gate` → `uv run python scripts/run_gate.py output/run_summary.json`.
+
+It loads the JSON, **re-evaluates** against the current `RunGateSettings` — not the stored verdict — prints the same block, exits with the same code. Change a threshold in `.env`, run `make gate`, see the effect without a 23-minute kickoff. It imports `schemas/run_summary.py` and `analysis/run_gate.py` and nothing else; it must work with no flow, no state, no network.
+
+### 8. Testing
+
+All offline, under the pytest-socket guard, pytest-mock only.
+
+| Test | Asserts |
+|---|---|
+| `evaluate`, per check | both sides of every threshold, with the 2026-09-05 values as the nominal cases: 64/64, 63/64, 18/64, 0 candidates, 17 underperformers |
+| unavailable input | `available=False` → FAIL, detail `"not measured"`; never absent from `checks` |
+| aggregation | FAIL > WARN > PASS; three WARNs are WARN; an empty check list is PASS |
+| `exit_code_for` | PASS→0, WARN→0, FAIL→1, ERROR→2 |
+| valuation collector | unpriced holdings excluded from `priced`, never from `total` |
+| orchestrator, state as `SimpleNamespace` | JSON written, round-trips through `RunSummary.model_validate_json`; a collector raising → verdict ERROR, traceback in caplog, nothing raised |
+| `scripts/run_gate.py` | changed threshold changes the verdict; exit codes; no `finwiz.flows` import |
+| `app_initializer` | `os._exit` (mocked) receives the code of the verdict |
+
+Deterministic Python end to end; fully inside the coverage gate.
+
+## Risks
+
+**The first real run will exit 1.** 28 % stale exceeds 25 %; if workstream B did not resolve pricing, `cost_known` fails too. This is intended — the gate tells the truth about a run known to be degraded. The first `PASS` comes from fixing Perplexity's failure rate or from deciding, in review, that a higher threshold is acceptable. It never comes from lowering the bar until the light turns green.
+
+**Anything that calls `crewai flow kickoff` and expects 0 will now see 1 or 2.** Nothing does today — no cron, no CI. Whoever wires one later (workstream E) is the intended consumer.
+
+**Thresholds are guesses until measured.** 0.95 / 0.95 / 0.25 are set from one run. `make gate` exists precisely so they can be revisited against the JSON of several runs without relaunching any of them.
+
+## Implementation order
+
+1. `schemas/run_summary.py` — the contract first; everything downstream is typed against it.
+2. `analysis/run_gate.py` + tests — pure, offline, no dependency on the rest.
+3. `config/settings.py` — `RunGateSettings`; a test that `FINWIZ_GATE__MAX_STALE_RATIO` overrides the default.
+4. `flow_state_models.py` fields + persist the freshness summary in `deep_analysis_orchestrator.py`.
+5. `orchestrators/run_gate_orchestrator.py` + tests — collectors, JSON, verdict block, ERROR path.
+6. `flows/orchestrator.py` call + `core/app_initializer.py` exit code + test.
+7. `scripts/run_gate.py` + `make gate` + tests.
+8. Live `crewai flow kickoff`: expect exit 1, read `output/run_summary.json`, confirm every number against the log by hand once. Then `make gate` on that file.
+
+Each step leaves the suite green. Steps 1–5 change no production behaviour; step 6 is the first that can change an exit code.
+
+## Done when
+
+- A live run writes `output/run_summary.json` and the dated copy, logs the verdict block, and exits with the code of its verdict.
+- Every check reads the source named in §3; the valuation ratio uses the hero's denominator.
+- An unavailable input FAILs its check with `"not measured"`.
+- Forcing an exception inside a collector yields verdict ERROR, exit 2, a traceback in the log, and a report that was still written.
+- `make gate` on the produced JSON reproduces the verdict, and a changed threshold changes it.
+- `make check` green.


### PR DESCRIPTION
Workstream **A** of the reevaluation roadmap (#160). Design and plan only — no code.

## Problem

Nothing checks the product after `kickoff()`. `core/app_initializer.py` calls `os._exit(0)` unconditionally, so the 2026-09-05 run — 28 % of fact packs from a 19-day-old cache, three inert phases, `$0.0000` for 15.9 M tokens — was indistinguishable from a good one to whoever launched it. Every one of those facts took several greps over the log to establish.

## Decisions

1. **Degraded runs exit non-zero and write `output/run_summary.json`.** The HTML report is always produced first — it is the evidence.
2. **FAIL = the report is not trustworthy** (coverage, valuation, cost visibility, freshness). **WARN = a known gap is still a gap** (discovery, alternatives, stress tests — tracked as workstream D). A gate red from day one until D ships would be Requirement 9.2 again.
3. **The gate is the flow's last act, in-process.** The JSON is the contract; the evaluation is a pure function over it. A standalone `make gate` re-evaluates any existing JSON against current thresholds — no flow, no 23-minute kickoff.

## Shape

Eight checks, severities in code, three thresholds in settings (`FINWIZ_GATE__MIN_COVERAGE_RATIO` / `MIN_PRICED_RATIO` / `MAX_STALE_RATIO`, defaults 0.95 / 0.95 / 0.25). A check whose input is missing **FAILs as `not measured`** — never skipped. Exit codes: PASS/WARN 0, FAIL 1, ERROR 2 — "nothing to report" and "I did not look" never share a code.

Against the motivating run, computed by hand: **verdict FAIL** (three crews unpriced — should now pass after #162; 28 % stale > 25 %). That is the correct verdict for that run, and the plan's evaluator tests use those exact numbers as the nominal case.

## Plan

Eight tasks: contract → thresholds → pure evaluator → state fields + persist the workstream-C freshness summary → orchestrator → flow call + exit code → `scripts/run_gate.py` + `make gate` → live verification with a by-hand cross-check of every number against its log source.

## Risk, stated

The first live run will exit 1. That is intended. The first PASS comes from fixing Perplexity's failure rate or from raising a threshold in review — never from lowering the bar until the light turns green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwsV4WdanisV9UBdGadCWe