### PR TITLE
chore(lint): accept hard tabs inside code blocks

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,4 +1,7 @@
 {
+  // Hard tabs stay legal inside code blocks: Makefile recipes require them, and a
+  // plan that showed spaces would hand the implementer a broken Makefile.
+  "MD010": { "code_blocks": false },
   // Markdown linting configuration for FinWiz documentation
 
   // Disable rules that conflict with our style


### PR DESCRIPTION
The run-gate plan (#165) documents two Makefile recipes in fenced `makefile` blocks. Make requires a real tab there, and MD010 flagged both. Replacing the tabs with spaces would hand the plan's implementer a Makefile that fails with `missing separator`.

`MD010` is now scoped to prose (`code_blocks: false`); it still catches tabs outside fences. `make docs-lint` is green again.

Cause of the slip: `make docs-lint | tail -1` in an ad-hoc shell line reports `tail`'s exit status, so `set -e` never saw the failure. The repo's own `docs-lint` target is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwsV4WdanisV9UBdGadCWe