### PR TITLE
fix(fact-pack): four follow-ups from the PR #167 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The report's fact-pack block no longer disappears as it ages.** A holding's
+  cached analysis stores the freshness it had when written; `FactPack`
+  cross-checks that against `fetched_at`, so once a file crossed the 3-day
+  boundary it failed validation and the whole fact-pack card was dropped from
+  the report — silently, and triggered by nothing but the clock. Freshness is
+  now re-derived on load, as the cache layer already did.
+
 ### Changed
 
 - **Fact packs are built from structured data, not an LLM.** For equities:

--- a/src/finwiz/analysis/fact_pack/composer.py
+++ b/src/finwiz/analysis/fact_pack/composer.py
@@ -44,10 +44,6 @@ _MAX_CITATIONS = 20
 # byte-identical in content to a holding that genuinely has no facts available.
 _SCHEMA_FALLBACK_SOURCE = "composer.schema_fallback"
 
-# A fund with no identifiable issuer is thin, not fatal -- only an unresolvable
-# ticker halts a holding outright.
-_PLACEHOLDER_FUND = FundFacts(issuer=PLACEHOLDER)
-
 # The exception-fallback pack must carry a details shape that matches the
 # declared asset_class (FactPack validates the pairing) -- a hardcoded
 # EquityFacts() fallback labelled asset_class="etf" would build a pack that
@@ -175,10 +171,13 @@ def compose_fact_pack(ticker: str, company_name: str, sector: str | None, indust
     # three sources (identity, filings, news) genuinely merge there.
     if asset_class == "etf":
         facts, citations, sources = fund_source.fund_facts(query_symbol, info)
-        details: EquityFacts | FundFacts | CryptoFacts = facts or _PLACEHOLDER_FUND
+        # A fund with no identifiable issuer is thin, not fatal -- only an
+        # unresolvable ticker halts a holding outright. The placeholder comes
+        # from the factory table so each pack owns its own instance.
+        details: EquityFacts | FundFacts | CryptoFacts = facts or _FALLBACK_DETAILS[asset_class]()
     elif asset_class == "crypto":
         crypto, citations = crypto_source.crypto_facts(query_symbol, info)
-        details = crypto or CryptoFacts(description=PLACEHOLDER)
+        details = crypto or _FALLBACK_DETAILS[asset_class]()
         sources = ("yfinance.info",) if crypto else ()
     else:
         details, citations, sources = _equity_details(query_symbol, info, ticker, company_name, sector, industry)

--- a/src/finwiz/analysis/fact_pack/confidence.py
+++ b/src/finwiz/analysis/fact_pack/confidence.py
@@ -64,8 +64,11 @@ def _crypto(facts: CryptoFacts) -> float:
     total = 0.0
     if _populated(facts.description):
         total += _CRYPTO_DESCRIPTION
-    # Supply is known when we can state it, and "uncapped" is a statement.
-    if facts.circulating_supply is not None and (facts.supply_is_capped or facts.max_supply is None):
+    # Supply is known when we can state it, and "uncapped" is a statement --
+    # so the cap flag deliberately does not gate this. It cannot: CryptoFacts
+    # enforces supply_is_capped == (max_supply is not None), which made the
+    # old `(supply_is_capped or max_supply is None)` guard `X or not X`.
+    if facts.circulating_supply is not None:
         total += _CRYPTO_SUPPLY
     if facts.market_cap is not None:
         total += _CRYPTO_MARKET_CAP

--- a/src/finwiz/analysis/fact_pack_research.py
+++ b/src/finwiz/analysis/fact_pack_research.py
@@ -11,8 +11,7 @@ news. `fetch_fact_pack`/`fetch_fact_pack_sync` are gone: they built a shape
 discriminated-union `FactPack` schema rejects outright (`extra="forbid"`).
 
 What remains here is what `perplexity_source` still needs: the retry-wrapped
-request schema (`_FactPackRaw`), the system prompt (`_SYSTEM_FR`), the legacy
-full-fact prompt builder (`_build_prompt`, still covered by its own tests), and
+request schema (`_FactPackRaw`), the system prompt (`_SYSTEM_FR`), and
 the sync/async bridge (`_run_coroutine_sync`) extracted from the old
 `fetch_fact_pack_sync` body.
 """
@@ -26,8 +25,6 @@ from collections.abc import Coroutine
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-
-from finwiz.analysis._helpers import _today_french
 
 logger = logging.getLogger(__name__)
 
@@ -144,34 +141,6 @@ _SYSTEM_FR = (
     "Perplexity. Tu auto-évalues ta confidence dans [0.0, 1.0]. Tu ne dois "
     "JAMAIS inventer des faits ; si tu n'as pas de source fiable, dis-le."
 )
-
-
-def _build_prompt(ticker: str, company_name: str, sector: str | None, industry: str | None) -> str:
-    today = _today_french()
-    sector_str = sector or "secteur inconnu"
-    industry_str = industry or "industrie inconnue"
-    return (
-        f"Date du jour : {today}.\n\n"
-        f"Recherche les faits VÉRIFIÉS et ACTUELS sur {company_name} ({ticker}, "
-        f"{sector_str} / {industry_str}).\n\n"
-        "1. **corporate_structure** (≤2000 chars) : structure actuelle de l'entité — "
-        "société-mère, filiales, divisions, et toute cession ou acquisition majeure "
-        "des 24 derniers mois. Exemple type : "
-        "'Independent — divested VMware November 2021. Subsidiary of Dell Technologies."
-        "'\n\n"
-        "2. **recent_events** (liste de 0 à 10 strings, ≤200 chars chacun) : "
-        f"événements matériels des 12 derniers mois (par rapport à {today}) — "
-        "résultats trimestriels notables, M&A, changements de direction, "
-        "événements réglementaires/légaux majeurs. Pas de bavardage marketing.\n\n"
-        "3. **leadership** (≤1000 chars) : CEO et CFO actuels avec dates de prise "
-        "de fonction si récents (<24 mois), plus tout changement d'équipe "
-        "exécutive matériel récent.\n\n"
-        "4. **confidence** : auto-évaluation [0.0-1.0] de la fiabilité de tes "
-        "réponses (sources multiples = haut, sources rares ou contradictoires = bas).\n\n"
-        "5. **source_citations** : URLs Perplexity utilisées (max 20).\n\n"
-        "Si tu n'as PAS de source fiable pour un champ, écris une description "
-        "courte expliquant l'incertitude — ne pas inventer."
-    )
 
 
 def _run_coroutine_sync[T](coro: Coroutine[Any, Any, T], *, timeout: float) -> T | None:

--- a/src/finwiz/orchestrators/reporting/enrichment.py
+++ b/src/finwiz/orchestrators/reporting/enrichment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Iterator
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -338,15 +339,24 @@ class ReportEnrichmentMixin:
             # labels. A malformed cached pack degrades to no fact-pack block,
             # never a traceback (Task 6/7: cached *_enriched.json can predate
             # this schema).
+            # Re-derive freshness before validating. The stored value was correct
+            # when written; FactPack cross-checks it against fetched_at, so a file
+            # that merely crossed the 3- or 7-day boundary fails validation and the
+            # except below drops the whole card -- data loss triggered by the clock
+            # alone. FactPackCache.get() re-derives on load for the same reason.
+            freshness = ""
             try:
-                rows = [list(r) for r in to_rows(FactPack.model_validate(fact))]
+                payload = dict(fact)
+                freshness = FactPack.derive_freshness(datetime.fromisoformat(str(payload["fetched_at"])))
+                payload["freshness"] = freshness
+                rows = [list(r) for r in to_rows(FactPack.model_validate(payload))]
             except Exception as e:
                 logger.warning(f"Skipping fact_pack card block: could not render cached pack: {e}")
                 rows = []
             if rows:
                 distilled["fact_pack"] = {
                     "rows": rows,
-                    "freshness": fact.get("freshness", ""),
+                    "freshness": freshness,
                     "source_citations": (fact.get("source_citations") or [])[:5],
                 }
 

--- a/tests/unit/analysis/fact_pack/test_composer.py
+++ b/tests/unit/analysis/fact_pack/test_composer.py
@@ -264,6 +264,23 @@ class TestPerClassComposition:
         assert pack.details.kind == "fund"
         assert pack.confidence == 0.0
 
+    def test_two_fallback_funds_do_not_share_one_details_object(self, mocker):
+        """Every thin fund got the SAME FundFacts instance, aliased into each pack.
+
+        Pydantic's default ``revalidate_instances='never'`` means a shared model is
+        aliased, not copied. Nothing mutates it today; nothing stops it either, and
+        a mutation would rewrite history for every fund that ever fell back.
+        _FALLBACK_DETAILS already holds a factory per class for this exact purpose.
+        """
+        mocker.patch.object(composer.yfinance_source, "resolve", return_value={"quoteType": "ETF"})
+        mocker.patch.object(composer.fund_source, "fund_facts", return_value=(None, (), ()))
+
+        a = composer.compose_fact_pack("AAAA.DE", "Fund A", None, None, "etf")
+        b = composer.compose_fact_pack("BBBB.DE", "Fund B", None, None, "etf")
+
+        assert a.details == b.details, "same content"
+        assert a.details is not b.details, "but not the same object"
+
     def test_an_unresolvable_ticker_still_returns_none(self, mocker):
         mocker.patch.object(composer.yfinance_source, "resolve", return_value={"trailingPegRatio": None})
         assert composer.compose_fact_pack("ZZZZNOTREAL", "Nothing", None, None, "stock") is None

--- a/tests/unit/analysis/test_fact_pack_research.py
+++ b/tests/unit/analysis/test_fact_pack_research.py
@@ -6,33 +6,14 @@ zero production callers once `stages/fact_pack.py` switched to
 `compose_fact_pack`. Their coverage moved to
 `tests/unit/analysis/fact_pack/test_gap_fill.py`, which exercises the
 replacement (`perplexity_source.fetch_missing_events`) through the composer.
-What remains here is what that replacement still depends on: `_build_prompt`
-(legacy, still used only by its own tests below) and `_FactPackRaw`'s
-truncating validators.
+What remains here is what that replacement still depends on: `_FactPackRaw`'s
+truncating validators. `_build_prompt` went with them -- it had no production
+caller once the composer owned the prompt, and survived only on these tests.
 """
 
 from __future__ import annotations
 
-from finwiz.analysis.fact_pack_research import (
-    _build_prompt,
-    _FactPackRaw,
-)
-
-
-class TestPromptBuilder:
-    def test_prompt_contains_today_and_company(self) -> None:
-        prompt = _build_prompt("DELL", "Dell Technologies", "Technology", "Hardware")
-        assert "Dell Technologies" in prompt
-        assert "DELL" in prompt
-        assert "Technology" in prompt
-        # French today date should contain a French month
-        assert any(m in prompt for m in ["janvier", "février", "mars", "avril", "mai", "juin", "juillet", "août", "septembre", "octobre", "novembre", "décembre"])
-
-    def test_prompt_handles_missing_sector(self) -> None:
-        prompt = _build_prompt("X", "Xenon", None, None)
-        assert "secteur inconnu" in prompt
-        assert "industrie inconnue" in prompt
-
+from finwiz.analysis.fact_pack_research import _FactPackRaw
 
 # ---------------------------------------------------------------------------
 # WS-D.2 — Truncating-validator regression tests (2026-04-29 follow-up)

--- a/tests/unit/orchestrators/test_reporting_orchestrator.py
+++ b/tests/unit/orchestrators/test_reporting_orchestrator.py
@@ -5,7 +5,7 @@ Tests report consolidation, HTML generation, and export path management.
 """
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from pytest import approx
@@ -561,6 +561,43 @@ class TestHoldingsInsightsExtraction:
         assert card["fact_pack"]["source_citations"] == ["https://a.com"]
         assert card["report_link"] == "stock/AAPL_report.html"
         assert card["grade"] == "A"
+
+    def test_a_pack_whose_stored_freshness_has_aged_still_renders(self, orchestrator, tmp_path, monkeypatch):
+        """An enriched file written 5 days ago says "fresh"; Python now derives "recent".
+
+        FactPack cross-checks the two in a model_validator, so validating the
+        stored payload as-is raises -- and the caller's except turns that into
+        rows=[], silently dropping the whole fact-pack card from the report.
+        Nothing about the pack is wrong; only the clock moved. FactPackCache.get
+        re-derives on load for exactly this reason; this path must too.
+        """
+        monkeypatch.chdir(tmp_path)
+        aged = datetime.now(UTC) - timedelta(days=5)
+        qualitative = {
+            "investment_synthesis": {"investment_thesis": "Aged but sound."},
+            "fact_pack": {
+                "asset_class": "stock",
+                "details": {
+                    "kind": "equity",
+                    "business_summary": "Single entity.",
+                    "leadership": "CEO X.",
+                    "recent_events": [],
+                    "events_from_filings": False,
+                },
+                "fetched_at": aged.isoformat(),
+                "freshness": "fresh",  # what it was when written
+                "confidence": 0.9,
+                "source_citations": [],
+                "sources_used": [],
+            },
+        }
+        self._write_enriched(tmp_path / "output" / "enriched" / "default" / "stock", "AAPL", qualitative)
+
+        card = orchestrator._extract_holdings_insights({"AAPL": {}})["AAPL"]
+
+        assert "fact_pack" in card, "the card vanished because the clock moved"
+        assert dict(card["fact_pack"]["rows"])["Structure"] == "Single entity."
+        assert card["fact_pack"]["freshness"] == "recent", "must report what Python derives now, not what was stored"
 
     def test_returns_none_when_no_qualitative(self, orchestrator, tmp_path, monkeypatch):
         # Arrange — enriched file with no qualitative section (ETF/crypto-only).

--- a/uv.lock
+++ b/uv.lock
@@ -12,38 +12,38 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
+aiohttp = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+backtrader = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+beautifulsoup4 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+crewai = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+crewai-cli = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+crewai-core = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+crewai-tools = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+empyrical-reloaded = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+fear-and-greed = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+feedparser = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+finnhub-python = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+fredapi = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 gitpython = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-pandas = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-quantlib = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+gnews = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+httpx = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+jinja2 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+langchain-core = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+litellm = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+nest-asyncio = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 numpy = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+pandas = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+plotly = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+psutil = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+pyportfolioopt = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+python-dateutil = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+python-dotenv = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+quantlib = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 scipy = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 ta-lib = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-aiohttp = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-litellm = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-yfinance = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-gnews = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-fredapi = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-crewai-core = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-finnhub-python = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-crewai-tools = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-python-dotenv = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-python-dateutil = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-feedparser = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-plotly = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-httpx = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-langchain-core = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 tenacity = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-backtrader = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-nest-asyncio = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-pyportfolioopt = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-crewai = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-fear-and-greed = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-empyrical-reloaded = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-crewai-cli = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 vadersentiment = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-psutil = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-beautifulsoup4 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-jinja2 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+yfinance = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [manifest]
 constraints = [{ name = "gitpython", specifier = ">=3.1.58" }]
@@ -1216,12 +1216,12 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "backtrader", specifier = ">=1.9.78.123" },
     { name = "beautifulsoup4", specifier = ">=4.15.0" },
-    { name = "crewai", specifier = ">=1.15.16" },
+    { name = "crewai", specifier = ">=1.15.18" },
     { name = "crewai-custom-tools", git = "https://github.com/fjacquet/crewai-custom-tools.git?rev=v0.6.0" },
     { name = "empyrical-reloaded", specifier = ">=0.5.12" },
     { name = "fear-and-greed", specifier = ">=0.4" },
     { name = "feedparser", specifier = ">=6.0.14" },
-    { name = "finnhub-python", specifier = ">=2.4.20" },
+    { name = "finnhub-python", specifier = ">=2.4.29" },
     { name = "fredapi", specifier = ">=0.5.2" },
     { name = "gnews", specifier = ">=0.8.2" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -1262,8 +1262,8 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.16.2,<1.0.0" },
-    { name = "scipy-stubs", specifier = ">=1.18.0.1" },
-    { name = "types-psutil", specifier = ">=7.2.2.20260518" },
+    { name = "scipy-stubs", specifier = ">=1.18.1.0" },
+    { name = "types-psutil", specifier = ">=7.2.2.20260827" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
     { name = "types-requests", specifier = ">=2.33.0.20260712" },
 ]
@@ -1274,7 +1274,7 @@ docs = [
     { name = "mkdocs-material", specifier = ">=9.7.7" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.3" },
     { name = "pre-commit", specifier = ">=4.6.2" },
-    { name = "pymdown-extensions", specifier = ">=11.0.1" },
+    { name = "pymdown-extensions", specifier = ">=11.0.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
Étape 2 of working through the PR #167 follow-ups. Four mechanical fixes in one PR, same blast radius.

**Closes #171, #172, #175. Partially addresses #176.**

## #171 — the report's fact-pack card vanished with age

The one that actually bites users. A cached `*_enriched.json` stores the freshness it had **when written**; `FactPack` cross-checks that against `fetched_at` in a `model_validator`. So a file that merely crossed the 3- or 7-day boundary failed validation, the caller's `except` turned it into `rows = []`, and the whole fact-pack card was dropped from the report — silently, triggered by nothing but the clock.

`FactPackCache.get()` already re-derives freshness on load for exactly this reason. This path now does the same, and the card reports what Python derives rather than what was stored.

The existing test could never have caught it: its fixture used `datetime.now(UTC)` alongside `"fresh"`, so the two values could not disagree. The new test ages `fetched_at` by five days and leaves `"fresh"` in place, which is what a real file looks like after a weekend. It fails on `main` with `freshness='fresh' contradicts fetched_at=... (Python derived: 'recent')`.

## #175 — every thin fund shared one object

`_PLACEHOLDER_FUND` was a single module-level `FundFacts` handed to every fund whose builder returned `None`. Pydantic's default `revalidate_instances='never'` aliases rather than copies, so a single mutation would have rewritten history for every fund that ever fell back. Nothing mutates it today; nothing stopped it either.

`_FALLBACK_DETAILS` already held a factory per class for this purpose. Both fallback branches now use it, which also removes a duplicate crypto placeholder that had drifted from the table.

## #172 — dead prompt builder

`_build_prompt` had no production caller once the composer owned the prompt, and survived only on its own tests. Deleted with them. `_SYSTEM_FR` and `_today_french` stay — gap-fill and other modules still use them.

## #176 — tautology removed, second half left open on purpose

The crypto supply branch guarded on `supply_is_capped or max_supply is None`. `CryptoFacts._check_supply_cap_consistency` enforces `supply_is_capped == (max_supply is not None)`, which makes that `X or not X` — always true, scoring nothing and obscuring the intent. Removed; the three existing tests (capped, uncapped, unknown) pin the behaviour unchanged.

The issue's second half — `turnover`, `sector_weights`, `volume_24h_market_cap_pct`, collected but never scored and never rendered — is **deliberately not in this PR**. Surfacing them changes what the model reads, and scoring them would move every existing confidence value. That is a product decision, not this batch's mechanical cleanup, so #176 stays open with that half.

## Test plan

- Full default suite: **5405 passed, 31 skipped, 53 deselected, 0 failed.**
- #171 and #175 each got a test written first and confirmed failing against `main` before the fix.
- #176 deliberately got no new test: the simplification must be behaviour-preserving, and the three existing crypto-supply tests are the check that it is.
- `mypy` and `vulture` clean via pre-commit.

The first commit is unrelated lockfile churn (`uv` reorders `exclude-newer-package` alphabetically on every run); isolating it stops it conflicting with pre-commit's stash on every future commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtXz89ibcafk3p5LP5Ewms