### PR TITLE
test(integration): repair the four deselected failures

### DIFF
--- a/tests/integration/test_ai_output_validation.py
+++ b/tests/integration/test_ai_output_validation.py
@@ -414,11 +414,20 @@ class TestRealCrewExecutionWithValidation:
 
         from finwiz.schemas.hybrid_analysis.metadata import DataQualityMetrics
 
-        # Try to import and initialize crew - skip if there are issues
+        # StockCrew currently cannot be instantiated at all: agents.yaml,
+        # tasks.yaml and the @agent methods have diverged, so CrewAI raises
+        # KeyError: 'sec_analyst' while mapping task variables (see #187).
+        # KeyError was absent from the except tuple below, so this test FAILED
+        # rather than skipped -- and integration tests are deselected from the
+        # default run, so neither the failure nor the broken crew was visible.
+        # Skipping on that specific error keeps the signal attached to the issue
+        # instead of silently widening the tuple and hiding it again.
         try:
             from finwiz.crews.stock_crew.stock_crew import StockCrew
 
             crew = StockCrew()
+        except KeyError as e:
+            pytest.skip(f"StockCrew is broken, see #187: KeyError {e}")
         except (ImportError, TypeError, AttributeError) as e:
             pytest.skip(f"Cannot initialize StockCrew: {e}")
 

--- a/tests/integration/test_data_source_orchestrator.py
+++ b/tests/integration/test_data_source_orchestrator.py
@@ -250,17 +250,19 @@ class TestDataSourceOrchestratorIntegration:
         # Act
         result = await orchestrator.get_fundamental_data("AAPL", sector="Technology")
 
-        # Assert - YFinance should be attempted first
-        assert len(result.sources_attempted) > 0
-        # Most cases YFinance succeeds for AAPL, but verify it was attempted
-        assert "YFinance" in result.sources_attempted or "Industry Average" in result.sources_succeeded
+        # Assert the ordering this test is named for, not mere membership.
+        # The previous assertions named the sources "YFinance" and
+        # "Industry Average"; the orchestrator emits adapter.source_name
+        # ("yfinance") and the literal "IndustryAverages". Neither string could
+        # ever match, so the first assertion passed only via its `or` and the
+        # fallback branch below was unreachable.
+        assert result.sources_attempted, "no source was even attempted"
+        assert result.sources_attempted[0] == "yfinance", f"yfinance heads the waterfall, got {result.sources_attempted}"
 
-        # If fallback was used, verify Industry Average was last
-        if result.used_fallback and "Industry Average" in result.sources_succeeded:
-            # Industry Average should be last source tried
-            lineage_dict = result.lineage.to_dict()
-            industry_avg_count = sum(1 for v in lineage_dict.values() if v == "Industry Average")
-            assert industry_avg_count > 0, "Should have some fields from industry averages"
+        if result.used_fallback:
+            assert result.sources_attempted[-1] == "IndustryAverages", "industry averages are the last resort, not an earlier rung"
+            lineage = result.lineage.to_dict()
+            assert any(v == "IndustryAverages" for v in lineage.values()), "fallback claimed, but no field is attributed to it"
 
         print("\n✓ Waterfall strategy verified")
         print(f"  Attempt order: {result.sources_attempted}")

--- a/tests/integration/test_deep_analysis_crew_integration.py
+++ b/tests/integration/test_deep_analysis_crew_integration.py
@@ -16,30 +16,31 @@ import pytest
 class TestDeepAnalysisCrewIntegration:
     """Integration tests for DeepAnalysisCrew execution."""
 
-    def test_should_instantiate_crew_for_crypto_without_keyerror(self):
-        """
-        Test that DeepAnalysisCrew instantiates for crypto without KeyError.
+    def test_configured_agents_and_tasks_match_the_declared_methods(self):
+        """Config and code must agree in both directions -- the KeyError this file exists for.
 
-        This verifies the fix for the production bug where risk_assessor
-        was causing KeyError during crew instantiation.
+        The original bug was a ``risk_assessor`` method reading an agents.yaml key
+        that had been deleted: ``KeyError: 'risk_assessor'`` at instantiation. The
+        two tests replaced here pinned the roster of that moment by name
+        (asset_analyst + investment_reporter) rather than the agreement itself, so
+        they broke when ``investment_reporter`` was later removed for unrelated
+        reasons -- reporting a defect where there was none, and going unnoticed
+        because integration tests are deselected by default.
 
-        Requirements: 2.1
+        This asserts the invariant instead of the census: every configured key has
+        a decorated method, and every decorated method has a configured key. It
+        holds for a one-agent crew and would still hold for a five-agent one, while
+        failing the moment either side drifts from the other.
         """
         from finwiz.crews.deep_analysis.deep_analysis import DeepAnalysisCrew
 
-        # Should instantiate without KeyError
         crew = DeepAnalysisCrew()
 
-        # Verify crew was created successfully
-        assert crew is not None
-        assert hasattr(crew, "agents_config")
-        assert hasattr(crew, "tasks_config")
+        def declared(marker: str) -> set[str]:
+            return {name for name, value in type(crew).__dict__.items() if getattr(value, marker, False)}
 
-        # Verify exactly 2 agents
-        assert len(crew.agents_config) == 2
-        assert "asset_analyst" in crew.agents_config
-        assert "investment_reporter" in crew.agents_config
-        assert "risk_assessor" not in crew.agents_config
+        assert set(crew.agents_config) == declared("is_agent"), "agents.yaml and the @agent methods disagree"
+        assert set(crew.tasks_config) == declared("is_task"), "tasks.yaml and the @task methods disagree"
 
     @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY") and not os.getenv("ANTHROPIC_API_KEY"), reason="Requires API keys for crew execution")
     def test_should_execute_crew_for_btc_usd_without_error(self):
@@ -80,26 +81,6 @@ class TestDeepAnalysisCrewIntegration:
             # Otherwise, log the error but don't fail the test
             # (API errors, rate limits, etc. are not the focus of this test)
             print(f"Note: Crew execution encountered error (not KeyError): {e}")
-
-    def test_should_verify_agent_methods_exist(self):
-        """
-        Test that crew has the correct agent methods.
-
-        Verifies that only asset_analyst and investment_reporter methods exist,
-        confirming risk_assessor has been removed.
-
-        Requirements: 2.2
-        """
-        from finwiz.crews.deep_analysis.deep_analysis import DeepAnalysisCrew
-
-        crew = DeepAnalysisCrew()
-
-        # Verify required agent methods exist
-        assert hasattr(crew, "asset_analyst"), "Missing asset_analyst method"
-        assert hasattr(crew, "investment_reporter"), "Missing investment_reporter method"
-
-        # Verify risk_assessor method does NOT exist
-        assert not hasattr(crew, "risk_assessor"), "risk_assessor method still exists"
 
     def test_should_not_log_deprecation_warnings(self, caplog):
         """


### PR DESCRIPTION
Étape 3a of the PR #167 follow-ups. **Closes #178.** Opens #187.

The default run deselects integration tests (`-m "not integration"`), so these four had been red without anyone seeing them. Three were rot. The fourth was a real defect the rot was hiding.

## `test_deep_analysis_crew_integration` — 2 tests, rot

Both asserted a two-agent roster (`asset_analyst` + `investment_reporter`) that no longer exists; the crew has one agent. They were written to prove a `risk_assessor` `KeyError` had been fixed, but they pinned **the roster of that moment** rather than the property that mattered — so they broke when `investment_reporter` was later removed for entirely unrelated reasons, reporting a defect where there was none.

Replaced with one test asserting the invariant in both directions: every `agents.yaml` key has an `@agent` method, and every `@agent` method has a key. Same for tasks. It holds for a one-agent crew, would hold for a five-agent one, and fails the moment either side drifts from the other.

Bite-checked by re-adding a `risk_assessor` config key with no method — fails with `agents.yaml and the @agent methods disagree`. Restored after.

## `test_data_source_orchestrator` — rot, and worse than it looked

It asserted the source was named `"YFinance"` and the fallback `"Industry Average"`. The orchestrator emits `adapter.source_name` (`"yfinance"`) and the literal `"IndustryAverages"`. **Neither string could ever match**, so the first assertion passed only via its `or`, and the fallback branch beneath it was unreachable code.

Now asserts the ordering the test is actually named for: `yfinance` heads the waterfall, `IndustryAverages` is last when the fallback fires.

## `test_ai_output_validation` — not rot, a real defect

`StockCrew()` cannot be instantiated at all. `agents.yaml`, `tasks.yaml` and the `@agent` methods have diverged, so CrewAI raises `KeyError: 'sec_analyst'` while mapping task variables. Five of six tasks point at an agent with no method, and two of the three methods that *do* exist read `agents_config` keys absent from the YAML.

`KeyError` was missing from this test's `except (ImportError, TypeError, AttributeError)` tuple, so it **failed** rather than skipping — and being deselected by default, neither the failure nor the broken crew was visible to anyone.

Skipping on that specific error, pointed at **#187**, rather than quietly widening the tuple and hiding it a second time.

**Not a live outage:** `StockCrew` is instantiated only from `crew_factory.execute_stock_crew`, which has zero production callers (only its own unit tests, which mock it). Dead code that is also broken. #187 carries the delete-or-repair decision.

Checked the other six crews for the same drift — `crypto_crew` 6/6, `deep_analysis` 1/1, `etf_crew` 3/3, `investment_discovery_crew` 6/6, `portfolio_rebalancing_crew` 7/7, `report_crew` 4/4. `stock_crew` is the only one that diverges.

## A correction to #178's own text

That issue claimed `tests/validation/stock_crew_validation.py` "is never collected — whatever it asserts, it has been asserting nothing." **That was wrong of me.** The file's docstring says plainly it is a *"Manual validation runner for StockCrew (not a unit test)... intended to be executed as a script"*. The missing `test_` prefix is deliberate and correct. Its real problem is that it imports `StockCrew` at module level, so it is dead alongside it — noted on #187, no change made here.

## Test plan

- Integration suite: **51 passed, 1 skipped, 0 failed** (was 4 failed, 49 passed).
- Default suite: **5405 passed, 31 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtXz89ibcafk3p5LP5Ewms