### PR TITLE
docs: CLAUDE.md described a Phase 4 that does not exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ main.py → core/app_initializer.py → flows/orchestrator.py (FinwizFlow)
                                           │           2. calculate_quantitative() [Python scorer, $0]
                                           │           3. generate_qualitative()  [AI crew, ~$0.05]
                                           │           4. synthesize()           [Python, $0]
-                                          ├── Phase 4: Discovery (crypto/stock/etf crews)
+                                          ├── Phase 4: Discovery (Python scoring, $0 — NOT the crews)
                                           ├── Phase 5: Alternative Matching
                                           └── Phase 6: Reporting (ReportingOrchestrator)
 ```
@@ -71,7 +71,7 @@ main.py → core/app_initializer.py → flows/orchestrator.py (FinwizFlow)
 |-----------|----------|------|
 | Main flow | `flows/orchestrator.py` → `FinwizFlow(Flow[FinwizState])` | Coordinates all phases via orchestrator delegation |
 | Flow state | `flow_state.py` → `FinwizState` (Pydantic) | Type-safe state shared across flow phases |
-| Crew factory | `crew_factory.py` → `CrewFactory` | Creates crews with error handling and fallback |
+| Crew factory | `crew_factory.py` → `CrewFactory` | Constructed at flow startup, then **never called** — every `execute_*_crew` method has zero callers (see #187) |
 | Analysis pipeline | `analysis/deep_analysis_pipeline.py` | Functional pipeline: Python scoring + AI insights |
 | Scoring engine | `scoring/deep_analysis_scorer.py` → `DeepAnalysisScorer` | Composite: 40% fundamental, 30% technical, 30% risk |
 | Tool factories | `tools/tool_factories.py` | `get_stock_crew_tools()`, `get_etf_crew_tools()`, etc. |
@@ -80,7 +80,9 @@ main.py → core/app_initializer.py → flows/orchestrator.py (FinwizFlow)
 
 ### Crew Pattern
 
-Each crew lives in `crews/<name>/` with `config/agents.yaml`, `config/tasks.yaml`, and a crew class using `@CrewBase`. Crews are: `stock_crew`, `etf_crew`, `crypto_crew`, `deep_analysis`, `investment_discovery_crew`, `portfolio_rebalancing_crew`, `report_crew`.
+Each crew lives in `crews/<name>/` with `config/agents.yaml`, `config/tasks.yaml`, and a crew class using `@CrewBase`.
+
+**Only `deep_analysis` runs.** It is reached from `analysis/_helpers.py`, not through `CrewFactory`. The other six — `stock_crew`, `etf_crew`, `crypto_crew`, `investment_discovery_crew`, `portfolio_rebalancing_crew`, `report_crew` — exist on disk and are wired into `CrewFactory`, but nothing calls the methods that would run them. No `*_export.json` has ever been produced. `stock_crew` has rotted far enough that it can no longer be instantiated at all. Their fate is tracked in #187; until it is settled, treat them as inert rather than as examples to follow.
 
 ### Orchestrator Delegation
 


### PR DESCRIPTION
Found while investigating #187. Three claims in `CLAUDE.md` are false, and the first is how the rest stayed hidden.

| Claim | Reality |
|---|---|
| `Phase 4: Discovery (crypto/stock/etf crews)` | `discovery_orchestrator.py` logs *"Using Python analysis"* for all three asset classes and holds **no crew reference at all** |
| `CrewFactory` — *"Creates crews with error handling and fallback"* | Constructed at `flows/orchestrator.py:107`, logs *"Crew factory initialized"*, then **never called**: all six `execute_*_crew` have zero callers, as do both `create_crew_inputs_for_*` helpers |
| Seven crews listed as equals | Only `deep_analysis` runs, reached from `analysis/_helpers.py`, not through `CrewFactory` |

The other six crews are inert. **No `*_export.json` has ever been produced** anywhere in `output/`. `stock_crew` has rotted far enough that it can no longer be instantiated — `agents.yaml`, `tasks.yaml` and the `@agent` methods have diverged (#187).

The story reconstructs itself: discovery moved to Python scoring — which is the repo's own **AI Minimalism** rule applied correctly — but nothing was deleted and the doc was never corrected.

Documenting inert code as live is worse than leaving it undocumented: it invites the next person to copy the pattern, and it is exactly why #187 read as *one broken crew* rather than *a subsystem with no caller*.

**The deletion decision is deliberately not taken here.** That is being specced separately — roughly 2,500 lines of crews plus the export chain, report generators, feature flags, and the consolidator / html_collector / validation-orchestrator branches that read state nothing sets. This PR only stops the documentation asserting a flow that does not run.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtXz89ibcafk3p5LP5Ewms