### PR TITLE
fix: refuse an unrecognised asset_class instead of pricing the wrong instrument (#177)

### DIFF
--- a/src/finwiz/analysis/fact_pack/composer.py
+++ b/src/finwiz/analysis/fact_pack/composer.py
@@ -131,22 +131,37 @@ def _clamp_citations(ticker: str, citations: tuple[str, ...]) -> list[str]:
 def compose_fact_pack(ticker: str, company_name: str, sector: str | None, industry: str | None, asset_class: str) -> FactPack | None:
     """Build a pack from free structured sources.
 
-    Returns None ONLY when the ticker resolves to nothing. Every other outcome is
-    a pack, however thin -- one provider must never be able to halt a holding,
-    which is exactly what happened on 2026-09-06 when a quota error took all 64.
+    Returns None when the ticker resolves to nothing, and when asset_class is not
+    one of the three enumerated values. Every other outcome is a pack, however thin
+    -- one provider must never be able to halt a holding, which is exactly what
+    happened on 2026-09-06 when a quota error took all 64.
     """
-    # Normalise here, once, so every downstream use -- routing, the main
-    # FactPack construction, the exception backstop, the Literal cast, and
-    # the asset_class/details.kind pairing validator -- only ever sees one of
-    # the three enumerated classes. An unrecognised value used to reach the
-    # backstop's _FALLBACK_DETAILS[asset_class] lookup unnormalised and raise
-    # KeyError from inside the one code path whose entire purpose is that a
-    # holding never dies. Falling back to "stock" preserves the behaviour
-    # routing's `else` branch already gave an unknown class; this just says
-    # so in a log line instead of doing it silently.
+    # Refuse an unrecognised asset_class rather than guessing one.
+    #
+    # This used to normalise to "stock", which kept the backstop's
+    # _FALLBACK_DETAILS[asset_class] lookup from raising KeyError but bought that
+    # safety with a wrong answer: to_yfinance_symbol only appends the "-USD" quote
+    # suffix for crypto, so a coin routed as equity is queried bare, and yfinance's
+    # bare BTC is the Grayscale trust -- a real, tradeable, *different* instrument
+    # whose numbers look entirely plausible in a report.
+    #
+    # The quoteType cross-check below cannot catch it. It compares yfinance's
+    # answer against the *declared* class, and the declared class is the guess:
+    # guess "stock", fetch the trust, get quoteType EQUITY, match. The guard is
+    # silent exactly when the guess is wrong in the way that matters.
+    #
+    # Returning None here reaches the same KeyError-free outcome by never letting
+    # an unknown class reach _FALLBACK_DETAILS at all. The holding's fact_pack
+    # stage then fails and the run gate's fact_pack.missing check surfaces it --
+    # machinery that already exists, unlike any means of surfacing "this pack may
+    # describe a different asset". See #177.
     if asset_class not in _FALLBACK_DETAILS:
-        logger.warning(f"fact_pack: {ticker} has unknown asset_class={asset_class!r}; routing as 'stock'")
-        asset_class = "stock"
+        logger.error(
+            f"fact_pack: {ticker} has unrecognised asset_class={asset_class!r} "
+            f"(expected one of {sorted(_FALLBACK_DETAILS)}); refusing to guess a "
+            f"routing, because a wrong guess silently prices a different instrument"
+        )
+        return None
 
     # Domain-model tickers stay bare (BTC, AAVE); yfinance needs the query form
     # (BTC-USD). Without this, yfinance's own `BTC` resolves to a Grayscale

--- a/src/finwiz/orchestrators/deep_analysis_orchestrator.py
+++ b/src/finwiz/orchestrators/deep_analysis_orchestrator.py
@@ -26,6 +26,7 @@ from finwiz.analysis.stages._ledger import RunLedger
 from finwiz.flow_state import DeepAnalysisResult, FinwizState
 from finwiz.infrastructure.resilience.crew_execution import CREW_TIMEOUT
 from finwiz.orchestrators.deep_analysis_data_collector import DeepAnalysisDataCollector
+from finwiz.schemas.common import AssetClass
 from finwiz.tools.logger import get_logger
 
 logger = get_logger(__name__)
@@ -70,6 +71,23 @@ def _analyze_single_sync(
 
     if not ticker or not asset_class:
         return (ticker or "unknown", None, None)
+
+    # Validate the class at the boundary, where a human can act on it. It arrives
+    # as a bare dict value off the portfolio CSV and used to be checked only for
+    # truthiness, so any string -- "bond", "commodity", a typo -- travelled as a
+    # plain str the whole way down; AssetClass never got a say. Deep in the fact
+    # pack composer that produced a guess, and a wrong guess prices a different
+    # instrument (see #177). A synthetic pending rather than (ticker, None, None):
+    # the renderer shows the reason, so the CSV row can be fixed, instead of the
+    # holding quietly vanishing behind a generic placeholder.
+    if asset_class not in {c.value for c in AssetClass}:
+        logger.error(f"Holding {ticker} has unrecognised asset_class={asset_class!r}; expected one of {[c.value for c in AssetClass]}")
+        pending = make_synthetic_pending(
+            ticker=ticker,
+            asset_class=asset_class,
+            rationale=f"Classe d'actif inconnue : {asset_class!r} — corriger le CSV du portefeuille",
+        )
+        return (ticker, pending, None)
 
     try:
         result, enriched = analyze_holding(

--- a/tests/unit/analysis/fact_pack/test_composer.py
+++ b/tests/unit/analysis/fact_pack/test_composer.py
@@ -56,6 +56,28 @@ class TestUnresolvable:
         mocker.patch.object(composer.yfinance_source, "resolve", return_value={"trailingPegRatio": None})
         assert composer.compose_fact_pack("ZZZZNOTREAL", "Nothing", None, None, "stock") is None
 
+    def test_an_unrecognised_asset_class_returns_none_without_resolving(self, mocker, caplog):
+        """An unknown class used to be normalised to "stock" and routed anyway.
+
+        That is how a coin gets priced as an equity: to_yfinance_symbol only
+        appends "-USD" for crypto, so a bare BTC reaches yfinance, where it is
+        the Grayscale trust -- a different, tradeable instrument whose numbers
+        look plausible in a report. The quoteType cross-check cannot catch it,
+        because it compares against the guessed class and EQUITY matches "stock".
+
+        Asserts the strong version: nothing is resolved at all, so no wrong
+        instrument can be fetched. See #177.
+        """
+        resolve = mocker.patch.object(composer.yfinance_source, "resolve")
+
+        with caplog.at_level("ERROR"):
+            pack = composer.compose_fact_pack("BTC", "Bitcoin", None, None, "digital_asset")
+
+        assert pack is None
+        resolve.assert_not_called()
+        assert "digital_asset" in caplog.text
+        assert "refusing to guess" in caplog.text
+
 
 class TestPackConstruction:
     def test_filings_outrank_news_for_recent_events(self, mocker):
@@ -311,28 +333,35 @@ class TestPerClassComposition:
 
 
 class TestUnknownAssetClass:
-    """An unenumerated asset_class must degrade to a labelled 'stock' pack, never kill the holding.
+    """An unenumerated asset_class must halt the pack, never be guessed at.
 
-    Before the entry-point normalisation, an unknown value reached the
-    backstop's _FALLBACK_DETAILS[asset_class] lookup unnormalised: the main
-    FactPack(...) call correctly rejected it (Literal validation), the except
-    caught that, and then the fallback line raised KeyError -- uncaught,
-    inside the one code path whose entire purpose is that a holding never
-    dies.
+    This class previously asserted the opposite -- that an unknown value
+    degraded to a labelled "stock" pack -- which was the right call for the
+    problem then in view (the backstop's _FALLBACK_DETAILS[asset_class] lookup
+    raised KeyError from inside the one code path whose purpose is that a
+    holding never dies) and the wrong call for the problem behind it.
+
+    Degrading to "stock" is not a neutral default. to_yfinance_symbol appends
+    the "-USD" quote suffix only for crypto, so a coin routed as equity is
+    queried bare -- and yfinance's bare BTC is the Grayscale trust, a real and
+    tradeable *different* asset. The pack would be complete, plausible, and
+    about the wrong instrument.
+
+    Refusing reaches the same KeyError-free outcome by never letting an unknown
+    class reach the backstop, and leaves the holding's missing pack visible to
+    the run gate's fact_pack.missing check. See #177.
     """
 
-    def test_an_unknown_asset_class_degrades_to_stock_with_a_warning(self, mocker, caplog):
+    def test_an_unknown_asset_class_returns_none_rather_than_guessing_stock(self, mocker, caplog):
         mocker.patch.object(composer.yfinance_source, "resolve", return_value={"quoteType": "EQUITY", "longBusinessSummary": "Designs phones."})
         mocker.patch.object(composer.yfinance_source, "filing_events", return_value=FactPackFragment())
         mocker.patch.object(composer.yfinance_source, "news_events", return_value=FactPackFragment())
 
-        with caplog.at_level("WARNING"):
+        with caplog.at_level("ERROR"):
             pack = composer.compose_fact_pack("AAPL", "Apple Inc.", None, None, "bond")
 
-        assert pack is not None
-        assert pack.asset_class == "stock"
-        assert pack.details.kind == "equity"
-        assert any("unknown asset_class='bond'" in r.message for r in caplog.records)
+        assert pack is None
+        assert any("asset_class='bond'" in r.message for r in caplog.records)
 
     @pytest.mark.parametrize("asset_class", ["stock", "etf", "crypto"])
     def test_the_backstop_still_returns_a_valid_pack_for_each_real_class(self, mocker, asset_class):

--- a/tests/unit/orchestrators/test_deep_analysis_orchestrator.py
+++ b/tests/unit/orchestrators/test_deep_analysis_orchestrator.py
@@ -277,6 +277,37 @@ class TestDeepAnalysisOrchestrator:
         assert pending.recommendation == "WAIT"
         assert "crew dépassé 900s" in pending.rationale
 
+    def test_unrecognised_asset_class_never_reaches_analysis(self, mocker):
+        """asset_class arrives as a bare dict value off the portfolio CSV.
+
+        It used to be checked only for truthiness, so any string travelled as a
+        plain str the whole way down and AssetClass never got a say. Deep in the
+        fact pack composer that became a guess, and a guessed class prices a
+        different instrument -- a coin routed as equity is queried without the
+        "-USD" suffix, and bare BTC is the Grayscale trust. See #177.
+
+        Asserts the strong version: analyze_holding is never called, so no
+        network work happens on a holding whose class we cannot trust.
+        """
+        from finwiz.orchestrators.deep_analysis_orchestrator import _analyze_single_sync
+
+        analyze = mocker.patch("finwiz.analysis.analyze_holding")
+
+        ticker, result, enriched = _analyze_single_sync(
+            {"ticker": "BTC", "asset_class": "digital_asset", "name": "Bitcoin"},
+            prefetched_data=None,
+            ledger=mocker.MagicMock(),
+            logger=mocker.MagicMock(),
+            make_synthetic_pending=DeepAnalysisOrchestrator._make_synthetic_pending,
+        )
+
+        analyze.assert_not_called()
+        assert ticker == "BTC"
+        assert enriched is None
+        assert result is not None, "the holding must stay visible, not vanish"
+        assert result.grade == "N/A"
+        assert "digital_asset" in result.rationale
+
     @pytest.mark.integration
     def test_should_skip_invalid_holdings(self, mocker, orchestrator, mock_deep_analysis_result, mock_enriched_analysis):
         """Test that holdings without ticker or asset_class are skipped."""


### PR DESCRIPTION
Closes #177.

A holding whose `asset_class` the pipeline did not recognise was routed as `"stock"` and priced as an equity. For a crypto ticker that means fetching a real, tradeable, *different* instrument and reporting its numbers as the holding's.

## The bug

`composer.py` normalised an unrecognised `asset_class` to `"stock"` with a warning. The normalisation was a correct fix for the problem then in view — an unknown value reached the exception backstop's `_FALLBACK_DETAILS[asset_class]` lookup and raised `KeyError` from inside the one code path whose entire purpose is that a holding never dies.

But `"stock"` is not a neutral default. `to_yfinance_symbol` appends the `-USD` quote suffix **only** for crypto, so a coin routed as equity is queried bare — and yfinance's bare `BTC` is the Grayscale Bitcoin Trust. The resulting pack is complete, internally consistent, plausible in a report, and about the wrong asset.

## Why the existing guard could not catch it

`composer.py` already cross-checks yfinance's `quoteType` against the declared class. It cannot help here, because the declared class *is* the guess:

| step | value |
|---|---|
| declared | `"digital_asset"` → guessed `"stock"` |
| queried | `BTC` (no `-USD`, because the guess said equity) |
| yfinance returns | Grayscale trust, `quoteType: EQUITY` |
| expected for `"stock"` | `EQUITY` |
| result | **match — no warning** |

The guard is silent exactly when the guess is wrong in the way that matters. That is what made this worth fixing rather than logging harder.

## The fix, in two places

**1. The composer refuses rather than guesses.** It now returns `None` before resolving anything, so no symbol whose class was guessed is ever fetched. This reaches the same `KeyError`-free outcome as the old normalisation by never letting an unknown class reach `_FALLBACK_DETAILS` at all.

The holding's `fact_pack` stage then fails and the run gate's `fact_pack.missing` check surfaces it. That machinery already exists; machinery to surface "this pack may describe a different asset" does not — which is why refusing beats marking the pack and letting it flow into scoring behind a flag.

**2. The class is validated at the boundary, so the guess is unreachable.** `asset_class` arrived at `_analyze_single_sync` as a bare dict value off the portfolio CSV (`holding.get("asset_class")`), checked only for truthiness, and travelled as a plain `str` the whole way down. `AssetClass` never got a say — any string, including a typo, reached the composer. It is now validated where a human can act on it.

An unrecognised value produces a synthetic pending naming the bad class rather than `(ticker, None, None)`, so the renderer shows *"Classe d'actif inconnue : 'x' — corriger le CSV du portefeuille"* instead of the holding vanishing behind a generic placeholder. This mirrors how the existing exception path already handles failures.

## Tests

Two, both asserting the strong version — that nothing is fetched, not merely that the output is right:

- `test_an_unrecognised_asset_class_returns_none_without_resolving` — `resolve.assert_not_called()`, so no wrong instrument can be queried.
- `test_unrecognised_asset_class_never_reaches_analysis` — `analyze_holding.assert_not_called()`, and the holding still appears in the results with the reason visible.

**One existing test was replaced, not deleted.** `test_an_unknown_asset_class_degrades_to_stock_with_a_warning` asserted the old behaviour — it was locking in the bug. Its replacement keeps the class docstring's history and records why the earlier call was right about the crash and wrong about what came after it.

## Verification

- `make test` — 4,587 passed, 31 skipped. Net +2 (three new tests, one replaced).
- `make lint` — clean.

## Note

The `_EXPECTED_QUOTE_TYPES` cross-check is left as it is. It still catches a *declared* class that contradicts yfinance — a genuinely mislabelled CSV row where the label is one of the three valid values — which is a different and still-useful signal. It just cannot be the guard for this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtXz89ibcafk3p5LP5Ewms
