### PR TITLE
fix: name fact-pack sources for the reader, and stop rendering a diagnostic as provenance (#174)

### DIFF
--- a/src/finwiz/reporting/sections/factpack.py
+++ b/src/finwiz/reporting/sections/factpack.py
@@ -77,17 +77,51 @@ def _fact_pack_body(fact_pack: FactPack) -> str:
     return f'<div class="small muted fact-pack-body">{" · ".join(parts)}</div>'
 
 
-def _sources_label(fact_pack: FactPack) -> str:
-    """Truthful, short label for the pill's provenance claim.
+# Reader-facing names for the internal source identifiers in FactPack.sources_used.
+# The tooltip reads "Vérifié via {label}", so these are prose, not keys: a reader
+# seeing "yfinance.funds_data" in a financial report reads it as leaked debug output.
+#
+# Both yfinance.info and yfinance.funds_data map to the same name on purpose — the
+# source really is Yahoo Finance either way, and the endpoint split is our concern,
+# not the reader's. _sources_label de-duplicates, so a fund pack drawing on both
+# says "Yahoo Finance" once.
+#
+# composer.schema_fallback is deliberately absent. It marks a pack the exception
+# backstop assembled: a diagnostic about how the pack was built, not a place any
+# fact came from. Rendering it as provenance told the reader the pack was
+# "verified via composer.schema_fallback", which is both meaningless and false.
+_SOURCE_LABELS: dict[str, str] = {
+    "yfinance.info": "Yahoo Finance",
+    "yfinance.funds_data": "Yahoo Finance",
+    "yfinance.sec_filings": "dépôts SEC",
+    "yfinance.news": "presse financière",
+    "perplexity.gap_fill": "Perplexity",
+    "etf_expense_ratios.yaml": "table de frais interne",
+}
 
-    Names the pack's real ``sources_used`` (e.g. "yfinance.info") when known;
-    falls back to a generic phrase rather than naming a source that may not
-    have run. Packs are built from yfinance and a curated table, with
-    Perplexity demoted to an optional gap-filler that may never fire — the
-    pill must not claim Perplexity verification unconditionally.
+
+def _sources_label(fact_pack: FactPack) -> str:
+    """Truthful, reader-facing label for the pill's provenance claim.
+
+    Translates the pack's ``sources_used`` identifiers into names a reader can
+    act on, de-duplicated and in first-seen order, and falls back to a generic
+    phrase rather than naming a source that may not have run. Packs are built
+    from yfinance and a curated table, with Perplexity demoted to an optional
+    gap-filler that may never fire — the pill must not claim Perplexity
+    verification unconditionally.
+
+    An identifier with no entry in ``_SOURCE_LABELS`` is omitted rather than
+    printed raw, so adding a source without adding its label degrades to the
+    generic phrase instead of leaking an internal name into a report. If you add
+    a source, add it above.
     """
-    if fact_pack.sources_used:
-        return ", ".join(fact_pack.sources_used)
+    seen: list[str] = []
+    for identifier in fact_pack.sources_used:
+        label = _SOURCE_LABELS.get(identifier)
+        if label is not None and label not in seen:
+            seen.append(label)
+    if seen:
+        return ", ".join(seen)
     return "sources structurées"
 
 

--- a/tests/unit/reporting/test_fact_pack_rendering.py
+++ b/tests/unit/reporting/test_fact_pack_rendering.py
@@ -8,7 +8,7 @@ from finwiz.reporting.section_generators import _fact_pack_provenance_footer
 from finwiz.schemas.hybrid_analysis.fact_pack import EquityFacts, FactPack
 
 
-def _build_fp(days_old: float = 0, citations: list[str] | None = None) -> FactPack:
+def _build_fp(days_old: float = 0, citations: list[str] | None = None, sources_used: list[str] | None = None) -> FactPack:
     fetched = datetime.now(UTC) - timedelta(days=days_old)
     return FactPack(
         asset_class="stock",
@@ -17,7 +17,50 @@ def _build_fp(days_old: float = 0, citations: list[str] | None = None) -> FactPa
         freshness=FactPack.derive_freshness(fetched),
         confidence=0.85,
         source_citations=citations or [],
+        sources_used=sources_used or [],
     )
+
+
+class TestSourcesLabel:
+    """The pill tooltip reads "Vérifié via {label}" — it is prose for a reader.
+
+    sources_used holds internal identifiers. Rendering them raw put strings like
+    "yfinance.funds_data" into a financial report, and put
+    "composer.schema_fallback" there as if the exception backstop were a place
+    facts came from. See #174.
+    """
+
+    def test_internal_identifiers_are_not_shown_to_the_reader(self) -> None:
+        html = _fact_pack_provenance_footer(_build_fp(sources_used=["yfinance.info", "yfinance.sec_filings"]))
+        assert "Yahoo Finance" in html
+        assert "dépôts SEC" in html
+        assert "yfinance" not in html
+
+    def test_the_schema_fallback_marker_is_not_rendered_as_provenance(self) -> None:
+        """It marks a pack the exception backstop assembled — a diagnostic, not a source."""
+        html = _fact_pack_provenance_footer(_build_fp(sources_used=["yfinance.info", "composer.schema_fallback"]))
+        assert "Yahoo Finance" in html
+        assert "schema_fallback" not in html
+        assert "composer" not in html
+
+    def test_a_pack_built_only_by_the_backstop_falls_back_to_the_generic_phrase(self) -> None:
+        """Dropping the diagnostic must not leave an empty "Vérifié via" claim."""
+        html = _fact_pack_provenance_footer(_build_fp(sources_used=["composer.schema_fallback"]))
+        assert "sources structurées" in html
+        assert "schema_fallback" not in html
+
+    def test_the_same_provider_is_named_once(self) -> None:
+        """A fund pack draws on yfinance.info and yfinance.funds_data; the reader
+        should see "Yahoo Finance", not it twice."""
+        label = _fact_pack_provenance_footer(_build_fp(sources_used=["yfinance.info", "yfinance.funds_data"]))
+        assert label.count("Yahoo Finance") == 1
+
+    def test_an_unlabelled_identifier_is_omitted_rather_than_leaked(self) -> None:
+        """Adding a source without adding its label degrades to the generic
+        phrase; it must never print the raw identifier into a report."""
+        html = _fact_pack_provenance_footer(_build_fp(sources_used=["some.new_source_nobody_labelled"]))
+        assert "some.new_source" not in html
+        assert "sources structurées" in html
 
 
 class TestProvenanceFooter:


### PR DESCRIPTION
Closes #174.

The fact-pack provenance pill's tooltip reads *"Vérifié via {label}"*, and the label was `FactPack.sources_used` joined raw.

## Two problems, one line

**Internal identifiers reached the reader.** `yfinance.funds_data`, `etf_expense_ratios.yaml` — module and filename strings, in a financial report, reading as leaked debug output.

**`composer.schema_fallback` was rendered as a source.** That marker means the exception backstop assembled the pack. It is a diagnostic about *how the pack was built*, not a place any fact came from. The report was telling readers their facts were "verified via composer.schema_fallback" — meaningless and false at the same time.

## The fix

Identifiers are translated to reader-facing names, de-duplicated in first-seen order:

| identifier | shown as |
|---|---|
| `yfinance.info` | Yahoo Finance |
| `yfinance.funds_data` | Yahoo Finance |
| `yfinance.sec_filings` | dépôts SEC |
| `yfinance.news` | presse financière |
| `perplexity.gap_fill` | Perplexity |
| `etf_expense_ratios.yaml` | table de frais interne |
| `composer.schema_fallback` | *(dropped)* |

Two deliberate choices:

- **`yfinance.info` and `yfinance.funds_data` share a name.** The source really is Yahoo Finance either way; which endpoint we called is our concern, not the reader's. De-duplication means a fund pack drawing on both says "Yahoo Finance" once rather than twice.
- **An unlabelled identifier is omitted, not printed raw.** Adding a source and forgetting to add its label degrades to the existing generic phrase ("sources structurées") instead of leaking a new internal name into a report. A test holds that line, and the docstring says to add the label when you add a source.

A pack the backstop built alone now falls back to the generic phrase rather than leaving an empty *"Vérifié via"* claim.

## Tests

Five, in a new `TestSourcesLabel` class:

- internal identifiers are not shown to the reader (asserts `"yfinance" not in html`)
- the schema-fallback marker is not rendered as provenance
- a pack built only by the backstop falls back to the generic phrase — dropping the diagnostic must not produce an empty claim
- the same provider is named once
- an unlabelled identifier is omitted rather than leaked

The shared `_build_fp` helper gained a `sources_used` parameter; it previously always defaulted to empty, which is why the raw-identifier path had no coverage.

## Verification

- `make test` — 4,592 passed, 31 skipped (+5).
- `make lint` — clean.

## Note

This changes only the tooltip. `sources_used` itself is unchanged — `composer.schema_fallback` still travels in the data, where it belongs as a diagnostic, and remains available to anything that wants to know a pack came from the backstop. What changes is that it is no longer presented to a reader as provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtXz89ibcafk3p5LP5Ewms
