### PR TITLE
fix: screen news headlines for relevance, not just for provider (#169)

### DIFF
--- a/src/finwiz/analysis/fact_pack/composer.py
+++ b/src/finwiz/analysis/fact_pack/composer.py
@@ -80,7 +80,7 @@ def _equity_details(
     fragment = merge_fragments(
         yfinance_source.equity_fragment(query_symbol, info),
         yfinance_source.filing_events(query_symbol),
-        yfinance_source.news_events(query_symbol),
+        yfinance_source.news_events(query_symbol, company_name),
     )
     recent_events = fragment.recent_events
     events_from_filings = fragment.events_from_filings

--- a/src/finwiz/analysis/fact_pack/sources/yfinance_source.py
+++ b/src/finwiz/analysis/fact_pack/sources/yfinance_source.py
@@ -8,6 +8,7 @@ instead of raising: a shape change must cost one field, never a holding.
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, date, datetime
 from typing import Any
 
@@ -21,6 +22,144 @@ logger = get_logger(__name__)
 
 _MAX_OFFICERS = 6
 _SOURCES = ("yfinance.info",)
+
+# Legal-form suffixes stripped before matching a company name against a headline.
+# "Mercedes-Benz Group AG" must match a headline saying "Mercedes-Benz"; leaving
+# the suffix on would require the wire to spell the legal entity, which it never does.
+_LEGAL_SUFFIXES = frozenset(
+    {
+        "ag",
+        "sa",
+        "sas",
+        "nv",
+        "bv",
+        "plc",
+        "inc",
+        "inc.",
+        "corp",
+        "corp.",
+        "co",
+        "co.",
+        "ltd",
+        "ltd.",
+        "llc",
+        "spa",
+        "se",
+        "oyj",
+        "ab",
+        "as",
+        "asa",
+        "holding",
+        "holdings",
+        "group",
+        "the",
+        "company",
+    }
+)
+
+# A token shorter than this is too generic to establish that a headline is about
+# the holding -- "EL" (EssilorLuxottica) matches "EL NINO", and a two-letter root
+# matches something in almost any sentence. Such a holding can still qualify
+# through the keyword arm; it just cannot qualify on its name alone.
+_MIN_NAME_TOKEN_CHARS = 4
+_MIN_TICKER_ROOT_CHARS = 3
+
+# Words that make a headline a corporate event regardless of whether it names the
+# company: a wire writing "Q3 profit beats estimates" under a ticker is reporting on
+# that ticker. Deliberately narrow -- every entry here is a hole through which
+# syndicated noise can pass, so only unambiguous corporate-finance vocabulary
+# qualifies. Anything arguable (an "outlook", a "report", a "deal") is left out.
+_CORPORATE_EVENT_KEYWORDS = frozenset(
+    {
+        "earnings",
+        "revenue",
+        "profit",
+        "profits",
+        "loss",
+        "losses",
+        "dividend",
+        "buyback",
+        "guidance",
+        "forecast",
+        "merger",
+        "acquisition",
+        "acquires",
+        "acquire",
+        "takeover",
+        "divest",
+        "divests",
+        "spinoff",
+        "ipo",
+        "bankruptcy",
+        "restructuring",
+        "layoffs",
+        "recall",
+        "lawsuit",
+        "settlement",
+        "probe",
+        "downgrade",
+        "downgrades",
+        "upgrade",
+        "upgrades",
+        "ceo",
+        "cfo",
+        "chairman",
+        "quarterly",
+        "shareholders",
+        "shares",
+        "stake",
+    }
+)
+
+
+def _name_tokens(company_name: str) -> set[str]:
+    """Distinctive lowercase tokens of a company name, legal forms removed."""
+    raw = "".join(ch if ch.isalnum() or ch in "-&" else " " for ch in company_name.lower())
+    return {tok for tok in raw.split() if len(tok) >= _MIN_NAME_TOKEN_CHARS and tok not in _LEGAL_SUFFIXES}
+
+
+def _ticker_root(symbol: str) -> str:
+    """The symbol without its exchange or quote suffix: MCHA.F -> MCHA, BTC-USD -> BTC."""
+    return symbol.split(".")[0].split("-")[0].strip().lower()
+
+
+def _is_relevant_headline(title: str, ticker: str, company_name: str) -> bool:
+    """Is this headline plausibly about the holding, rather than syndicated noise?
+
+    Yahoo's ticker stream is loosely associated: a live run surfaced
+    "2026-08-09 This City May Be the South's Most Underrated Getaway" as MCHA.F's
+    only recent_event, which then reached the qualitative prompt inside the block
+    it labels AUTORITAIRE. The provider allowlist screens *who published*, never
+    *what about* -- a reputable wire syndicates travel copy under a ticker just as
+    readily. See #169.
+
+    Two independent ways to qualify, because either alone is wrong:
+
+    - The headline names the holding (ticker root or a distinctive name token).
+      Catches company-specific news whatever it is about.
+    - The headline carries unambiguous corporate-event vocabulary. Catches the
+      wire style that omits the name it is already filed under -- "Q3 profit beats
+      estimates" -- which a name-only gate would discard.
+
+    Neither is sufficient alone: name-only drops real events, keyword-only lets
+    through any syndicated piece that happens to use a financial word. Requiring
+    both would be stricter than the evidence justifies.
+    """
+    haystack = title.lower()
+
+    # Match at a word start, not anywhere: a bare substring test let "el"
+    # (EssilorLuxottica) match "EL NINO", and would equally match "shell" or
+    # "held". Prefix-at-word-start still catches the common case where a wire
+    # writes the name and the ticker is its stem -- AIR.PA against "Airbus".
+    root = _ticker_root(ticker)
+    candidates = _name_tokens(company_name)
+    if len(root) >= _MIN_TICKER_ROOT_CHARS:
+        candidates = candidates | {root}
+    if any(re.search(rf"\b{re.escape(token)}", haystack) for token in candidates):
+        return True
+
+    words = {"".join(ch for ch in w if ch.isalnum()) for w in haystack.split()}
+    return bool(words & _CORPORATE_EVENT_KEYWORDS)
 
 
 def _ticker(symbol: str) -> Any:
@@ -140,8 +279,13 @@ def _extract_filing_event(filing: Any, now: datetime) -> tuple[str | None, str |
     return event, url
 
 
-def _extract_news_event(item: Any, now: datetime) -> tuple[str | None, str | None]:
-    """Extract a news event and URL from a raw item, or return (None, None)."""
+def _extract_news_event(item: Any, now: datetime, ticker: str = "", company_name: str = "") -> tuple[str | None, str | None]:
+    """Extract a news event and URL from a raw item, or return (None, None).
+
+    Screens relevance as well as provider: see _is_relevant_headline. The ticker
+    and company_name default to empty so an unrelated caller still gets the old
+    provider/date/title behaviour, but the live path always passes both.
+    """
     if not isinstance(item, dict):
         return None, None
     content = item.get("content") or {}
@@ -157,6 +301,9 @@ def _extract_news_event(item: Any, now: datetime) -> tuple[str | None, str | Non
         return None, None
     title = _safe_str(content.get("title"))
     if not title:
+        return None, None
+    if (ticker or company_name) and not _is_relevant_headline(title, ticker, company_name):
+        logger.debug(f"fact_pack: {ticker} dropped an off-topic headline: {title!r}")
         return None, None
     event = f"{published.date().isoformat()} {title}"[:_EVENT_MAX_CHARS]
     url = (content.get("canonicalUrl") or {}).get("url")
@@ -207,8 +354,13 @@ def filing_events(ticker: str, now: datetime | None = None) -> FactPackFragment:
         return FactPackFragment()
 
 
-def news_events(ticker: str, now: datetime | None = None) -> FactPackFragment:
-    """Wire-service headlines in the last 12 months. Weaker than filings, still cited."""
+def news_events(ticker: str, company_name: str = "", now: datetime | None = None) -> FactPackFragment:
+    """Wire-service headlines in the last 12 months. Weaker than filings, still cited.
+
+    Headlines are screened for relevance to the holding, not merely for a
+    reputable provider -- Yahoo's ticker stream syndicates unrelated copy under a
+    symbol, and a thin pack is exactly where one bogus "fact" carries most weight.
+    """
     now = now or datetime.now(UTC)
     try:
         items = _ticker(ticker).news or []
@@ -221,7 +373,7 @@ def news_events(ticker: str, now: datetime | None = None) -> FactPackFragment:
             # must cost that item, not every good headline and citation
             # gathered before it.
             try:
-                event, url = _extract_news_event(item, now)
+                event, url = _extract_news_event(item, now, ticker, company_name)
             except Exception as e:
                 logger.warning(f"fact_pack: {ticker} skipped a malformed news item: {e}")
                 continue

--- a/tests/unit/analysis/fact_pack/test_yfinance_events.py
+++ b/tests/unit/analysis/fact_pack/test_yfinance_events.py
@@ -100,6 +100,54 @@ class TestNewsEvents:
         assert fragment.citations == ("https://example.com/reuters/1",)
         assert fragment.events_from_filings is False
 
+    def test_the_travel_article_that_reached_a_live_prompt_is_dropped(self, mocker):
+        """MCHA.F's only recent_event on a live run was a travel headline.
+
+        It reached the qualitative prompt inside the block that prompt labels
+        AUTORITAIRE, presented as a recent corporate event about the holding.
+        The provider allowlist screens who published, never what about — a
+        reputable wire syndicates travel copy under a ticker just as readily.
+
+        This is the exact string from that run. It had no fixture before, which
+        is why it shipped. See #169.
+        """
+        news = [self._item("This City May Be the South's Most Underrated Getaway", "Reuters", "https://example.com/travel/1")]
+        mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
+
+        assert src.news_events("MCHA.F", "Mercedes-Benz Group AG", now=NOW).recent_events == ()
+
+    def test_a_headline_naming_the_company_is_kept(self, mocker):
+        """The legal suffix is stripped: a wire writes "Mercedes-Benz", never "Mercedes-Benz Group AG"."""
+        news = [self._item("Mercedes-Benz opens a battery plant", "Reuters", "https://example.com/mb/1")]
+        mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
+
+        assert src.news_events("MCHA.F", "Mercedes-Benz Group AG", now=NOW).recent_events == ("2026-09-05 Mercedes-Benz opens a battery plant",)
+
+    def test_a_corporate_event_headline_is_kept_even_without_the_company_name(self, mocker):
+        """Wires omit the name they have already filed the story under.
+
+        A name-only gate would discard this, which is why the keyword arm exists.
+        """
+        news = [self._item("Q3 profit beats estimates", "Reuters", "https://example.com/q3/1")]
+        mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
+
+        assert src.news_events("MCHA.F", "Mercedes-Benz Group AG", now=NOW).recent_events == ("2026-09-05 Q3 profit beats estimates",)
+
+    def test_a_headline_matching_the_ticker_root_is_kept(self, mocker):
+        """MCHA.F -> MCHA: the exchange suffix must not defeat the match."""
+        news = [self._item("MCHA halted pending announcement", "Reuters", "https://example.com/t/1")]
+        mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
+
+        assert src.news_events("MCHA.F", "", now=NOW).recent_events == ("2026-09-05 MCHA halted pending announcement",)
+
+    def test_a_short_name_token_does_not_match_an_unrelated_word(self, mocker):
+        """ "EL" (EssilorLuxottica) must not match "EL NINO"; tokens under four
+        characters are too generic to establish relevance."""
+        news = [self._item("EL NINO expected to persist into spring", "Reuters", "https://example.com/w/1")]
+        mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
+
+        assert src.news_events("EL.PA", "EL", now=NOW).recent_events == ()
+
     def test_opinion_providers_are_excluded_entirely(self, mocker):
         news = [self._item("Prediction: Amazon Will Join Nvidia", "Motley Fool", "https://example.com/fool/1")]
         mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
@@ -111,9 +159,13 @@ class TestNewsEvents:
         assert src.news_events("AAPL", now=NOW).recent_events == ()
 
     def test_event_text_is_truncated_to_two_hundred_chars(self, mocker):
-        news = [self._item("x" * 400, "Reuters", "https://example.com/r/long")]
+        news = [self._item("AAPL " + "x" * 400, "Reuters", "https://example.com/r/long")]
         mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
-        assert all(len(e) <= 200 for e in src.news_events("AAPL", now=NOW).recent_events)
+        events = src.news_events("AAPL", now=NOW).recent_events
+        # Assert non-empty first: the relevance gate made this vacuous once, and
+        # `all()` over an empty tuple is True. See #169.
+        assert events
+        assert all(len(e) <= 200 for e in events)
 
     def test_news_raising_exception_degrades_the_field_and_does_not_raise(self, mocker):
         mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=RuntimeError("HTTP Error 404")))
@@ -135,7 +187,7 @@ class TestEventCaps:
         assert len(src.filing_events("AAPL", now=NOW).recent_events) == 10
 
     def test_news_events_cap_at_ten_items(self, mocker):
-        news = [self._news_item(f"News {i}", "Reuters") for i in range(15)]
+        news = [self._news_item(f"AAPL quarterly earnings note {i}", "Reuters") for i in range(15)]
         mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
         assert len(src.news_events("AAPL", now=NOW).recent_events) == 10
 
@@ -167,10 +219,17 @@ class TestMalformedData:
 
     def test_news_events_skips_non_dict_entries(self, mocker):
         news = [
-            {"content": {"title": "Good", "pubDate": "2026-09-05T19:40:00Z", "provider": {"displayName": "Reuters"}, "canonicalUrl": {"url": "https://example.com/1"}}},
+            {"content": {"title": "Good earnings", "pubDate": "2026-09-05T19:40:00Z", "provider": {"displayName": "Reuters"}, "canonicalUrl": {"url": "https://example.com/1"}}},
             None,
             "not a dict",
-            {"content": {"title": "Also good", "pubDate": "2026-09-05T19:40:00Z", "provider": {"displayName": "Reuters"}, "canonicalUrl": {"url": "https://example.com/2"}}},
+            {
+                "content": {
+                    "title": "Also good dividend news",
+                    "pubDate": "2026-09-05T19:40:00Z",
+                    "provider": {"displayName": "Reuters"},
+                    "canonicalUrl": {"url": "https://example.com/2"},
+                }
+            },
         ]
         mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
         fragment = src.news_events("AAPL", now=NOW)
@@ -219,9 +278,16 @@ class TestPerItemContainment:
         """
         news = [
             {"content": {"title": "Bad", "pubDate": "2026-09-05T19:40:00Z", "provider": "Reuters", "canonicalUrl": {"url": "https://example.com/bad"}}},
-            {"content": {"title": "Good headline", "pubDate": "2026-09-05T19:40:00Z", "provider": {"displayName": "Reuters"}, "canonicalUrl": {"url": "https://example.com/good"}}},
+            {
+                "content": {
+                    "title": "Good earnings headline",
+                    "pubDate": "2026-09-05T19:40:00Z",
+                    "provider": {"displayName": "Reuters"},
+                    "canonicalUrl": {"url": "https://example.com/good"},
+                }
+            },
         ]
         mocker.patch.object(src, "_ticker", return_value=_FakeTicker(news=news))
         fragment = src.news_events("AAPL", now=NOW)
-        assert fragment.recent_events == ("2026-09-05 Good headline",)
+        assert fragment.recent_events == ("2026-09-05 Good earnings headline",)
         assert fragment.citations == ("https://example.com/good",)


### PR DESCRIPTION
Closes #169.

A live run gave `MCHA.F` exactly one `recent_event`:

> `2026-08-09 This City May Be the South's Most Underrated Getaway`

A travel article, presented to the qualitative model as a recent corporate event about the holding — inside the block the prompt labels **AUTORITAIRE**.

## Why it got through

The allowlist in `yfinance_source.py` screens **who published**, never **what about**. Yahoo's ticker stream is loosely associated and syndicates unrelated copy under a symbol, so a reputable wire carries a travel piece through unchanged.

The scoring was honest about it — that pack's `confidence` was 0.25 — but the noise shipped regardless, and a thin pack is exactly the case where a single bogus "fact" carries the most weight.

## The gate

A headline now qualifies **two ways, either sufficient**:

1. **It names the holding** — the ticker root, or a distinctive token of the company name with legal forms (`AG`, `SA`, `PLC`, `Inc`…) stripped. A wire writes "Mercedes-Benz", never "Mercedes-Benz Group AG".
2. **It carries unambiguous corporate-event vocabulary** — `earnings`, `dividend`, `merger`, `guidance`, `CEO`, `lawsuit`, and similar.

Neither alone is right. Name-only discards the wire style that omits the name it has already filed the story under — *"Q3 profit beats estimates"* is a real event and names nobody. Keyword-only lets through any syndicated piece that happens to use a financial word. The keyword set is deliberately narrow, because **every entry is a hole**; anything arguable ("outlook", "report", "deal") is left out.

## A hole the tests caught

My first cut matched substrings anywhere. A test written for `EL.PA` (EssilorLuxottica) found it immediately: the two-character root `el` matched *"EL NINO expected to persist into spring"*, and would equally have matched "shell" or "held".

Fixed by matching at word starts and requiring a ticker root of at least three characters to qualify on its own. Prefix-at-word-start still catches the useful case — `AIR.PA` against "Airbus". A holding with a very short ticker can still qualify through its name or the keyword arm; it just cannot qualify on the root alone.

## Existing fixtures

Four used arbitrary titles (`"News 0"`, `"Good"`, `"x" * 400`) that the gate correctly drops. They test caps and malformed-data containment, not relevance, so their titles were made relevant rather than the gate weakened.

One deserves calling out: `test_event_text_is_truncated_to_two_hundred_chars` did not fail — it **silently became vacuous**, because `all()` over an empty tuple is `True`. It now asserts the events are non-empty before asserting anything about their length. That is the same defect class as #201, caught this time because the change made it visible.

## Tests

Five new, fixturing the real yfinance item shape (`content.provider.displayName`, `content.title`, `content.pubDate`, `content.canonicalUrl`):

- **the exact MCHA.F travel headline is dropped** — the case the issue notes had no fixture, which is why it shipped
- a headline naming the company is kept, with the legal suffix stripped
- a corporate-event headline is kept without the company name
- a headline matching the ticker root is kept, exchange suffix notwithstanding
- a short name token does not match an unrelated word

## Verification

- `make test` — 4,597 passed, 31 skipped.
- `make lint` — clean.

## Scope

News only. SEC filings are untouched: they are dated, filed and citable, and remain the preferred source — this gate applies to the weaker fallback, which is where the noise was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtXz89ibcafk3p5LP5Ewms
