### PR TITLE
feat: render the three fact-pack fields that were collected and thrown away (#186)

### DIFF
--- a/src/finwiz/analysis/fact_pack/render.py
+++ b/src/finwiz/analysis/fact_pack/render.py
@@ -10,9 +10,19 @@ from finwiz.schemas.hybrid_analysis.fact_pack import CryptoFacts, EquityFacts, F
 
 _MAX_HOLDINGS_SHOWN = 5
 
+# Sector weights arrive with ~11 buckets. Concentration is the fact worth
+# reading, and it lives in the largest few -- the tail adds length to a prompt
+# block and a report cell without changing what either says.
+_MAX_SECTORS_SHOWN = 5
+
 
 def _pct(value: float | None) -> str:
     return "—" if value is None else f"{value * 100:.2f}".replace(".", ",") + " %"
+
+
+def _sector_label(key: str) -> str:
+    """Yfinance sector keys are snake_case ("consumer_cyclical"); make them readable."""
+    return key.replace("_", " ").strip().capitalize()
 
 
 def _supply(facts: CryptoFacts) -> str:
@@ -48,6 +58,14 @@ def _fund_rows(facts: FundFacts) -> list[Row]:
         buckets = [f"{k} {_pct(v)}" for k, v in sorted(facts.asset_mix.items(), key=lambda kv: -kv[1]) if v > 0]
         if buckets:
             rows.append(("Allocation", buckets))
+    if facts.sector_weights:
+        sectors = [f"{_sector_label(k)} {_pct(v)}" for k, v in sorted(facts.sector_weights.items(), key=lambda kv: -kv[1]) if v > 0]
+        if sectors:
+            rows.append(("Secteurs", sectors[:_MAX_SECTORS_SHOWN]))
+    # `is not None`, not truthiness: 0.0 is a real and notable fact -- an index
+    # fund that did not trade all year. The same distinction the expense ratio makes.
+    if facts.turnover is not None:
+        rows.append(("Rotation annuelle", _pct(facts.turnover)))
     return rows
 
 
@@ -58,6 +76,10 @@ def _crypto_rows(facts: CryptoFacts) -> list[Row]:
     rows.append(("Offre", _supply(facts)))
     if facts.market_cap is not None:
         rows.append(("Capitalisation", f"{facts.market_cap:,.0f}".replace(",", " ")))
+    # Daily traded value against total value: the asset's liquidity, and the
+    # difference between a position you can exit and one you are holding.
+    if facts.volume_24h_market_cap_pct is not None:
+        rows.append(("Volume 24 h / capitalisation", _pct(facts.volume_24h_market_cap_pct)))
     return rows
 
 

--- a/tests/unit/analysis/fact_pack/test_render.py
+++ b/tests/unit/analysis/fact_pack/test_render.py
@@ -57,6 +57,49 @@ class TestLabels:
         assert "21" in supply
 
 
+class TestPreviouslyUnrenderedFields:
+    """turnover, sector_weights and volume_24h_market_cap_pct were collected on
+    every run, stored in every cached pack, and read by nothing — neither scored
+    nor rendered, so they reached neither the model nor the reader. That was the
+    worst of the available states: the data was paid for and thrown away. See #186.
+
+    All three are fractions at source, verified against real cached packs
+    (a fund at turnover 1.1228, BTC at 0.0145), so _pct is the correct formatter.
+    """
+
+    def test_a_funds_turnover_is_rendered_as_a_percentage(self):
+        pack = _pack("etf", FundFacts(issuer="iShares", turnover=1.1228))
+        assert ("Rotation annuelle", "112,28 %") in to_rows(pack)
+
+    def test_a_zero_turnover_is_shown_rather_than_treated_as_missing(self):
+        """0.0 is a real fact — an index fund that did not trade all year.
+        The same `is not None` distinction the expense ratio already makes."""
+        pack = _pack("etf", FundFacts(issuer="iShares", turnover=0.0))
+        assert ("Rotation annuelle", "0,00 %") in to_rows(pack)
+
+    def test_sector_weights_render_as_a_list_largest_first(self):
+        pack = _pack("etf", FundFacts(issuer="iShares", sector_weights={"realestate": 0.02, "technology": 0.41, "basic_materials": 0.09}))
+        sectors = next(value for label, value in to_rows(pack) if label == "Secteurs")
+        assert sectors == ["Technology 41,00 %", "Basic materials 9,00 %", "Realestate 2,00 %"]
+
+    def test_sector_weights_are_capped_so_the_tail_does_not_pad_the_prompt(self):
+        pack = _pack("etf", FundFacts(issuer="iShares", sector_weights={f"sector_{i}": (20 - i) / 100 for i in range(11)}))
+        sectors = next(value for label, value in to_rows(pack) if label == "Secteurs")
+        assert len(sectors) == 5
+
+    def test_a_crypto_liquidity_ratio_is_rendered(self):
+        pack = _pack("crypto", CryptoFacts(description="Bitcoin", circulating_supply=19_000_000.0, volume_24h_market_cap_pct=0.014470552))
+        assert ("Volume 24 h / capitalisation", "1,45 %") in to_rows(pack)
+
+    def test_the_new_rows_reach_the_model_not_just_the_report(self):
+        """to_prompt_block is built from to_rows, so rendering reaches both
+        consumers. This asserts the half that is easy to forget."""
+        pack = _pack("etf", FundFacts(issuer="iShares", turnover=1.1228, sector_weights={"technology": 0.41}))
+        block = to_prompt_block(pack)
+        assert "Rotation annuelle : 112,28 %" in block
+        assert "Technology 41,00 %" in block
+
+
 class TestRowValueContract:
     """A row's value is a plain str for prose and a list[str] for a
     genuinely list-shaped fact (holdings, recent events, allocation


### PR DESCRIPTION
Closes #186.

Three fields were fetched on every run and stored in every cached pack, then read by nothing:

| Field | Model | What it means |
|---|---|---|
| `turnover` | `FundFacts` | a fund's churn cost |
| `sector_weights` | `FundFacts` | its concentration |
| `volume_24h_market_cap_pct` | `CryptoFacts` | a coin's liquidity |

Absent from `confidence.py`, `render.py` and `reporting/sections/factpack.py` alike, so they reached neither the model nor the reader. As the issue puts it, that is the worst of the available states: the data is paid for and thrown away.

## Rendering, not scoring

Of the three ways out, this takes the additive one.

Scoring them into `confidence` would re-weight every existing component — both scorers use fixed weights — moving the number on every cached pack for reasons a reader could not see, and needing a cache schema bump to go with it. Rendering changes what is *shown*, not what anything computes.

One correction to the issue while I was in there: it says scoring would shift the run gate's thresholds. It would not — `run_gate_orchestrator.py` does not reference `confidence` at all. The cache bump and the invisible movement are still real reasons; that one is not.

Because `to_prompt_block` is built from `to_rows`, a single change reaches **both** the report and the model's AUTORITAIRE block. A test asserts the prompt half specifically, since it is the one easy to forget.

## Units were verified, not assumed

`volume_24h_market_cap_pct` reads as though it were already a percentage. It is not. Checked against real cached packs rather than the field name:

```
BTC-USD  -> 0.014470552     # 1.45% daily volume / market cap
AUUSI.SW -> turnover 1.1228 # 112% annual turnover
2B7K.DE  -> sector_weights {realestate: 0.0206, technology: ...}
```

All three are fractions, so the existing `_pct` helper is correct. Reading that field as already-percent would have rendered every crypto liquidity figure **100× too large** — a plausible-looking number, in a financial report, about a real position.

## Two smaller judgements

- **Sector weights are capped at the largest five.** Concentration is the fact worth reading and it lives in the top buckets; the remaining six pad a prompt block and a report cell without changing what either says.
- **Turnover uses `is not None`, not truthiness.** `0.0` is a real and notable fact — an index fund that did not trade all year — and it is the same distinction the expense ratio already makes two lines above.

Sector keys arrive snake_case from yfinance (`consumer_cyclical`), so they are made readable rather than printed raw.

## Tests

Six new, in `TestPreviouslyUnrenderedFields`:

- turnover renders as a percentage
- a zero turnover is shown rather than treated as missing
- sector weights render as a list, largest first
- sector weights are capped
- the crypto liquidity ratio renders
- **the new rows reach the model, not just the report** — asserted through `to_prompt_block`

## Verification

- `make test` — 4,603 passed, 31 skipped.
- `make lint` — clean.

## Note on scope

This does not touch what is collected or how confidence is computed. If these fields should also *count* toward confidence, that is a separate change with a different risk profile — it moves every existing value — and deserves its own decision rather than riding along with a display change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtXz89ibcafk3p5LP5Ewms
