### PR TITLE
docs: record the deletion and test-counting rules this session paid for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ make mypy                              # uv run mypy src/finwiz
 make coverage
 ```
 
+`ruff format` (via `make lint`) formats fenced `python` blocks **inside Markdown**.
+A code *fragment* in a python fence gets rewritten on every lint, dirtying the working
+tree of whatever branch is checked out. Fence fragments as `text` instead.
+
 ## Project Overview
 
 FinWiz is an AI-powered financial analysis platform built with CrewAI. It analyzes portfolios of stocks, ETFs, and crypto using a hybrid approach: deterministic Python scoring ($0, <100ms) for quantitative analysis, and AI crews for qualitative insights only.
@@ -116,6 +120,29 @@ Each crew lives in `crews/<name>/` with `config/agents.yaml`, `config/tasks.yaml
 - Markers: `integration`, `unit`, `slow`, `asyncio`, `performance`, `benchmark`, `crew`, `flow`
 - Default pytest run excludes integration tests (`-m "not integration"`)
 - Coverage reports to `htmlcov/`, minimum 65%
+- `@pytest.mark.anyio` tests are collected **twice** (asyncio + trio backends). When
+  reconciling a test-count change, multiply anyio tests by 2 before comparing.
+- A class-level `@pytest.mark.skip` can be hiding a *broken fixture*, not a deferred
+  judgement. Before trusting one, delete the marker and run: 20 "skipped" Perplexity
+  tests were erroring at setup (PR #215).
+
+## Deleting code
+
+- **Prove it dead first.** Module-level unreachability is necessary, not sufficient.
+  Run `git log -S'<symbol>' --oneline --all`, find the commit that removed the last
+  reader, and *read it*. A present-tense grep returning nothing is not proof.
+- **Sweep all call surfaces**, not just `src/`: `tests`, `scripts`, `bin`, Makefile
+  recipe bodies, `pyproject.toml`, `.pre-commit-config.yaml`, `.github/workflows/`,
+  `mkdocs.yml`.
+- **Grep both forms** — `scripts/foo.py` *and* dotted `scripts.foo`. `Makefile:165`
+  wires a gate as `python -m scripts.check_stage_contract`, invisible to a path grep.
+- **Run `uvx vulture src/finwiz --min-confidence 80` before pushing a deletion.**
+  Vulture matches names *globally*, so deleting a module can unmask an unused-variable
+  warning in a file your diff never touched, failing the CI `extra` job.
+- **`ls` lies after a deletion** — stale `__pycache__` leaves the directory listed.
+  Check `git ls-files`.
+- `pyproject.toml`'s `[tool.ruff.lint.per-file-ignores]` collects deletion residue:
+  ruff drops unmatched rows **silently**, so lint stays green while they rot.
 
 ## Environment Variables
 


### PR DESCRIPTION
Records the rules this session paid for, so the next session doesn't re-learn them. 27 lines, no code changes.

## Testing (2 lines added)

- **`@pytest.mark.anyio` tests are collected twice** (asyncio + trio backends). Reconciling a test-count change without knowing this makes a *correct* deletion look wrong — it cost a full verification detour on #213.
- **A class-level `@pytest.mark.skip` can hide a broken fixture**, not a deferred judgement. 20 "skipped" Perplexity tests were erroring at setup (PR #215).

## New `## Deleting code` section

Every rule from a deletion that went wrong:

- **Prove death with `git log -S`** and read the commit that removed the last reader. A present-tense grep returning nothing is not proof — #187 deleted live code twice on that basis.
- **Sweep every call surface**, not just `src/`.
- **Grep both the path and dotted forms** — `Makefile:165` wires a gate as `python -m scripts.check_stage_contract`, invisible to a path grep.
- **Run vulture before pushing a deletion.** It matches names *globally*, so a deletion can unmask a warning in a file the diff never touched. This failed CI on PR #214.
- **`ls` lies after a deletion** — stale `__pycache__` keeps the directory listed.
- `per-file-ignores` rows rot silently; ruff drops unmatched ones without error.

## Quick Reference (1 note)

`ruff format` rewrites fenced python blocks **inside Markdown**, dirtying the working tree on every lint. Three separate sessions reverted the symptom before `852b98a` found the cause.

## Verification

- `make lint` — clean, and `879 files left unchanged` confirms ruff does not rewrite the new text (the note's own claim, tested).
- Fence count in `CLAUDE.md` is balanced (34).
- `make docs-validate` — the 20 errors it reports are **pre-existing and present on `main`**, all under `docs/superpowers/`; none in `CLAUDE.md`. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtXz89ibcafk3p5LP5Ewms
