### PR TITLE
feat(alternatives): implement sector matching and cheaper-ETF search

### DIFF
--- a/src/finwiz/orchestrators/alternatives_matching_orchestrator.py
+++ b/src/finwiz/orchestrators/alternatives_matching_orchestrator.py
@@ -9,6 +9,70 @@ from finwiz.tools.logger import get_logger
 logger = get_logger(__name__)
 
 
+# A fund whose largest sector is below this weight is treated as having no single
+# sector: a broad world index peaks around 0.24 in Technology, which is a
+# composition fact, not a sector thesis.
+_MIN_DOMINANT_SECTOR_WEIGHT = 0.40
+
+
+def _fact_pack_details(analysis: Any) -> dict[str, Any]:
+    """Return the fact pack's ``details`` mapping, or an empty one."""
+    fact_pack = getattr(analysis, "fact_pack", None)
+    if fact_pack is None:
+        return {}
+    details = fact_pack.get("details") if isinstance(fact_pack, dict) else getattr(fact_pack, "details", None)
+    return details if isinstance(details, dict) else {}
+
+
+def _extract_sector(analysis: Any) -> str | None:
+    """Best available sector label for a holding, or None.
+
+    An equity has one sector. A fund does not -- it has ``sector_weights`` -- so
+    its dominant sector is used, which is what makes "same sector" mean anything
+    for a fund at all. Below ``_MIN_DOMINANT_SECTOR_WEIGHT`` the fund is too
+    diversified for a single label to describe it (a world index would otherwise
+    be filed under Technology at ~24%), and None is returned so the sector step
+    skips rather than pairing a broad fund with a sector fund.
+    """
+    details = _fact_pack_details(analysis)
+
+    sector = details.get("sector")
+    if isinstance(sector, str) and sector.strip():
+        return sector.strip()
+
+    weights = details.get("sector_weights")
+    if isinstance(weights, dict) and weights:
+        numeric = {k: float(v) for k, v in weights.items() if isinstance(v, (int, float))}
+        if numeric:
+            top, weight = max(numeric.items(), key=lambda kv: kv[1])
+            if weight >= _MIN_DOMINANT_SECTOR_WEIGHT:
+                return top.replace("_", " ").strip()
+
+    return None
+
+
+def _extract_expense_ratio(analysis: Any) -> float | None:
+    """Expense ratio as a fraction (0.0015 = 0.15%), or None when unknown."""
+    details = _fact_pack_details(analysis)
+    candidates = [details.get("expense_ratio")]
+
+    fundamentals = getattr(analysis, "fundamental_details", None)
+    if isinstance(fundamentals, dict):
+        candidates.append(fundamentals.get("expense_ratio"))
+
+    for value in candidates:
+        if value is None:
+            continue
+        try:
+            ratio = float(value)
+        except (TypeError, ValueError):
+            continue
+        if 0.0 <= ratio < 1.0:
+            return ratio
+
+    return None
+
+
 class AlternativesMatchingOrchestrator:
     """Finds and matches A+ alternatives for underperforming holdings."""
 
@@ -86,6 +150,8 @@ class AlternativesMatchingOrchestrator:
                 composite_score = holding.get("composite_score")
                 name = holding.get("name", ticker)
                 asset_class = holding.get("asset_class", "stock")
+                sector = holding.get("sector")
+                expense_ratio = holding.get("expense_ratio")
             else:
                 grade = getattr(holding, "grade", "D")
                 # Try risk_score directly first (DeepAnalysisResult), then fall back to risk.score (legacy)
@@ -96,6 +162,8 @@ class AlternativesMatchingOrchestrator:
                 composite_score = getattr(holding, "composite_score", None)
                 name = getattr(holding, "name", ticker)
                 asset_class = getattr(holding, "asset_class", "stock")
+                sector = getattr(holding, "sector", None)
+                expense_ratio = getattr(holding, "expense_ratio", None)
 
             # Only find alternatives for grades C, D, or F (Requirement 4.1)
             if grade not in ["C", "D", "F"]:
@@ -120,6 +188,8 @@ class AlternativesMatchingOrchestrator:
                     grade=grade,
                     composite_score=composite_score,
                     risk_score=risk_score,
+                    sector=sector,
+                    expense_ratio=expense_ratio,
                 )
 
                 # Find alternatives using existing tool (Requirement 4.2)
@@ -226,10 +296,15 @@ class AlternativesMatchingOrchestrator:
                 "risk": {"score": analysis.risk_score} if analysis.risk_score is not None else {},
                 "name": getattr(analysis, "name", ticker),
                 "asset_class": analysis.asset_class,
+                # Sector and expense ratio drive the sector-match and cheaper-ETF
+                # searches. Without them those two steps are blind and return
+                # empty regardless of what the candidate universe holds.
+                "sector": _extract_sector(analysis),
+                "expense_ratio": _extract_expense_ratio(analysis),
             }
             holdings.append(holding_dict)
 
-        # Match alternatives using discovery crew output
+        # Match alternatives using the Python discovery output
         alternatives_data = self.match_alternatives_for_holdings(holdings, discovery_data)
 
         # Update structured Flow state

--- a/src/finwiz/scoring/discovery/pipeline.py
+++ b/src/finwiz/scoring/discovery/pipeline.py
@@ -26,6 +26,32 @@ ENRICHMENT_SCORE_THRESHOLD = 0.80
 MAX_ENRICHMENT_CANDIDATES = 10
 
 
+def _cost_and_size_fields(candidate: Any) -> dict[str, Any]:
+    """Expense ratio and market cap for a candidate, omitting what is unknown.
+
+    Carried so the alternatives matcher can prove one fund is cheaper than
+    another: the screener already fetches the ratio
+    (``discovery/fundamentals_adapter.py`` reads ``annualReportExpenseRatio``),
+    and dropping it here is what left the cheaper-ETF search comparing against
+    fabricated defaults.
+
+    Absent keys, never explicit ``None``: downstream readers distinguish "field
+    not produced" from "produced as null", and writing null drops the whole
+    opportunity.
+    """
+    fields: dict[str, Any] = {}
+
+    expense_ratio = (getattr(candidate, "metadata", None) or {}).get("expense_ratio")
+    if expense_ratio is not None:
+        fields["expense_ratio"] = expense_ratio
+
+    market_cap = getattr(candidate, "market_cap", None)
+    if market_cap is not None:
+        fields["market_cap"] = market_cap
+
+    return fields
+
+
 class NewcomerDiscoveryPipeline:
     """Orchestrates newcomer discovery for a single asset class."""
 
@@ -488,6 +514,7 @@ class NewcomerDiscoveryPipeline:
                 "sector": getattr(c, "sector", None),
                 "asset_class": getattr(c, "asset_class", self.asset_class),
             }
+            | _cost_and_size_fields(c)
             for c in result.candidates
         ]
         return {

--- a/src/finwiz/tools/alternative_finder_tool.py
+++ b/src/finwiz/tools/alternative_finder_tool.py
@@ -15,6 +15,7 @@ from typing import Any, Literal, cast
 
 from pydantic import BaseModel, Field
 
+from finwiz.quantitative.etf.etf_expense_fallback import get_fallback_expense_ratio
 from finwiz.schemas.portfolio_review import Alternative, AssetClass, Grade
 from finwiz.tools.logger import get_logger
 
@@ -30,6 +31,25 @@ logger = get_logger(__name__)
 # Broader than "A+ only" so this isn't perpetually empty: A+ alone requires a >=95%
 # composite score, which is rare in practice.
 _A_BAND_GRADES: frozenset[str] = frozenset({"A+", "A"})
+
+
+def _coerce_expense_ratio(value: Any) -> float | None:
+    """Return an expense ratio as a fraction, or None when absent or unusable.
+
+    Discovery items carry no expense ratio today, so this mostly guards the
+    ``None`` case. It also refuses a negative or absurd value rather than letting
+    it flow into a comparison: anything at or above 1.0 is not a fraction, and
+    silently treating 0.07 (a percent) as 7% would invert every comparison.
+    """
+    if value is None:
+        return None
+    try:
+        ratio = float(value)
+    except (TypeError, ValueError):
+        return None
+    if ratio < 0.0 or ratio >= 1.0:
+        return None
+    return ratio
 
 
 class HoldingProfile(BaseModel):
@@ -190,20 +210,11 @@ class AlternativeFinder:
         """
         alternatives = []
 
-        discovery_file = self.discovery_output_dir / "consolidated_discovery.json"
-        if not discovery_file.exists():
-            self.logger.warning(f"No discovery output found at {discovery_file}; A-band alternatives unavailable for this run.")
+        opportunities = self._load_opportunities()
+        if not opportunities:
             return alternatives
 
         try:
-            with open(discovery_file) as f:
-                discovery_data = json.load(f)
-
-            opportunities = discovery_data.get("opportunities", [])
-            if not opportunities:
-                self.logger.warning(f"Discovery output exists but has no opportunities. File: {discovery_file}")
-                return alternatives
-
             aplus_items = [item for item in opportunities if isinstance(item, dict) and item.get("asset_class") == holding.asset_class and item.get("grade") in _A_BAND_GRADES]
 
             if not aplus_items:
@@ -232,19 +243,57 @@ class AlternativeFinder:
 
         except Exception as e:
             self.logger.error(
-                f"Error reading discovery output from {discovery_file}: {e}",
-                extra={"error": str(e), "file": str(discovery_file)},
+                f"Error building A-band alternatives for {holding.ticker}: {e}",
+                extra={"error": str(e), "ticker": holding.ticker},
                 exc_info=True,
             )
 
         return alternatives
 
+    def _load_opportunities(self) -> list[dict]:
+        """Read the flat ``opportunities`` list from ``consolidated_discovery.json``.
+
+        This is the single candidate universe behind all three search steps. It is
+        read once per step rather than cached, because a run writes it during
+        discovery and reads it during matching, in that order.
+        """
+        discovery_file = self.discovery_output_dir / "consolidated_discovery.json"
+        if not discovery_file.exists():
+            self.logger.warning(f"No discovery output found at {discovery_file}; no alternatives can be sourced this run.")
+            return []
+
+        try:
+            with open(discovery_file) as f:
+                discovery_data = json.load(f)
+        except Exception as e:
+            self.logger.error(
+                f"Error reading discovery output from {discovery_file}: {e}",
+                extra={"error": str(e), "file": str(discovery_file)},
+                exc_info=True,
+            )
+            return []
+
+        opportunities = discovery_data.get("opportunities", [])
+        if not opportunities:
+            self.logger.warning(f"Discovery output exists but has no opportunities. File: {discovery_file}")
+            return []
+
+        return [item for item in opportunities if isinstance(item, dict)]
+
     def _create_alternative_from_aplus(
         self,
         item: dict,
         holding: HoldingProfile,
+        *,
+        is_a_plus: bool = True,
+        discovery_source: str = "python_discovery_a_band",
     ) -> Alternative | None:
-        """Create Alternative object from A+ discovery item."""
+        """Build an ``Alternative`` from one discovery opportunity.
+
+        Shared by all three search steps; ``is_a_plus`` and ``discovery_source``
+        record which step produced the candidate so the report can distinguish an
+        A-band pick from a same-sector or cheaper-fund one.
+        """
         from finwiz.exceptions.data_quality import MissingRequiredFieldError
 
         try:
@@ -292,10 +341,18 @@ class AlternativeFinder:
             liquidity_improvement = None
 
             if holding.asset_class == "etf":
-                # Calculate expense ratio savings
-                current_expense = holding.expense_ratio or 0.50
-                alternative_expense = item.get("expense_ratio", 0.10)
-                expense_ratio_savings = current_expense - alternative_expense
+                # Report a saving only when BOTH sides are known. The previous
+                # defaults (0.50 held / 0.10 alternative) were fabricated AND on
+                # the wrong scale: real expense ratios here are fractions
+                # (data/etf_expense_ratios.yaml stores 0.0007 for 0.07%), so the
+                # substituted numbers produced a "saving" of 0.40 -- a 40-point
+                # fiction on a scale where a real gap is ~0.005. An omitted
+                # saving reads as unknown; a fabricated one reads as measured.
+                alternative_expense = _coerce_expense_ratio(item.get("expense_ratio"))
+                if alternative_expense is None:
+                    alternative_expense = get_fallback_expense_ratio(ticker)
+                if holding.expense_ratio is not None and alternative_expense is not None:
+                    expense_ratio_savings = holding.expense_ratio - alternative_expense
 
             elif holding.asset_class == "stock":
                 # Fundamental improvements
@@ -305,10 +362,12 @@ class AlternativeFinder:
                 }
 
             elif holding.asset_class == "crypto":
-                # Liquidity improvement (if available)
-                current_market_cap = holding.market_cap or 1000000
-                alternative_market_cap = item.get("market_cap", 10000000)
-                liquidity_improvement = (alternative_market_cap - current_market_cap) / current_market_cap
+                # Same rule as expense ratios: an unknown market cap is left
+                # unknown. The old 1e6 / 1e7 substitutes always yielded exactly
+                # +900% "liquidity improvement" for any pair with missing data.
+                alternative_market_cap = item.get("market_cap")
+                if holding.market_cap and alternative_market_cap:
+                    liquidity_improvement = (alternative_market_cap - holding.market_cap) / holding.market_cap
 
             return Alternative(
                 ticker=ticker,
@@ -321,9 +380,9 @@ class AlternativeFinder:
                 risk_score_standardized=item.get("risk_score", 2.0),
                 key_metrics=item.get("key_metrics", {}),
                 thesis_bullets=item.get("thesis_bullets", []),
-                citations=item.get("citations", ["Discovery Crew A+ Analysis"]),
-                is_a_plus_candidate=True,
-                discovery_source="investment_discovery_crew",
+                citations=item.get("citations", ["Python discovery scoring (A-band)"]),
+                is_a_plus_candidate=is_a_plus,
+                discovery_source=discovery_source,
                 confidence_level=item.get("confidence_level", 0.85),
                 expected_annual_benefit=item.get("expected_annual_benefit"),
                 transition_strategy=transition_strategy,
@@ -342,24 +401,141 @@ class AlternativeFinder:
             return None
 
     def _find_sector_alternatives(self, holding: HoldingProfile) -> list[Alternative]:
-        """Find alternatives in the same sector (placeholder for future implementation)."""
-        # This would integrate with sector/industry databases
-        # For now, return empty list
-        self.logger.info(
-            "Sector matching not yet implemented",
-            extra={"ticker": holding.ticker},
+        """Find same-sector candidates graded strictly better than the holding.
+
+        Reads the same discovery opportunities as step 1 but without the A-band
+        filter. That filter is why step 1 is usually empty: a real run graded only
+        2 of 17 opportunities A-band, and both were stocks, so a portfolio of
+        underperforming ETFs could never be matched. Here any grade above the
+        holding's own qualifies -- swapping a D for a B is a real improvement.
+
+        Requires ``holding.sector``. For an ETF that is the dominant sector of its
+        fact-pack ``sector_weights``; when it is absent the step is skipped rather
+        than matched on a guess, because a wrong sector pairs unrelated funds.
+        """
+        if not holding.sector:
+            self.logger.info(
+                f"No sector known for {holding.ticker}; skipping sector matching rather than pairing on a guess",
+                extra={"ticker": holding.ticker, "asset_class": holding.asset_class},
+            )
+            return []
+
+        opportunities = self._load_opportunities()
+        if not opportunities:
+            return []
+
+        held_grade_value = self.grade_values.get(holding.grade, 0)
+        target_sector = holding.sector.strip().casefold()
+
+        candidates = [
+            item
+            for item in opportunities
+            if item.get("asset_class") == holding.asset_class
+            and item.get("ticker")
+            and item.get("ticker") != holding.ticker
+            and str(item.get("sector") or "").strip().casefold() == target_sector
+            and self.grade_values.get(str(item.get("grade")), 0) > held_grade_value
+        ]
+
+        if not candidates:
+            self.logger.info(
+                f"No {holding.asset_class} in sector {holding.sector!r} graded above {holding.grade} for {holding.ticker}",
+                extra={"ticker": holding.ticker, "sector": holding.sector, "grade": holding.grade},
+            )
+            return []
+
+        # Best grade first, then best score, so the strongest swap leads.
+        candidates.sort(
+            key=lambda i: (self.grade_values.get(str(i.get("grade")), 0), i.get("composite_score") or 0.0),
+            reverse=True,
         )
-        return []
+
+        alternatives = []
+        for item in candidates:
+            alternative = self._create_alternative_from_aplus(
+                item=item,
+                holding=holding,
+                is_a_plus=str(item.get("grade")) in _A_BAND_GRADES,
+                discovery_source="sector_match",
+            )
+            if alternative:
+                alternatives.append(alternative)
+
+        self.logger.info(
+            f"Found {len(alternatives)} same-sector alternatives for {holding.ticker} in {holding.sector}",
+            extra={"ticker": holding.ticker, "sector": holding.sector, "count": len(alternatives)},
+        )
+        return alternatives
 
     def _find_lower_cost_etf_alternatives(self, holding: HoldingProfile) -> list[Alternative]:
-        """Find lower-cost ETF alternatives (placeholder for future implementation)."""
-        # This would integrate with ETF databases to find similar exposure with lower fees
-        # For now, return empty list
+        """Find ETFs that are strictly cheaper and no worse graded.
+
+        Both sides must have a *known* expense ratio. Candidate ratios come from
+        the discovery item when present, else the curated table
+        (``data/etf_expense_ratios.yaml``); a candidate with no ratio is skipped,
+        never assumed cheap. All ratios here are fractions (0.0007 = 0.07%), the
+        same scale on both sides of the comparison.
+
+        The curated table is small, so this step is often legitimately empty. That
+        is reported as missing data, not as "no cheaper fund exists".
+        """
+        if holding.expense_ratio is None:
+            self.logger.info(
+                f"No expense ratio known for {holding.ticker}; cannot prove another fund is cheaper",
+                extra={"ticker": holding.ticker},
+            )
+            return []
+
+        opportunities = self._load_opportunities()
+        if not opportunities:
+            return []
+
+        held_grade_value = self.grade_values.get(holding.grade, 0)
+        priced: list[tuple[dict, float]] = []
+        unpriced = 0
+
+        for item in opportunities:
+            ticker = item.get("ticker")
+            if item.get("asset_class") != "etf" or not ticker or ticker == holding.ticker:
+                continue
+            if self.grade_values.get(str(item.get("grade")), 0) < held_grade_value:
+                continue
+            ratio = _coerce_expense_ratio(item.get("expense_ratio"))
+            if ratio is None:
+                ratio = get_fallback_expense_ratio(ticker)
+            if ratio is None:
+                unpriced += 1
+                continue
+            if ratio < holding.expense_ratio:
+                priced.append((item, ratio))
+
+        if not priced:
+            self.logger.info(
+                f"No cheaper ETF found for {holding.ticker} (its ratio {holding.expense_ratio:.4f}); "
+                f"{unpriced} candidate(s) had no expense ratio in the discovery item or the curated table",
+                extra={"ticker": holding.ticker, "unpriced_candidates": unpriced},
+            )
+            return []
+
+        # Cheapest first -- this step exists to cut cost.
+        priced.sort(key=lambda pair: pair[1])
+
+        alternatives = []
+        for item, _ratio in priced:
+            alternative = self._create_alternative_from_aplus(
+                item=item,
+                holding=holding,
+                is_a_plus=str(item.get("grade")) in _A_BAND_GRADES,
+                discovery_source="lower_cost_etf",
+            )
+            if alternative:
+                alternatives.append(alternative)
+
         self.logger.info(
-            "ETF cost comparison not yet implemented",
-            extra={"ticker": holding.ticker},
+            f"Found {len(alternatives)} cheaper ETF alternatives for {holding.ticker}",
+            extra={"ticker": holding.ticker, "count": len(alternatives)},
         )
-        return []
+        return alternatives
 
     def _create_transition_strategy(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ os.environ.setdefault("CREWAI_TOOLS_RATE_LIMIT_DISABLED", "1")
 os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -96,6 +97,31 @@ _EXTRA_CONFIG_ENV_VARS = (
     "PERPLEXITY_API_KEY",
     "PPLX_API_KEY",
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_output_dir(monkeypatch, tmp_path, request):
+    """Run every unit test in a scratch cwd so nothing writes into the real ``output/``.
+
+    Production writers resolve their destinations relative to the current working
+    directory (``Path("output")``), so a unit test that exercised one of them
+    overwrote the repository's real run artefacts. That is how a `make test` run
+    replaced `output/discovery/consolidated_discovery.json` with Faker fixtures.
+
+    Integration tests keep the repository root: they are meant to produce real
+    artefacts. A test that needs the repo root can request ``repo_root``.
+    """
+    if request.node.get_closest_marker("integration"):
+        yield
+        return
+    monkeypatch.chdir(tmp_path)
+    yield
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    """Absolute path to the repository root, valid despite the scratch cwd."""
+    return Path(__file__).resolve().parent.parent
 
 
 @pytest.fixture(autouse=True)

--- a/tests/property/test_file_size_properties.py
+++ b/tests/property/test_file_size_properties.py
@@ -15,6 +15,8 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
 
 def count_lines(file_path: Path) -> int:
     """Count non-empty lines in a file."""
@@ -24,7 +26,7 @@ def count_lines(file_path: Path) -> int:
 
 def get_orchestrator_files() -> list[Path]:
     """Get all Python files in the orchestrators directory."""
-    orchestrators_dir = Path("src/finwiz/orchestrators")
+    orchestrators_dir = _REPO_ROOT / "src/finwiz/orchestrators"
     if not orchestrators_dir.exists():
         return []
     return list(orchestrators_dir.glob("*.py"))
@@ -32,7 +34,7 @@ def get_orchestrator_files() -> list[Path]:
 
 def get_flow_orchestrator_files() -> list[Path]:
     """Get flow orchestrator files."""
-    flows_dir = Path("src/finwiz/flows")
+    flows_dir = _REPO_ROOT / "src/finwiz/flows"
     if not flows_dir.exists():
         return []
 
@@ -288,7 +290,7 @@ class TestSingleResponsibility:
 
         **Validates: Requirements 1.3**
         """
-        orchestrators_dir = Path("src/finwiz/orchestrators")
+        orchestrators_dir = _REPO_ROOT / "src/finwiz/orchestrators"
         if not orchestrators_dir.exists():
             pytest.skip("Orchestrators directory not found")
 

--- a/tests/unit/crews/test_deep_analysis_crew.py
+++ b/tests/unit/crews/test_deep_analysis_crew.py
@@ -11,6 +11,8 @@ CrewAI framework and LLM calls, which is not practical for unit tests.
 
 from pathlib import Path
 
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
 
 class TestDeepAnalysisCrew:
     """Test cases for DeepAnalysisCrew - focused on tool routing and configuration."""
@@ -20,7 +22,7 @@ class TestDeepAnalysisCrew:
         import yaml
 
         # Load the actual YAML file
-        config_path = Path("src/finwiz/crews/deep_analysis/config/agents.yaml")
+        config_path = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/agents.yaml"
         with open(config_path) as f:
             config = yaml.safe_load(f)
 
@@ -37,7 +39,7 @@ class TestDeepAnalysisCrew:
         import yaml
 
         # Load the actual YAML file
-        config_path = Path("src/finwiz/crews/deep_analysis/config/tasks.yaml")
+        config_path = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/tasks.yaml"
         with open(config_path) as f:
             config = yaml.safe_load(f)
 
@@ -136,8 +138,8 @@ class TestDeepAnalysisCrew:
 
     def test_configuration_files_exist(self):
         """Test that configuration files exist."""
-        agents_config = Path("src/finwiz/crews/deep_analysis/config/agents.yaml")
-        tasks_config = Path("src/finwiz/crews/deep_analysis/config/tasks.yaml")
+        agents_config = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/agents.yaml"
+        tasks_config = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/tasks.yaml"
 
         assert agents_config.exists(), "agents.yaml configuration file not found"
         assert tasks_config.exists(), "tasks.yaml configuration file not found"
@@ -236,7 +238,7 @@ class TestAssetAnalystToolless:
     def test_tasks_yaml_has_no_perplexity_instruction(self) -> None:
         # The prompt must not contradict reality by telling the LLM it has a
         # Perplexity tool when it doesn't.
-        config_path = Path("src/finwiz/crews/deep_analysis/config/tasks.yaml")
+        config_path = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/tasks.yaml"
         text = config_path.read_text(encoding="utf-8")
         assert "OUTIL DE VÉRIFICATION" not in text
         assert "Perplexity Sonar Search" not in text
@@ -251,7 +253,7 @@ class TestCrewMaxIter:
     def test_crew_source_uses_max_iter_2(self) -> None:
         # Source-level check (rather than instantiating the Crew, which the
         # other tests in this file deliberately avoid).
-        path = Path("src/finwiz/crews/deep_analysis/deep_analysis.py")
+        path = _REPO_ROOT / "src/finwiz/crews/deep_analysis/deep_analysis.py"
         text = path.read_text(encoding="utf-8")
         assert "max_iter=2" in text
         assert "max_iter=5" not in text
@@ -265,14 +267,14 @@ class TestPerHoldingTimeoutDefault:
 
     def test_crew_execution_uses_crew_timeout_var(self) -> None:
         """crew_execution.py must read FINWIZ_CREW_TIMEOUT (not FINWIZ_HOLDING_TIMEOUT)."""
-        path = Path("src/finwiz/infrastructure/resilience/crew_execution.py")
+        path = _REPO_ROOT / "src/finwiz/infrastructure/resilience/crew_execution.py"
         text = path.read_text(encoding="utf-8")
         assert 'os.getenv("FINWIZ_CREW_TIMEOUT", "600")' in text
         assert 'os.getenv("FINWIZ_HOLDING_TIMEOUT"' not in text
 
     def test_orchestrator_holding_timeout_default_is_900s(self) -> None:
         """The orchestrator outer holding budget defaults to 900 s."""
-        path = Path("src/finwiz/orchestrators/deep_analysis_orchestrator.py")
+        path = _REPO_ROOT / "src/finwiz/orchestrators/deep_analysis_orchestrator.py"
         text = path.read_text(encoding="utf-8")
         assert 'os.getenv("FINWIZ_HOLDING_TIMEOUT", "900")' in text
         assert 'os.getenv("FINWIZ_HOLDING_TIMEOUT", "600")' not in text

--- a/tests/unit/crews/test_deep_analysis_prompt.py
+++ b/tests/unit/crews/test_deep_analysis_prompt.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 import yaml
 
-TASKS_YAML = Path("src/finwiz/crews/deep_analysis/config/tasks.yaml")
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+TASKS_YAML = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/tasks.yaml"
 
 
 def test_tasks_yaml_includes_fact_pack_section() -> None:

--- a/tests/unit/crews/test_hybrid_crew_integration.py
+++ b/tests/unit/crews/test_hybrid_crew_integration.py
@@ -9,13 +9,15 @@ from pathlib import Path
 
 import yaml
 
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
 
 class TestHybridDeepAnalysisCrewIntegration:
     """Test hybrid architecture for Deep Analysis Crew."""
 
     def test_should_load_qualitative_focused_agent_configurations(self):
         """Test that Deep Analysis Crew agents are configured for qualitative analysis."""
-        config_path = Path("src/finwiz/crews/deep_analysis/config/agents.yaml")
+        config_path = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/agents.yaml"
         with open(config_path) as f:
             config = yaml.safe_load(f)
 
@@ -36,7 +38,7 @@ class TestHybridDeepAnalysisCrewIntegration:
 
     def test_should_load_qualitative_focused_task_configurations(self):
         """Test that Deep Analysis Crew tasks are configured for qualitative analysis."""
-        config_path = Path("src/finwiz/crews/deep_analysis/config/tasks.yaml")
+        config_path = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/tasks.yaml"
         with open(config_path) as f:
             config = yaml.safe_load(f)
 
@@ -63,7 +65,7 @@ class TestHybridDeepAnalysisCrewIntegration:
 
     def test_should_use_hybrid_analysis_schemas(self):
         """Test that tasks reference hybrid analysis Pydantic schemas in expected_output."""
-        config_path = Path("src/finwiz/crews/deep_analysis/config/tasks.yaml")
+        config_path = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/tasks.yaml"
         with open(config_path) as f:
             config = yaml.safe_load(f)
 
@@ -80,7 +82,7 @@ class TestHybridDeepAnalysisCrewIntegration:
 
     def test_should_pass_python_context_to_tasks(self):
         """Test that tasks receive Python-calculated metrics as context."""
-        config_path = Path("src/finwiz/crews/deep_analysis/config/tasks.yaml")
+        config_path = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/tasks.yaml"
         with open(config_path) as f:
             config = yaml.safe_load(f)
 
@@ -203,7 +205,7 @@ class TestHybridCrewNoCalculationTools:
 
     def test_deep_analysis_crew_agents_should_focus_on_qualitative_analysis(self):
         """Test that Deep Analysis Crew agents focus on qualitative analysis (not calculations)."""
-        config_path = Path("src/finwiz/crews/deep_analysis/config/agents.yaml")
+        config_path = _REPO_ROOT / "src/finwiz/crews/deep_analysis/config/agents.yaml"
         with open(config_path) as f:
             config = yaml.safe_load(f)
 

--- a/tests/unit/integration/test_discovery_writer_reader_contract.py
+++ b/tests/unit/integration/test_discovery_writer_reader_contract.py
@@ -25,6 +25,7 @@ import pytest
 from finwiz.orchestrators.extraction.aplus import APlusDataExtractor
 from finwiz.schemas.newcomer_discovery import NewcomerCandidate, NewcomerDiscoveryResult
 from finwiz.scoring.discovery.pipeline import NewcomerDiscoveryPipeline
+from finwiz.tools.alternative_finder_tool import AlternativeFinder, HoldingProfile
 
 _FILENAMES = {"stock": "a_plus_stocks.json", "etf": "a_plus_etfs.json", "crypto": "a_plus_crypto.json"}
 
@@ -177,3 +178,52 @@ class TestDiscoveryWriterReaderContract:
             rationale = " | ".join(opportunities[0].rationale)
             assert "derived from grade" in rationale, f"confidence provenance missing from {rationale}"
             assert "is a default, not measured" in rationale, f"risk_score provenance missing from {rationale}"
+
+
+def test_writer_carries_expense_ratio_so_the_cheaper_etf_search_can_use_it(mocker, tmp_path):
+    """The cheaper-ETF search needs a candidate ratio; the writer must not drop it.
+
+    The screener already fetches ``annualReportExpenseRatio``
+    (discovery/fundamentals_adapter.py) onto the candidate's metadata. Before this
+    contract existed the writer dropped it, so the matcher had nothing to compare
+    and fell back to fabricated defaults.
+    """
+    mocker.patch.object(NewcomerDiscoveryPipeline, "_load_portfolio_tickers")
+
+    candidate = _make_candidate("VWCE", "Vanguard FTSE All-World", "etf")
+    candidate.metadata = {"expense_ratio": 0.0022}
+
+    pipeline = NewcomerDiscoveryPipeline("etf")
+    payload = pipeline._to_legacy_format(
+        NewcomerDiscoveryResult(
+            asset_class="etf",
+            session_id="s1",
+            timestamp="2026-01-01T00:00:00",
+            candidates=[candidate],
+            total_candidates=1,
+            summary="test",
+        ),
+        time.time(),
+    )
+
+    assert payload["opportunities"][0]["expense_ratio"] == 0.0022
+
+    # And the reader turns it into a real, correctly scaled saving.
+    discovery_dir = tmp_path / "discovery"
+    discovery_dir.mkdir()
+    (discovery_dir / "consolidated_discovery.json").write_text(json.dumps(payload, default=str))
+
+    finder = AlternativeFinder(output_dir=tmp_path)
+    holding = HoldingProfile(
+        ticker="PRICEY.L",
+        name="Expensive",
+        asset_class="etf",
+        grade="D",
+        composite_score=0.3,
+        risk_score=3.0,
+        expense_ratio=0.0050,
+    )
+
+    alternatives = finder._find_lower_cost_etf_alternatives(holding)
+    assert [a.ticker for a in alternatives] == ["VWCE"]
+    assert alternatives[0].expense_ratio_savings == pytest.approx(0.0028)

--- a/tests/unit/orchestrators/test_alternatives_matching_orchestrator.py
+++ b/tests/unit/orchestrators/test_alternatives_matching_orchestrator.py
@@ -1,6 +1,7 @@
 """Unit tests for AlternativesMatchingOrchestrator."""
 
 import os
+from types import SimpleNamespace
 
 import pytest
 from hypothesis import given, settings
@@ -9,6 +10,8 @@ from hypothesis import strategies as st
 from finwiz.flow_state import DeepAnalysisResult, FinwizState
 from finwiz.orchestrators.alternatives_matching_orchestrator import (
     AlternativesMatchingOrchestrator,
+    _extract_expense_ratio,
+    _extract_sector,
 )
 
 
@@ -448,3 +451,38 @@ def test_property_alternative_structure_validation_with_mocker(mocker):
 
         # Reset mock for next iteration
         mocker.stop(mock_finder)
+
+
+class TestHoldingProfileEnrichment:
+    """Sector and expense-ratio extraction feeding the sector/cost searches."""
+
+    def _analysis(self, details=None, fundamentals=None):
+        return SimpleNamespace(fact_pack={"details": details or {}}, fundamental_details=fundamentals or {})
+
+    def test_should_read_equity_sector_directly(self):
+        assert _extract_sector(self._analysis({"sector": " Healthcare "})) == "Healthcare"
+
+    def test_should_use_dominant_sector_for_a_concentrated_fund(self):
+        analysis = self._analysis({"sector_weights": {"technology": 0.62, "financial_services": 0.20, "realestate": 0.18}})
+        assert _extract_sector(analysis) == "technology"
+
+    def test_should_refuse_a_single_label_for_a_diversified_fund(self):
+        """A world index peaking at 24% Technology is not a technology fund."""
+        analysis = self._analysis({"sector_weights": {"technology": 0.24, "financial_services": 0.18, "healthcare": 0.15, "industrials": 0.14}})
+        assert _extract_sector(analysis) is None
+
+    def test_should_return_none_without_a_fact_pack(self):
+        assert _extract_sector(SimpleNamespace(fact_pack=None)) is None
+
+    def test_should_read_expense_ratio_from_fact_pack(self):
+        assert _extract_expense_ratio(self._analysis({"expense_ratio": 0.0015})) == 0.0015
+
+    def test_should_fall_back_to_fundamental_details(self):
+        assert _extract_expense_ratio(self._analysis({}, {"expense_ratio": 0.0022})) == 0.0022
+
+    def test_should_reject_percent_scaled_expense_ratio(self):
+        """0.15 meaning 15% would invert every cost comparison against fractions."""
+        assert _extract_expense_ratio(self._analysis({"expense_ratio": 1.5})) is None
+
+    def test_should_return_none_when_expense_ratio_absent(self):
+        assert _extract_expense_ratio(self._analysis({})) is None

--- a/tests/unit/orchestrators/test_discovery_orchestrator.py
+++ b/tests/unit/orchestrators/test_discovery_orchestrator.py
@@ -18,6 +18,18 @@ from finwiz.orchestrators.discovery_orchestrator import DiscoveryOrchestrator
 class TestDiscoveryOrchestrator:
     """Test suite for DiscoveryOrchestrator."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_output_dir(self, monkeypatch, tmp_path):
+        """Keep discovery writes inside tmp_path.
+
+        The orchestrator writes to a relative ``output/`` path, so without this
+        every test here overwrote the repository's real run artefacts
+        (`output/discovery/consolidated_discovery.json` and friends) with Faker
+        fixtures. Two tests below already chdir'd for their own assertions; this
+        covers the rest of the class.
+        """
+        monkeypatch.chdir(tmp_path)
+
     @pytest.fixture
     def state(self):
         """Create a FinwizState instance for testing."""

--- a/tests/unit/orchestrators/test_reporting_orchestrator.py
+++ b/tests/unit/orchestrators/test_reporting_orchestrator.py
@@ -19,6 +19,11 @@ from finwiz.scoring.grading_system import count_grade_distribution
 class TestReportingOrchestrator:
     """Test suite for ReportingOrchestrator."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_output_dir(self, monkeypatch, tmp_path):
+        """Keep report writes inside tmp_path rather than the real ``output/``."""
+        monkeypatch.chdir(tmp_path)
+
     @pytest.fixture
     def state(self):
         """Create a FinwizState instance for testing."""

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
 # Match the [5.X.Y] - YYYY-MM-DD format used in Keep-a-Changelog
 _CHANGELOG_HEADER = re.compile(r"^## \[(\d+\.\d+\.\d+)\] - \d{4}-\d{2}-\d{2}", re.MULTILINE)
 _PYPROJECT_VERSION = re.compile(r'^version = "(\d+\.\d+\.\d+)"', re.MULTILINE)
@@ -15,8 +17,8 @@ def test_pyproject_version_matches_latest_changelog_release() -> None:
 
     Pins v5.2.0+ alignment: the SemVer tag, pyproject, and CHANGELOG must agree.
     """
-    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
-    changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
+    pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    changelog = (_REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
 
     pp_match = _PYPROJECT_VERSION.search(pyproject)
     assert pp_match is not None, "pyproject.toml has no version line"
@@ -31,7 +33,7 @@ def test_pyproject_version_matches_latest_changelog_release() -> None:
 
 def test_version_is_5_2_0_or_later() -> None:
     """Pin the v5.2.0 alignment epoch -- versions <5.2.0 are now historical."""
-    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+    pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     pp_match = _PYPROJECT_VERSION.search(pyproject)
     assert pp_match is not None
     parts = tuple(int(p) for p in pp_match.group(1).split("."))

--- a/tests/unit/tools/test_alternative_finder_tool.py
+++ b/tests/unit/tools/test_alternative_finder_tool.py
@@ -544,7 +544,7 @@ class TestAlternativeFinder:
         assert len(alternatives) > 0
         for alt in alternatives:
             assert alt.is_a_plus_candidate is True
-            assert alt.discovery_source == "investment_discovery_crew"
+            assert alt.discovery_source == "python_discovery_a_band"
             assert alt.confidence_level is not None
             assert alt.confidence_level > 0.0
 
@@ -669,3 +669,188 @@ class TestAlternativeFinder:
 
         # Assert
         assert alternatives == []
+
+
+class TestSectorAlternatives:
+    """Step 2: same-sector candidates graded strictly better than the holding."""
+
+    @pytest.fixture
+    def finder(self, tmp_path):
+        return AlternativeFinder(output_dir=tmp_path)
+
+    def _write_opportunities(self, tmp_path, opportunities):
+        discovery_dir = tmp_path / "discovery"
+        discovery_dir.mkdir(exist_ok=True)
+        (discovery_dir / "consolidated_discovery.json").write_text(
+            json.dumps({"timestamp": "2026-09-08T00:00:00", "total_opportunities": len(opportunities), "opportunities": opportunities})
+        )
+
+    def _holding(self, **kwargs):
+        base = {
+            "ticker": "BAD.PA",
+            "name": "Underperformer",
+            "asset_class": "stock",
+            "grade": "D",
+            "composite_score": 0.30,
+            "risk_score": 3.0,
+            "sector": "Healthcare",
+        }
+        base.update(kwargs)
+        return HoldingProfile(**base)
+
+    def test_should_match_same_sector_candidate_graded_better(self, finder, tmp_path):
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "GOOD.PA", "name": "Better", "grade": "B", "composite_score": 0.75, "sector": "Healthcare", "asset_class": "stock"}],
+        )
+
+        alternatives = finder._find_sector_alternatives(self._holding())
+
+        assert [a.ticker for a in alternatives] == ["GOOD.PA"]
+        assert alternatives[0].discovery_source == "sector_match"
+        # B is not A-band, so this must not be advertised as an A+ pick.
+        assert alternatives[0].is_a_plus_candidate is False
+
+    def test_should_reject_candidate_graded_no_better_than_holding(self, finder, tmp_path):
+        """A same-grade swap is churn, not an improvement."""
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "SAME.PA", "name": "Same", "grade": "D", "composite_score": 0.31, "sector": "Healthcare", "asset_class": "stock"}],
+        )
+
+        assert finder._find_sector_alternatives(self._holding()) == []
+
+    def test_should_reject_other_sector_and_other_asset_class(self, finder, tmp_path):
+        self._write_opportunities(
+            tmp_path,
+            [
+                {"ticker": "TECH.PA", "name": "Tech", "grade": "A", "composite_score": 0.9, "sector": "Technology", "asset_class": "stock"},
+                {"ticker": "HEALTH.L", "name": "Health ETF", "grade": "A", "composite_score": 0.9, "sector": "Healthcare", "asset_class": "etf"},
+            ],
+        )
+
+        assert finder._find_sector_alternatives(self._holding()) == []
+
+    def test_should_skip_when_holding_sector_unknown(self, finder, tmp_path):
+        """Never pair on a guessed sector — a wrong pairing swaps unrelated assets."""
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "GOOD.PA", "name": "Better", "grade": "A", "composite_score": 0.9, "sector": "Healthcare", "asset_class": "stock"}],
+        )
+
+        assert finder._find_sector_alternatives(self._holding(sector=None)) == []
+
+    def test_should_match_sector_case_insensitively(self, finder, tmp_path):
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "GOOD.PA", "name": "Better", "grade": "B", "composite_score": 0.75, "sector": "  healthcare ", "asset_class": "stock"}],
+        )
+
+        assert [a.ticker for a in finder._find_sector_alternatives(self._holding())] == ["GOOD.PA"]
+
+    def test_should_rank_best_grade_first(self, finder, tmp_path):
+        self._write_opportunities(
+            tmp_path,
+            [
+                {"ticker": "OK.PA", "name": "Ok", "grade": "C+", "composite_score": 0.60, "sector": "Healthcare", "asset_class": "stock"},
+                {"ticker": "BEST.PA", "name": "Best", "grade": "A", "composite_score": 0.92, "sector": "Healthcare", "asset_class": "stock"},
+            ],
+        )
+
+        assert [a.ticker for a in finder._find_sector_alternatives(self._holding())] == ["BEST.PA", "OK.PA"]
+
+
+class TestLowerCostEtfAlternatives:
+    """Step 3: ETFs that are strictly cheaper and no worse graded."""
+
+    @pytest.fixture
+    def finder(self, tmp_path):
+        return AlternativeFinder(output_dir=tmp_path)
+
+    def _write_opportunities(self, tmp_path, opportunities):
+        discovery_dir = tmp_path / "discovery"
+        discovery_dir.mkdir(exist_ok=True)
+        (discovery_dir / "consolidated_discovery.json").write_text(
+            json.dumps({"timestamp": "2026-09-08T00:00:00", "total_opportunities": len(opportunities), "opportunities": opportunities})
+        )
+
+    def _etf(self, **kwargs):
+        base = {
+            "ticker": "PRICEY.L",
+            "name": "Expensive fund",
+            "asset_class": "etf",
+            "grade": "D",
+            "composite_score": 0.30,
+            "risk_score": 3.0,
+            "expense_ratio": 0.0050,  # 0.50%, a fraction
+        }
+        base.update(kwargs)
+        return HoldingProfile(**base)
+
+    def test_should_find_cheaper_etf_of_equal_grade(self, finder, tmp_path):
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "CHEAP.L", "name": "Cheap", "grade": "D", "composite_score": 0.31, "asset_class": "etf", "expense_ratio": 0.0007}],
+        )
+
+        alternatives = finder._find_lower_cost_etf_alternatives(self._etf())
+
+        assert [a.ticker for a in alternatives] == ["CHEAP.L"]
+        assert alternatives[0].discovery_source == "lower_cost_etf"
+        # 0.0050 - 0.0007, on one consistent fraction scale.
+        assert alternatives[0].expense_ratio_savings == pytest.approx(0.0043)
+
+    def test_should_reject_more_expensive_fund(self, finder, tmp_path):
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "WORSE.L", "name": "Dearer", "grade": "A", "composite_score": 0.9, "asset_class": "etf", "expense_ratio": 0.0080}],
+        )
+
+        assert finder._find_lower_cost_etf_alternatives(self._etf()) == []
+
+    def test_should_reject_cheaper_but_worse_graded_fund(self, finder, tmp_path):
+        """Cheapness never buys a downgrade."""
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "CHEAPBAD.L", "name": "Cheap but worse", "grade": "F", "composite_score": 0.1, "asset_class": "etf", "expense_ratio": 0.0001}],
+        )
+
+        assert finder._find_lower_cost_etf_alternatives(self._etf()) == []
+
+    def test_should_skip_candidate_with_unknown_expense_ratio(self, finder, tmp_path):
+        """An unpriced candidate is never assumed cheap."""
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "UNKNOWN.L", "name": "No ratio", "grade": "B", "composite_score": 0.7, "asset_class": "etf"}],
+        )
+
+        assert finder._find_lower_cost_etf_alternatives(self._etf()) == []
+
+    def test_should_skip_when_holding_expense_ratio_unknown(self, finder, tmp_path):
+        """Without the held fund's own cost there is nothing to prove cheaper than."""
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "CHEAP.L", "name": "Cheap", "grade": "B", "composite_score": 0.7, "asset_class": "etf", "expense_ratio": 0.0007}],
+        )
+
+        assert finder._find_lower_cost_etf_alternatives(self._etf(expense_ratio=None)) == []
+
+    def test_should_rank_cheapest_first(self, finder, tmp_path):
+        self._write_opportunities(
+            tmp_path,
+            [
+                {"ticker": "MID.L", "name": "Mid", "grade": "B", "composite_score": 0.7, "asset_class": "etf", "expense_ratio": 0.0020},
+                {"ticker": "CHEAPEST.L", "name": "Cheapest", "grade": "B", "composite_score": 0.7, "asset_class": "etf", "expense_ratio": 0.0005},
+            ],
+        )
+
+        assert [a.ticker for a in finder._find_lower_cost_etf_alternatives(self._etf())] == ["CHEAPEST.L", "MID.L"]
+
+    def test_should_reject_percent_scaled_ratio_as_unusable(self, finder, tmp_path):
+        """A value >= 1.0 is not a fraction; treating 7.0 as 700% must not pass as cheap."""
+        self._write_opportunities(
+            tmp_path,
+            [{"ticker": "BADSCALE.L", "name": "Percent scaled", "grade": "B", "composite_score": 0.7, "asset_class": "etf", "expense_ratio": 7.0}],
+        )
+
+        assert finder._find_lower_cost_etf_alternatives(self._etf()) == []


### PR DESCRIPTION
The run gate's `alternatives` check has been failing **structurally, not occasionally**. Two of the finder's three search steps were `return []` placeholders, and the third only accepts A-band candidates. On a real run, 2 of 17 discovery opportunities were A-band and both were stocks — so a portfolio of underperforming ETFs could not be matched by any path. The check could never pass.

## Step 2 — same-sector matching

Reads the same discovery opportunities as step 1, without the A-band filter. Any grade **strictly above** the holding's qualifies: swapping a D for a B is a real improvement, and requiring A+ is what kept this permanently empty. Ranked best grade first.

**An ETF has no single sector.** For equities `sector` is direct; for funds the dominant `sector_weights` entry is used, and only when it clears `_MIN_DOMINANT_SECTOR_WEIGHT` (0.40). Below that a world index would be filed under Technology at ~24% and paired against sector funds. An unknown sector **skips** the step rather than pairing on a guess.

## Step 3 — cheaper ETFs

Both sides must have a *known* expense ratio. A candidate without one is skipped, never assumed cheap. Cheapness never buys a downgrade. Cheapest first.

## Two defects in the code these build on

**1. Fabricated figures on the wrong scale.** `_create_alternative_from_aplus` used `holding.expense_ratio or 0.50` and `item.get("expense_ratio", 0.10)` — but real ratios here are fractions (`0.0007` = 0.07%). The published "saving" was therefore `0.40`, a 40-point fiction where a real gap is ~0.005. Crypto had the same shape: a missing market cap always produced exactly **+900%** "liquidity improvement". Both now report only when both sides are known, matching the `_build_risk_metrics` precedent.

**2. The writer dropped the expense ratio.** The screener already fetches `annualReportExpenseRatio` onto candidate metadata, but `_to_legacy_format` never persisted it — which is *why* step 3 had nothing to compare against. Now carried, as **absent keys rather than explicit nulls**: writing `None` dropped the whole opportunity downstream (caught by the existing writer↔reader contract tests).

Also wires `sector` and `expense_ratio` into `HoldingProfile` — they were left `None`, which would have kept both new steps blind regardless of the search logic — and drops the stale `investment_discovery_crew` naming (the crews went in #187; discovery is Python scoring).

## Measured against real data, including where it does *not* help

Run against the actual 2026-09-07 discovery output (17 opportunities, 4 ETFs):

| Case | Before | After |
|---|---|---|
| D-graded stock, Financial Services | 0 | **7** (MS, BAC, C, JPM, GS, V, SCHW) |
| Held ETF `IJPA.L` | 0 | **0** |

**The 2026-09-08 WARN would not have cleared.** All 18 underperformers that run were ETFs. `IJPA.L`'s `sector_weights` are too diversified to name a sector (by design, above), and the 4 ETF candidates carried no expense ratio — the curated fallback table has only 7 entries. Step 3 will start producing results for ETFs as discovery-side ratios flow through (defect 2), but the candidate universe is the remaining limit, and that is a separate problem from these placeholders.

What changes today: the gate stops reporting an outcome that was impossible by construction, and reports a real, data-limited one.

## Verification

- 21 new tests, including scale-inversion guards (a `7.0` ratio must not read as cheap) and the "diversified fund gets no sector label" case
- Full suite **4,152 passed**, 7 skipped
- `make lint`, `uvx vulture` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtXz89ibcafk3p5LP5Ewms
